### PR TITLE
Win32 compile fixes

### DIFF
--- a/fbmuck/include/config.h
+++ b/fbmuck/include/config.h
@@ -201,18 +201,6 @@
 /************************************************************************/
 
 /*
- * Windows compile environment.
- */
-#ifdef WIN32
-#undef SPAWN_HOST_RESOLVER
-#define NO_MEMORY_COMMAND
-#define NO_USAGE_COMMAND
-#define NOCOREDUMP
-#define SCARY_MUF_PRIMS /* Most Windows users don't have their own compiler */
-#include "win32.h"
-#endif
-
-/*
  * Very general defines 
  */
 #define TRUE  1
@@ -366,6 +354,18 @@
 
 #ifndef SYS_TYPE
 # define SYS_TYPE "UNKNOWN"
+#endif
+
+/*
+ * Windows compile environment.
+ */
+#ifdef WIN32
+#undef SPAWN_HOST_RESOLVER
+#define NO_MEMORY_COMMAND
+#define NO_USAGE_COMMAND
+#define NOCOREDUMP
+#define SCARY_MUF_PRIMS /* Most Windows users don't have their own compiler */
+#include "win32.h"
 #endif
 
 #endif /* _CONFIG_H */

--- a/fbmuck/include/db.h
+++ b/fbmuck/include/db.h
@@ -543,7 +543,7 @@ struct frame {
 	short skip_declare;         /* tells interp to skip next scoped var decl */
 	short wantsblanks;          /* specifies program will accept blank READs */
 	dbref trig;					/* triggering object */
-	long started;				/* When this program started. */
+	time_t started;				/* When this program started. */
 	int instcnt;				/* How many instructions have run. */
 	int pid;					/* what is the process id? */
 	char* errorstr;             /* the error string thrown */

--- a/fbmuck/include/externs.h
+++ b/fbmuck/include/externs.h
@@ -92,9 +92,9 @@ extern void write_program(struct line *first, dbref i);
 
 /* events.c */
 extern void dump_db_now(void);
-extern long next_event_time(void);
+extern time_t next_event_time(void);
 extern void next_muckevent(void);
-extern long next_muckevent_time(void);
+extern time_t next_muckevent_time(void);
 
 /* game.c */
 void cleanup_game();
@@ -146,7 +146,7 @@ extern time_t sel_prof_start_time;
 #ifdef SPAWN_HOST_RESOLVER
 extern void spawn_resolver(void);
 #endif
-extern char * time_format_2(long dt);
+extern char * time_format_2(time_t dt);
 
 /* interp.c */
 extern void do_abort_silent(void);

--- a/fbmuck/makefile.win
+++ b/fbmuck/makefile.win
@@ -95,8 +95,8 @@ BASE_OBJ="$(INTDIR)\array.obj" \
 	"$(INTDIR)\speech.obj" \
 	"$(INTDIR)\strftime.obj" \
 	"$(INTDIR)\stringutil.obj" \
+	"$(INTDIR)\time.obj" \
 	"$(INTDIR)\timequeue.obj" \
-	"$(INTDIR)\timestamp.obj" \
 	"$(INTDIR)\tune.obj" \
 	"$(INTDIR)\unparse.obj" \
 	"$(INTDIR)\utils.obj" \

--- a/fbmuck/makefile.win
+++ b/fbmuck/makefile.win
@@ -10,7 +10,7 @@ SRCDIR=.\src
 INCDIR=.\include
 OUTDIR=.\game
 INTDIR=.\compile
-OPENSSLDIR=e:\cyg\openssl
+OPENSSLDIR=e:\sandbox\openssl
 
 CPP=cl.exe
 CPP_OPS=/nologo /EHsc /MT /W3 /O2 /c /D "_X86_" /D "_WIN32_" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /D "FD_SETSIZE=4096" /D "_WINSOCK_DEPRECATED_NO_WARNINGS" /D "_CRT_SECURE_NO_WARNINGS" /D "_CRT_NONSTDC_NO_WARNINGS" /D "_CRT_SECURE_NO_DEPRECATE" /D "POSIX" /I"$(WINDIR)" /I"$(INCDIR)" /I"$(OPENSSLDIR)\include" /Fd"$(INTDIR)\\"
@@ -18,7 +18,7 @@ LINK32=link.exe
 LINK32_OPS=/NODEFAULTLIB:libc /LIBPATH:".\win32" /LIBPATH:"$(OPENSSLDIR)\lib\vc" pcre.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib ws2_32.lib libeay32MD.lib ssleay32MD.lib winmm.lib /nologo /subsystem:console /incremental:no /machine:I386
 
 # Enable These for debugging
-#CPP_OPS=/Od /D "_DEBUG" /Zi /EHsc /nologo /MTd /W3 /D "_X86_" /D "_WIN32_" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /D "FD_SETSIZE=4096" /D "_CRT_SECURE_NO_WARNINGS" /D "_CRT_NONSTDC_NO_WARNINGS" /D "_CRT_SECURE_NO_DEPRECATE" /D "POSIX" /I"$(INCDIR)" /I"$(OPENSSLDIR)\include" /Fd"$(INTDIR)\\" /c
+#CPP_OPS=/c /Od /D "_DEBUG" /Zi /EHsc /nologo /MTd /W3 /D "_X86_" /D "_WIN32_" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /D "FD_SETSIZE=4096" /D "_WINSOCK_DEPRECATED_NO_WARNINGS" /D "_CRT_SECURE_NO_WARNINGS" /D "_CRT_NONSTDC_NO_WARNINGS" /D "_CRT_SECURE_NO_DEPRECATE" /D "POSIX" /I"$(WINDIR)" /I"$(INCDIR)" /I"$(OPENSSLDIR)\include" /Fd"$(INTDIR)\\"
 #LINK32_OPS=/DEBUG /NODEFAULTLIB:libc /LIBPATH:".\win32" /LIBPATH:"$(OPENSSLDIR)\lib\vc" pcre.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib ws2_32.lib libeay32MD.lib ssleay32MD.lib winmm.lib /nologo /subsystem:console /incremental:no /machine:I386
 
 

--- a/fbmuck/src/events.c
+++ b/fbmuck/src/events.c
@@ -10,16 +10,16 @@
  * Dump the database every so often.
  ****************************************************************/
 
-static long last_dump_time = 0L;
+static time_t last_dump_time = 0L;
 static int dump_warned = 0;
 
-long
+time_t
 next_dump_time(void)
 {
-	long currtime = (long) time((time_t *) NULL);
+	time_t currtime = (time_t) time((time_t *) NULL);
 
 	if (!last_dump_time)
-		last_dump_time = (long) time((time_t *) NULL);
+		last_dump_time = (time_t) time((time_t *) NULL);
 
 	if (tp_dbdump_warning && !dump_warned) {
 		if (((last_dump_time + tp_dump_interval) - tp_dump_warntime)
@@ -40,10 +40,10 @@ next_dump_time(void)
 void
 check_dump_time(void)
 {
-	long currtime = (long) time((time_t *) NULL);
+	time_t currtime = (time_t) time((time_t *) NULL);
 
 	if (!last_dump_time)
-		last_dump_time = (long) time((time_t *) NULL);
+		last_dump_time = (time_t) time((time_t *) NULL);
 
 	if (!dump_warned) {
 		if (((last_dump_time + tp_dump_interval) - tp_dump_warntime)
@@ -72,7 +72,7 @@ check_dump_time(void)
 void
 dump_db_now(void)
 {
-	long currtime = (long) time((time_t *) NULL);
+	time_t currtime = (time_t) time((time_t *) NULL);
 
 	add_property((dbref) 0, "_sys/lastdumptime", NULL, (int) currtime);
 	fork_and_dump();
@@ -84,15 +84,15 @@ dump_db_now(void)
  * Periodic cleanups *
  *********************/
 
-static long last_clean_time = 0L;
+static time_t last_clean_time = 0L;
 
-long
+time_t
 next_clean_time(void)
 {
-	long currtime = (long) time((time_t *) NULL);
+	time_t currtime = (time_t) time((time_t *) NULL);
 
 	if (!last_clean_time)
-		last_clean_time = (long) time((time_t *) NULL);
+		last_clean_time = (time_t) time((time_t *) NULL);
 
 	if ((last_clean_time + tp_clean_interval) < currtime)
 		return (0L);
@@ -104,10 +104,10 @@ next_clean_time(void)
 void
 check_clean_time(void)
 {
-	long currtime = (long) time((time_t *) NULL);
+	time_t currtime = (time_t) time((time_t *) NULL);
 
 	if (!last_clean_time)
-		last_clean_time = (long) time((time_t *) NULL);
+		last_clean_time = (time_t) time((time_t *) NULL);
 
 	if ((last_clean_time + tp_clean_interval) < currtime) {
 		last_clean_time = currtime;
@@ -125,17 +125,17 @@ check_clean_time(void)
  *  general handling for timed events like dbdumps, timequeues, etc.
  **********************************************************************/
 
-long
-mintime(long a, long b)
+time_t
+mintime(time_t a, time_t b)
 {
 	return ((a > b) ? b : a);
 }
 
 
-long
+time_t
 next_muckevent_time(void)
 {
-	long nexttime = 1000L;
+	time_t nexttime = 1000L;
 
 	nexttime = mintime(next_event_time(), nexttime);
 	nexttime = mintime(next_dump_time(), nexttime);

--- a/fbmuck/src/interface.c
+++ b/fbmuck/src/interface.c
@@ -141,9 +141,9 @@ struct descriptor_data {
 	telnet_states_t telnet_state;
 	int telnet_sb_opt;
 	int short_reads;
-	long last_time;
-	long connected_at;
-	long last_pinged_at;
+	time_t last_time;
+	time_t connected_at;
+	time_t last_pinged_at;
 	const char *hostname;
 	const char *username;
 	int quota;
@@ -215,7 +215,7 @@ int process_output(struct descriptor_data *d);
 int process_input(struct descriptor_data *d);
 void announce_connect(int, dbref);
 void announce_disconnect(struct descriptor_data *);
-char *time_format_1(long);
+char *time_format_1(time_t);
 void    init_descriptor_lookup();
 void    init_descr_count_lookup();
 void    remember_descriptor(struct descriptor_data *);
@@ -1304,8 +1304,8 @@ shovechars()
 				 * If SSL isn't already in place, give TELNET STARTTLS
 				 * handshaking a couple seconds to respond, to start it.
 				 */
-				const long welcome_pause = 2; /* seconds */
-				long timeon = now - d->connected_at;
+				const time_t welcome_pause = 2; /* seconds */
+				time_t timeon = now - d->connected_at;
 
 				if (d->ssl_session || !tp_starttls_allow) {
 					FD_SET(d->descriptor, &output_set);
@@ -3197,7 +3197,7 @@ dump_users(struct descriptor_data *e, char *user)
 }
 
 char *
-time_format_1(long dt)
+time_format_1(time_t dt)
 {
 	register struct tm *delta;
 	static char buf[64];
@@ -3211,7 +3211,7 @@ time_format_1(long dt)
 }
 
 char *
-time_format_2(long dt)
+time_format_2(time_t dt)
 {
 	register struct tm *delta;
 	static char buf[64];
@@ -3788,7 +3788,7 @@ least_idle_player_descr(dbref who)
 	struct descriptor_data *best_d = NULL;
 	int dcount, di;
 	int* darr;
-	long best_time = 0;
+	time_t best_time = 0;
 
 	darr = get_player_descrs(who, &dcount);
 	for (di = 0; di < dcount; di++) {
@@ -3812,7 +3812,7 @@ most_idle_player_descr(dbref who)
 	struct descriptor_data *best_d = NULL;
 	int dcount, di;
 	int* darr;
-	long best_time = 0;
+	time_t best_time = 0;
 
 	darr = get_player_descrs(who, &dcount);
 	for (di = 0; di < dcount; di++) {

--- a/fbmuck/src/mfuns.c
+++ b/fbmuck/src/mfuns.c
@@ -1576,7 +1576,7 @@ mfn_convtime(MFUNARGS)
 #ifdef SUNOS
 	snprintf(buf, BUFFER_LEN, "%ld", timelocal(&otm));
 #else
-	snprintf(buf, BUFFER_LEN, "%ld", mktime(&otm));
+	snprintf(buf, BUFFER_LEN, "%lld", mktime(&otm));
 #endif
 	return buf;
 }
@@ -1739,7 +1739,7 @@ mfn_secs(MFUNARGS)
 	time_t lt;
 
 	time(&lt);
-	snprintf(buf, BUFFER_LEN, "%ld", lt);
+	snprintf(buf, BUFFER_LEN, "%lld", lt);
 	return buf;
 }
 
@@ -2034,7 +2034,7 @@ mfn_created(MFUNARGS)
 	if (obj == PERMDENIED)
 		ABORT_MPI("CREATED", "Permission denied.");
 
-	snprintf(buf, BUFFER_LEN, "%ld", DBFETCH(obj)->ts.created);
+	snprintf(buf, BUFFER_LEN, "%lld", DBFETCH(obj)->ts.created);
 
 	return buf;
 }
@@ -2051,7 +2051,7 @@ mfn_lastused(MFUNARGS)
 	if (obj == PERMDENIED)
 		ABORT_MPI("LASTUSED", "Permission denied.");
 
-	snprintf(buf, BUFFER_LEN, "%ld", DBFETCH(obj)->ts.lastused);
+	snprintf(buf, BUFFER_LEN, "%lld", DBFETCH(obj)->ts.lastused);
 
 	return buf;
 }
@@ -2068,7 +2068,7 @@ mfn_modified(MFUNARGS)
 	if (obj == PERMDENIED)
 		ABORT_MPI("MODIFIED", "Permission denied.");
 
-	snprintf(buf, BUFFER_LEN, "%ld", DBFETCH(obj)->ts.modified);
+	snprintf(buf, BUFFER_LEN, "%lld", DBFETCH(obj)->ts.modified);
 
 	return buf;
 }

--- a/fbmuck/src/mfuns.c
+++ b/fbmuck/src/mfuns.c
@@ -1576,7 +1576,7 @@ mfn_convtime(MFUNARGS)
 #ifdef SUNOS
 	snprintf(buf, BUFFER_LEN, "%ld", timelocal(&otm));
 #else
-	snprintf(buf, BUFFER_LEN, "%lld", mktime(&otm));
+	snprintf(buf, BUFFER_LEN, "%lld", (long long) mktime(&otm));
 #endif
 	return buf;
 }
@@ -1739,7 +1739,7 @@ mfn_secs(MFUNARGS)
 	time_t lt;
 
 	time(&lt);
-	snprintf(buf, BUFFER_LEN, "%lld", lt);
+	snprintf(buf, BUFFER_LEN, "%lld", (long long) lt);
 	return buf;
 }
 
@@ -2034,7 +2034,7 @@ mfn_created(MFUNARGS)
 	if (obj == PERMDENIED)
 		ABORT_MPI("CREATED", "Permission denied.");
 
-	snprintf(buf, BUFFER_LEN, "%lld", DBFETCH(obj)->ts.created);
+	snprintf(buf, BUFFER_LEN, "%lld", (long long) DBFETCH(obj)->ts.created);
 
 	return buf;
 }
@@ -2051,7 +2051,7 @@ mfn_lastused(MFUNARGS)
 	if (obj == PERMDENIED)
 		ABORT_MPI("LASTUSED", "Permission denied.");
 
-	snprintf(buf, BUFFER_LEN, "%lld", DBFETCH(obj)->ts.lastused);
+	snprintf(buf, BUFFER_LEN, "%lld", (long long) DBFETCH(obj)->ts.lastused);
 
 	return buf;
 }
@@ -2068,7 +2068,7 @@ mfn_modified(MFUNARGS)
 	if (obj == PERMDENIED)
 		ABORT_MPI("MODIFIED", "Permission denied.");
 
-	snprintf(buf, BUFFER_LEN, "%lld", DBFETCH(obj)->ts.modified);
+	snprintf(buf, BUFFER_LEN, "%lld", (long long) DBFETCH(obj)->ts.modified);
 
 	return buf;
 }

--- a/fbmuck/src/mkversion.c
+++ b/fbmuck/src/mkversion.c
@@ -17,6 +17,8 @@
 #include <time.h>
 #ifndef WIN32
 #include <dirent.h>
+#else
+#include "win32.h"
 #endif
 #include "sha1.h"
 

--- a/fbmuck/src/mufevent.c
+++ b/fbmuck/src/mufevent.c
@@ -350,7 +350,7 @@ muf_event_list(dbref player, const char *pat)
 				snprintf(prognamestr, sizeof(prognamestr), "%s", NAME(proc->prog));
 			}
 			snprintf(buf, sizeof(buf), pat, pidstr, "--",
-					time_format_2((long) (rtime - proc->fr->started)),
+					time_format_2((time_t) (rtime - proc->fr->started)),
 					inststr, cpustr, progstr, prognamestr, NAME(proc->player),
 					"EVENT_WAITFOR");
 			if (Wizard(OWNER(player)) || (OWNER(proc->prog) == OWNER(player))

--- a/fbmuck/src/time.c
+++ b/fbmuck/src/time.c
@@ -47,7 +47,7 @@ mucktime(const time_t* t) {
 #ifndef WIN32
 	return localtime(t);
 #else
-	return u32localtime(t);
+	return uw32localtime(t);
 #endif
 }
 

--- a/fbmuck/src/timequeue.c
+++ b/fbmuck/src/timequeue.c
@@ -696,7 +696,7 @@ timequeue_pid_frame(int pid)
 }
 
 
-long
+time_t
 next_event_time(void)
 {
 	time_t rtime = time((time_t *) NULL);
@@ -707,7 +707,7 @@ next_event_time(void)
 		} else if (rtime >= tqhead->when) {
 			return (0L);
 		} else {
-			return ((long) (tqhead->when - rtime));
+			return ((time_t) (tqhead->when - rtime));
 		}
 	}
 	return (-1L);
@@ -744,7 +744,7 @@ has_refs(dbref program, timequeue ptr)
 }
 
 
-extern char *time_format_2(long dt);
+extern char *time_format_2(time_t dt);
 
 void
 list_events(dbref player)
@@ -772,10 +772,10 @@ list_events(dbref player)
 		snprintf(pidstr, sizeof(pidstr), "%d", ptr->eventnum);
 		/* next due */
 		strcpyn(duestr, sizeof(duestr), ((ptr->when - rtime) > 0) ?
-				time_format_2((long) (ptr->when - rtime)) : "Due");
+				time_format_2((time_t) (ptr->when - rtime)) : "Due");
 		/* Run length */
 		strcpyn(runstr, sizeof(runstr), ptr->fr ?
-				time_format_2((long) (rtime - ptr->fr->started)): "0s");
+				time_format_2((time_t) (rtime - ptr->fr->started)): "0s");
 		/* Thousand Instructions executed */
 		snprintf(inststr, sizeof(inststr), "%d", ptr->fr? (ptr->fr->instcnt / 1000) : 0);
 

--- a/fbmuck/src/wiz.c
+++ b/fbmuck/src/wiz.c
@@ -896,7 +896,7 @@ do_muf_topprofs(dbref player, char *arg1)
 		dbref  prog;
 		double proftime;
 		double pcnt;
-		long   comptime;
+		time_t   comptime;
 		long   usecount;
 	} *tops = NULL;
 
@@ -989,7 +989,7 @@ do_muf_topprofs(dbref player, char *arg1)
 		tops = tops->next;
 		free(curr);
 	}
-	snprintf(buf, sizeof(buf), "Profile Length (sec): %5ld  %%idle: %5.2f%%  Total Cycles: %5lu",
+	snprintf(buf, sizeof(buf), "Profile Length (sec): %5lld  %%idle: %5.2f%%  Total Cycles: %5lu",
 			(current_systime-sel_prof_start_time),
 			((double)(sel_prof_idle_sec+(sel_prof_idle_usec/1000000.0))*100.0)/
 			(double)((current_systime-sel_prof_start_time)+0.01),
@@ -1007,7 +1007,7 @@ do_mpi_topprofs(dbref player, char *arg1)
 		dbref  prog;
 		double proftime;
 		double pcnt;
-		long   comptime;
+		time_t   comptime;
 		long   usecount;
 	} *tops = NULL;
 
@@ -1099,7 +1099,7 @@ do_mpi_topprofs(dbref player, char *arg1)
 		tops = tops->next;
 		free(curr);
 	}
-	snprintf(buf, sizeof(buf), "Profile Length (sec): %5ld  %%idle: %5.2f%%  Total Cycles: %5lu",
+	snprintf(buf, sizeof(buf), "Profile Length (sec): %5lld  %%idle: %5.2f%%  Total Cycles: %5lu",
 			(current_systime-sel_prof_start_time),
 			(((double)sel_prof_idle_sec+(sel_prof_idle_usec/1000000.0))*100.0)/
 			(double)((current_systime-sel_prof_start_time)+0.01),
@@ -1117,7 +1117,7 @@ do_all_topprofs(dbref player, char *arg1)
 		dbref  prog;
 		double proftime;
 		double pcnt;
-		long   comptime;
+		time_t   comptime;
 		long   usecount;
 		short  type;
 	} *tops = NULL;
@@ -1271,7 +1271,7 @@ do_all_topprofs(dbref player, char *arg1)
 		tops = tops->next;
 		free(curr);
 	}
-	snprintf(buf, sizeof(buf), "Profile Length (sec): %5ld  %%idle: %5.2f%%  Total Cycles: %5lu",
+	snprintf(buf, sizeof(buf), "Profile Length (sec): %5lld  %%idle: %5.2f%%  Total Cycles: %5lu",
 			(current_systime-sel_prof_start_time),
 			((double)(sel_prof_idle_sec+(sel_prof_idle_usec/1000000.0))*100.0)/
 			(double)((current_systime-sel_prof_start_time)+0.01),

--- a/fbmuck/win32/win32.h
+++ b/fbmuck/win32/win32.h
@@ -16,11 +16,33 @@ extern void set_console();
 #define getpid _getpid
 #define pid_t int
 #define ssize_t long
+
+#ifndef tzname
+#define tzname _tzname
+#endif
+
+#ifndef strncasecmp
 #define strncasecmp _strnicmp
+#endif
+
+#ifndef strcasecmp
 #define strcasecmp _stricmp
+#endif
+
+#ifndef vsnprintf
 #define vsnprintf _vsnprintf
+#endif
+
+#ifndef snprintf
 #define snprintf _snprintf
+#endif
+
+#ifndef popen
 #define popen _popen
+#endif
+
+#ifndef pclose
 #define pclose _pclose
+#endif
 
 #endif


### PR DESCRIPTION
Here's an explanation of the changes:

* Changed config.h to move the WIN32 stuff to the bottom. There were includes for header files after the win32.h include. So it would redefine some of the POSIX functions which would generate compile issues. This might have just been Visual Studio 2015 being a pain, but since that's released now I moved to it.
* Updated the windows makefile to include the timestamp file that was added, as well as updating the debugging options. Which I needed for some of these other changes.
* Changed the mkversion to include win32.h as the defaults no longer include the needed windows header files. 
* Changed win32.h to check of certain functions are defined before trying to define them. This avoids issues with popen and _popen for example.
* Changed some %ld's to %lld's since time_t is now a 64 bit value.
* And lastly, there as a smattering of commits to chance some 'long' values to 'time_t'. Long should NOT be used to do math on time_t types. The big reason is that the sizeof on long can vary from system to system. Windows, for example, leaves long as 4 bytes, but linux defines it as 8. So, linux would happily let you work with both, but windows would not. This became a problem in the time_format_x functions which took a 'long' and then cast it's pointer into a time_t. This is obviously wrong, and windows gmtime returned NULL (likely due to the 8 by dereferencing into a 4 byte value on the stack). And since the return value of gmtime isn't checked, segfault. So, to clean it up I looked at a number of places where time_t values were worked on and stored in longs. There were a few parts dealing with the mpi/muf profiling that also worked with doubles (converting to %'s), but they seemed to subtract two time_t's from each other, thus resulting in a number I thought would be small enough to fit into a long. Someone might want to look into that and perhaps rework those parts to be more friendly with time_t calculations.
