### PR TITLE
Fixed an issue where data could be pending in SSL buffer but not the …

### DIFF
--- a/fbmuck/src/interface.c
+++ b/fbmuck/src/interface.c
@@ -1478,7 +1478,7 @@ shovechars()
 #endif
 			for (cnt = 0, d = descriptor_list; d; d = dnext) {
 				dnext = d->next;
-				if (FD_ISSET(d->descriptor, &input_set)) {
+				if (FD_ISSET(d->descriptor, &input_set) || (d->ssl_session && SSL_pending(d->ssl_session))) {
 					if (!process_input(d)) {
 						d->booted = 1;
 					}


### PR DESCRIPTION
…socket.

This was originally reported to me by Bennie (of BeipMU fame). If you sent more data in a single packet than the input buffer could handle (something like +4096 or +8192 bytes or so), then the unread data would sit in the SSL buffers. If the client never sent any more data, the MUCK would not process the commands over that threshold. This adds a check to SSL_pending for any active SSL sockets to see if the SSL buffers have pending data to read, and not just the data that raw sockets return in SELECT.

This should likely trickle back up into FB6.xx as well since FM and any other text muck is affected by it.