### PR TITLE
Use SSL_OP_SINGLE_ECDH_USE; disable SSL session resumption

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -1096,6 +1096,12 @@ shovechars()
         SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_TICKET);
 #endif
 
+        /* Disable the session cache on the assumption that session resumption is not
+           worthwhile given our long-lived connections. This also avoids any concern
+           about session secret keys in memory for a long time. (By default, OpenSSL
+           only clears timed out sessions every 256 connections.) */
+        SSL_CTX_set_session_cache_mode(ssl_ctx, SSL_SESS_CACHE_OFF);
+
 #if defined(SSL_CTX_set_ecdh_auto)
         /* In OpenSSL >= 1.0.2, this exists; otherwise, fallback to the older
            API where we have to name a curve. */

--- a/src/interface.c
+++ b/src/interface.c
@@ -1088,6 +1088,14 @@ shovechars()
         SSL_CTX_set_options(ssl_ctx, SSL_OP_SINGLE_ECDH_USE);
 #endif
 
+#ifdef SSL_OP_NO_TICKET
+        /* OpenSSL supports session tickets by default but never rotates the keys by default.
+           Since session resumption isn't important for MUCK performance and since this
+           breaks forward secrecy, just disable tickets rather than trying to implement
+           key rotation. */
+        SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_TICKET);
+#endif
+
 #if defined(SSL_CTX_set_ecdh_auto)
         /* In OpenSSL >= 1.0.2, this exists; otherwise, fallback to the older
            API where we have to name a curve. */

--- a/src/interface.c
+++ b/src/interface.c
@@ -1081,6 +1081,13 @@ shovechars()
 	SSL_load_error_strings ();
  	OpenSSL_add_ssl_algorithms (); 
 	ssl_ctx = SSL_CTX_new (SSLv23_server_method ());
+
+#ifdef SSL_OP_SINGLE_ECDH_USE
+        /* As a default "optimization", OpenSSL shares ephemeral keys between sessions.
+           Disable this to improve forward secrecy. */
+        SSL_CTX_set_options(ssl_ctx, SSL_OP_SINGLE_ECDH_USE);
+#endif
+
 #if defined(SSL_CTX_set_ecdh_auto)
         /* In OpenSSL >= 1.0.2, this exists; otherwise, fallback to the older
            API where we have to name a curve. */


### PR DESCRIPTION
Apparently, by default, OpenSSL uses a single key for ECDH across all sessions in a server rather than generating a new key for each connection. This gives weaker forward secrecy properties than one would expect and thus is often disabled (e.g. both Apache mod_ssl and Nginx disable this feature). This patch does the same.

Also, disable session resumption, which isn't very useful for us (since clients don't rapidly reconnect to MUCKs):
- disable ticket support, which would break forward secrecy unless we were to regularly rotate the keys used to encrypt session tickets. 
- disable session cache support, where session IDs expire by default after 5 minutes (from connection start, it seems), but OpenSSL only clears expired sessions every 256 connections.