### PR TITLE
Correct mpi time functions offset handling.

### DIFF
--- a/fbmuck/src/mfuns.c
+++ b/fbmuck/src/mfuns.c
@@ -1493,7 +1493,7 @@ mfn_time(MFUNARGS)
 	lt = time((time_t*) NULL);
 	if (argc == 1) {
 		lt += (3600 * atoi(argv[0]));
-		lt += get_tz_offset();
+		lt -= get_tz_offset();
 	}
 	tm = MUCKTIME(lt);
 	format_time(buf, BUFFER_LEN - 1, "%T", tm);
@@ -1507,10 +1507,10 @@ mfn_date(MFUNARGS)
 	time_t lt;
 	struct tm *tm;
 
-	lt = time((time_t*) NULL);
+	time(&lt);
 	if (argc == 1) {
 		lt += (3600 * atoi(argv[0]));
-		lt += get_tz_offset();
+		lt -= get_tz_offset();
 	}
 	tm = MUCKTIME(lt);
 	format_time(buf, BUFFER_LEN - 1, "%D", tm);
@@ -1534,9 +1534,9 @@ mfn_ftime(MFUNARGS)
 		if (offval < 25 && offval > -25) {
 			lt += 3600 * offval;
 		} else {
-			lt -= offval;
+			lt += offval;
 		}
-		lt += get_tz_offset();
+		lt -= get_tz_offset();
 	}
 	tm = MUCKTIME(lt);
 	format_time(buf, BUFFER_LEN - 1, argv[0], tm);


### PR DESCRIPTION
There are several places in MPI where we permit a user to provide
a custom time offset overriding the timezone. To do this, we
mutilate UTC time before passing it to the `MUCKTIME()` macro.
However, we were doubling the value of `get_tz_offset()` in
these cases rather than negating it.

A cleaner solution to this would be using gmtime(), but we don't
know if that's available for our present compatibility goals.

Some historical tickets:
http://sourceforge.net/p/fbmuck/bugs/257/
http://sourceforge.net/p/fbmuck/bugs/271/

Testing done:
Create a MUCK with non-UTC localtime and test mpi codes before and
after the change:

   {ftime:%m-%d %X,2}
   {date:0}
   {ftime:%Y-%m-%d %X,0,0}  # Should be epoch.
   etc.