### PR TITLE
Updated fuzzball.cnf with more secure defaults

### DIFF
--- a/fbmuck/fuzzball.cnf
+++ b/fbmuck/fuzzball.cnf
@@ -1,5 +1,6 @@
 [ req ]
-default_bits		= 2048
+default_bits		= 4096
+default_md		= sha512
 distinguished_name	= req_distinguished_name
 #attributes		= req_attributes
 #x509_extensions	= # The extentions to add to the self signed cert

--- a/fbmuck/fuzzball.cnf
+++ b/fbmuck/fuzzball.cnf
@@ -1,6 +1,6 @@
 [ req ]
 default_bits		= 4096
-default_md		= sha512
+default_md		= sha256
 distinguished_name	= req_distinguished_name
 #attributes		= req_attributes
 #x509_extensions	= # The extentions to add to the self signed cert


### PR DESCRIPTION
Updated the fuzzball.cnf file with some better defaults. 4096 bits and sha256 over sha1. These will provide more security for people making their first certs.