### PR TITLE
Fixed '@hashes all' so it doesn't show git hash if not available.

### DIFF
--- a/fbmuck/src/version.tpl
+++ b/fbmuck/src/version.tpl
@@ -74,7 +74,10 @@ do_hashes(dbref player, char *args) {
 	} else if (!strcasecmp(args, "sha1")) {
 		b_sha1 = 1;
 	} else {
-		b_git = b_sha1 = 1;
+		b_sha1 = 1;
+#ifdef GIT_AVAILABLE
+		b_git = 1;
+#endif
 	}
 
 	/* Header */


### PR DESCRIPTION
A simple fix to disable GIT hashes from the "all" option if they weren't available at compile time.