### PR TITLE
Add option to honor server cipher preference order

### DIFF
--- a/fbmuck/include/defaults.h
+++ b/fbmuck/include/defaults.h
@@ -94,6 +94,7 @@
     "CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:" \
     "!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA"
 #define STARTTLS_ALLOW 0
+#define SERVER_CIPHER_PREFERENCE 1
 
 /* amount of object endowment, based on cost */
 #define MAX_OBJECT_ENDOWMENT 100

--- a/fbmuck/include/tune.h
+++ b/fbmuck/include/tune.h
@@ -150,6 +150,7 @@ extern int tp_verbose_clone;
 extern int tp_muf_comments_strict;
 extern int tp_m3_huh;
 extern int tp_starttls_allow;
+extern int tp_cipher_server_preference;
 extern int tp_7bit_thing_names;
 extern int tp_7bit_other_names;
 extern int tp_idle_ping_enable;

--- a/fbmuck/src/interface.c
+++ b/fbmuck/src/interface.c
@@ -1181,6 +1181,10 @@ shovechars()
 #endif
         SSL_CTX_set_cipher_list(ssl_ctx, tp_ssl_cipher_preference_list);
 
+        if (tp_cipher_server_preference) {
+            SSL_CTX_set_options(ssl_ctx, SSL_OP_CIPHER_SERVER_PREFERENCE);
+        }
+
  
 	if (!SSL_CTX_use_certificate_chain_file (ssl_ctx, SSL_CERT_FILE)) {
 		log_status("Could not load certificate file %s", SSL_CERT_FILE);

--- a/fbmuck/src/tune.c
+++ b/fbmuck/src/tune.c
@@ -71,7 +71,7 @@ struct tune_str_entry tune_str_list[] = {
 	{"Misc",       "huh_mesg", &tp_huh_mesg, 0, 1, "Command unrecognized warning"},
 	{"SSL",        "ssl_keyfile_passwd", &tp_ssl_keyfile_passwd, MLEV_GOD, 1, "Password for SSL keyfile"},
         {"SSL",        "ssl_cipher_preference_list", &tp_ssl_cipher_preference_list, MLEV_GOD, 1,
-                       "OpenSSL cipher list"},
+                       "OpenSSL cipher list (changes requires restart)"},
 	{"Database",   "pcreate_flags", &tp_pcreate_flags, 0, 1, "Initial Player Flags"},
 	{"Database",   "reserved_names", &tp_reserved_names, 0, 1, "Reserved names smatch"},
 	{"Database",   "reserved_player_names", &tp_reserved_player_names, 0, 1, "Reserved player names smatch"},
@@ -344,7 +344,7 @@ struct tune_bool_entry tune_bool_list[] = {
 	{"Misc",	"m3_huh", &tp_m3_huh, 3, "Enable huh? to call an exit named \"huh?\" and set M3, with full command string"},
 	{"Misc",	"strict_god_priv", &tp_strict_god_priv, MLEV_GOD, "Only God can touch God's objects"},
 	{"SSL",        "starttls_allow", &tp_starttls_allow, 3, "Enable TELNET STARTTLS encryption on plaintext port"},
-        {"SSL",        "server_cipher_preference", &tp_cipher_server_preference, 4, "Honor server cipher preference order over client's"},
+        {"SSL",        "server_cipher_preference", &tp_cipher_server_preference, 4, "Honor server cipher preference order over client's (changes require restart)"},
 	{"Charset",	"7bit_thing_names", &tp_7bit_thing_names, 4, "Thing names may contain only 7-bit characters"},
 	{"Charset",	"7bit_other_names", &tp_7bit_other_names, 4, "Exit/room/muf names may contain only 7-bit characters"},
 

--- a/fbmuck/src/tune.c
+++ b/fbmuck/src/tune.c
@@ -277,6 +277,7 @@ int tp_ignore_bidirectional = IGNORE_BIDIRECTIONAL;
 int tp_verbose_clone = VERBOSE_CLONE;
 int tp_muf_comments_strict = MUF_COMMENTS_STRICT;
 int tp_starttls_allow = STARTTLS_ALLOW;
+int tp_cipher_server_preference = SERVER_CIPHER_PREFERENCE;
 int tp_m3_huh = M3_HUH;
 int tp_7bit_thing_names = ASCII_THING_NAMES;
 int tp_7bit_other_names = ASCII_OTHER_NAMES;
@@ -343,6 +344,7 @@ struct tune_bool_entry tune_bool_list[] = {
 	{"Misc",	"m3_huh", &tp_m3_huh, 3, "Enable huh? to call an exit named \"huh?\" and set M3, with full command string"},
 	{"Misc",	"strict_god_priv", &tp_strict_god_priv, MLEV_GOD, "Only God can touch God's objects"},
 	{"SSL",        "starttls_allow", &tp_starttls_allow, 3, "Enable TELNET STARTTLS encryption on plaintext port"},
+        {"SSL",        "server_cipher_preference", &tp_cipher_server_preference, 4, "Honor server cipher preference order over client's"},
 	{"Charset",	"7bit_thing_names", &tp_7bit_thing_names, 4, "Thing names may contain only 7-bit characters"},
 	{"Charset",	"7bit_other_names", &tp_7bit_other_names, 4, "Exit/room/muf names may contain only 7-bit characters"},
 


### PR DESCRIPTION
TLS configuration recommendations (like [this](https://wiki.mozilla.org/Security/Server_Side_TLS)) typically advise using server cipher preference order over client (which is default in OpenSSL). This adds a tune to configure this OpenSSL option.

Also add a note to some SSL tune descriptions that they don't take effect until restart.