### PR TITLE
Use ./config.status instead of ./configure to regenerate Makefiles

### DIFF
--- a/fbmuck/Makefile.in
+++ b/fbmuck/Makefile.in
@@ -68,7 +68,7 @@ nuke:
 	${RM} Makefile config.status config.cache config.log game/restart
 
 Makefile: Makefile.in
-	./configure
+	./config.status Makefile
 	@echo Please re-run Make, because the Makefile was re-generated.
 	@false
 

--- a/fbmuck/src/Makefile.in
+++ b/fbmuck/src/Makefile.in
@@ -208,7 +208,7 @@ depend:
 	chmod -w Makefile
 
 Makefile: Makefile.in
-	cd .. && ./configure
+	cd .. && ./config.status
 	@echo " "
 	@echo Please re-run Make, as the Makefile was re-generated.
 	@echo " "


### PR DESCRIPTION
The config.status script is a better way to recreate configure-generated files since it will pass the same configure flags as were passed to configure to generate it.