### PR TITLE
Move USE_SSL #define to config.h.

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -209,6 +209,10 @@
 #define TRUE  1
 #define FALSE 0
 
+#ifdef HAVE_LIBSSL
+# define USE_SSL
+#endif
+
 /*
  * Memory/malloc stuff.
  */

--- a/include/interface.h
+++ b/include/interface.h
@@ -6,6 +6,15 @@
 #include "mcp.h"
 #endif
 
+/* For the SSL* type. */
+#ifdef USE_SSL
+# ifdef HAVE_OPENSSL
+#  include <openssl/ssl.h>
+# else
+#  include <ssl.h>
+# endif
+#endif
+
 typedef enum {
 	TELNET_STATE_NORMAL,
 	TELNET_STATE_IAC,

--- a/src/interface.c
+++ b/src/interface.c
@@ -38,10 +38,6 @@
 # include <sys/select.h>
 #endif
 
-#ifdef HAVE_LIBSSL
-# define USE_SSL
-#endif
-
 #ifdef USE_SSL
 # ifdef HAVE_OPENSSL
 #  include <openssl/ssl.h>


### PR DESCRIPTION
Fixes problem where struct descriptor_data in interface.h will
be wrong when included from any file that doesn't set USE_SSL first.