### PR TITLE
Add command to reload SSL configuration

### DIFF
--- a/game/data/help.txt
+++ b/game/data/help.txt
@@ -32,18 +32,18 @@ ALPHA|ALPHABETICAL|COMMANDS
 You can get more help on the following topics:
 
 Symbols
-  @action        @armageddon    @attach        @bless         @boot
-  @chown         @chown_lock    @conlock       @contents      @create
-  @describe      @dig           @drop          @dump          @edit
-  @entrances     @fail          @find          @force         @force_lock
-  @idescribe     @kill          @link          @list          @lock
-  @mcpedit       @mcpprogram    @name          @newpassword   @odrop
-  @oecho         @ofail         @open          @osuccess      @owned
-  @password      @pcreate       @pecho         @program       @propset
-  @ps            @recycle       @restart       @restrict      @set
-  @shutdown      @stats         @success       @teleport      @toad
-  @trace         @unbless       @uncompile     @unlink        @unlock
-  @usage         @wall          
+  @action        @armageddon    @attach         @bless         @boot
+  @chown         @chown_lock    @conlock        @contents      @create
+  @describe      @dig           @drop           @dump          @edit
+  @entrances     @fail          @find           @force         @force_lock
+  @idescribe     @kill          @link           @list          @lock
+  @mcpedit       @mcpprogram    @name           @newpassword   @odrop
+  @oecho         @ofail         @open           @osuccess      @owned
+  @password      @pcreate       @pecho          @program       @propset
+  @ps            @recycle       @reconfiguressl @restart       @restrict
+  @set           @shutdown      @stats          @success       @teleport
+  @toad          @trace         @unbless        @uncompile     @unlink
+  @unlock        @usage         @wall
 
 A's
   abode  
@@ -1970,3 +1970,10 @@ robots may use this command.
 Also see: OUTPUTPREFIX
 ~
 ~
+@RECONFIGURESSL
+@RECONFIGURESSL
+
+  Only wizards may use this command.  Attempt to reread SSL certificate files
+and reset SSL options from @tune settings.  If it fails (for example,
+the new certificate file is not usable), old settings will persist. Must be
+typed in full.

--- a/include/config.h
+++ b/include/config.h
@@ -209,6 +209,10 @@
 #define TRUE  1
 #define FALSE 0
 
+#ifdef HAVE_LIBSSL
+# define USE_SSL
+#endif
+
 /*
  * Memory/malloc stuff.
  */

--- a/include/interface.h
+++ b/include/interface.h
@@ -146,6 +146,10 @@ extern void ignore_add_player(dbref Player, dbref Who);
 extern void ignore_remove_player(dbref Player, dbref Who);
 extern void ignore_remove_from_all_players(dbref Player);
 
+#ifdef USE_SSL
+extern int reconfigure_ssl(void);
+#endif
+
 /* the following symbols are provided by game.c */
 
 extern void process_command(int descr, dbref player, char *command);

--- a/include/interface.h
+++ b/include/interface.h
@@ -6,6 +6,15 @@
 #include "mcp.h"
 #endif
 
+/* For the SSL* type. */
+#ifdef USE_SSL
+# ifdef HAVE_OPENSSL
+#  include <openssl/ssl.h>
+# else
+#  include <ssl.h>
+# endif
+#endif
+
 typedef enum {
 	TELNET_STATE_NORMAL,
 	TELNET_STATE_IAC,

--- a/src/game.c
+++ b/src/game.c
@@ -166,6 +166,18 @@ do_shutdown(dbref player)
 	}
 }
 
+#ifdef USE_SSL
+void
+do_reinitialize_ssl(dbref player)
+{
+        if (reconfigure_ssl()) {
+                notify(player, "Successfully reloaded SSL configuration.");
+        } else {
+                notify(player, "Failed to reconfigure SSL; check status log for info.");
+        }
+}
+#endif
+
 void
 do_restart(dbref player)
 {
@@ -1111,14 +1123,22 @@ process_command(int descr, dbref player, char *command)
 				break;
 			case 'r':
 			case 'R':
-				/* @recycle, @relink, @restart, @restrict */
+				/* @recycle, @reconfiguressl, @relink, @restart, @restrict */
 				switch (command[3]) {
 				case 'c':
 				case 'C':
-					Matched("@recycle");
-					NOGUEST("@recycle", player);
-					do_recycle(descr, player, arg1);
-					break;
+#ifdef USE_SSL
+                                        if (!strcmp(command, "@reconfiguressl")) {
+                                                WIZARDONLY("@reconfiguressl", player);
+                                                PLAYERONLY("@reconfiguressl", player);
+                                                do_reinitialize_ssl(player);
+                                                break;
+                                        }
+#endif
+                                        Matched("@recycle");
+                                        NOGUEST("@recycle", player);
+                                        do_recycle(descr, player, arg1);
+                                        break;
 				case 'l':
 				case 'L':
 					Matched("@relink");

--- a/src/game.c
+++ b/src/game.c
@@ -168,7 +168,7 @@ do_shutdown(dbref player)
 
 #ifdef USE_SSL
 void
-do_reinitialize_ssl(dbref player)
+do_reconfigure_ssl(dbref player)
 {
         if (reconfigure_ssl()) {
                 notify(player, "Successfully reloaded SSL configuration.");
@@ -1131,7 +1131,7 @@ process_command(int descr, dbref player, char *command)
                                         if (!strcmp(command, "@reconfiguressl")) {
                                                 WIZARDONLY("@reconfiguressl", player);
                                                 PLAYERONLY("@reconfiguressl", player);
-                                                do_reinitialize_ssl(player);
+                                                do_reconfigure_ssl(player);
                                                 break;
                                         }
 #endif

--- a/src/interface.c
+++ b/src/interface.c
@@ -38,10 +38,6 @@
 # include <sys/select.h>
 #endif
 
-#ifdef HAVE_LIBSSL
-# define USE_SSL
-#endif
-
 #ifdef USE_SSL
 # ifdef HAVE_OPENSSL
 #  include <openssl/ssl.h>

--- a/src/interface.c
+++ b/src/interface.c
@@ -4482,7 +4482,11 @@ int reconfigure_ssl(void) {
 
         new_ssl_ctx = configure_new_ssl_ctx();
 
-        if (new_ssl_ctx != NULL && ssl_numsocks == 0 && ssl_numsocks_v6 == 0) {
+        if (new_ssl_ctx != NULL && ssl_numsocks == 0
+#ifdef USE_IPV6
+            && ssl_numsocks_v6 == 0
+#endif
+        ) {
             bind_ssl_sockets();
         }
 


### PR DESCRIPTION
This pull request includes #12.

Add a Wizard-only command `@reconfiguressl` to reinitialize the SSL_CTX, including reloading certificate files. The new configuration will be effective for all subsequent connections. Notably, this allows certificates to be renewed without restarting a MUCK. It also allows changes to SSL @tunes to be effective without restarting.

In the event that reconfiguring SSL fails, for example because a new certificate file is bad, the old configuration remains active, and a vague error is given to the Wizard running the command and a less vague error appears in the log file.