### PR TITLE
Amend @tune help; not entirely wizard-only

### DIFF
--- a/game/data/help.txt
+++ b/game/data/help.txt
@@ -1918,8 +1918,6 @@ typed in full.
 @TUNE %<param>
 @TUNE info <param>
 
-  This is a wizard-only command.
-
   View and modify tunable parameters that configure how the server operates,
 or provide help on a parameter.  Examples:
 
@@ -1930,7 +1928,8 @@ or provide help on a parameter.  Examples:
   @tune %foo         resets foo to the default system value
   @tune info foo     briefly describes foo
 
-  Some parameters may require a @RESTART or reload to apply.
+  Some parameters require wizard-level or higher to view or set, and some
+parameters may require a @RESTART or reload to apply.
 ~
 ~
 ~

--- a/game/data/info/muckhelp
+++ b/game/data/info/muckhelp
@@ -1579,8 +1579,6 @@ typed in full.
 @TUNE %<param>
 @TUNE info <param>
 
-  This is a wizard-only command.
-
   View and modify tunable parameters that configure how the server operates,
 or provide help on a parameter.  Examples:
 
@@ -1591,7 +1589,8 @@ or provide help on a parameter.  Examples:
   @tune %foo         resets foo to the default system value
   @tune info foo     briefly describes foo
 
-  Some parameters may require a @RESTART or reload to apply.
+  Some parameters require wizard-level or higher to view or set, and some
+parameters may require a @RESTART or reload to apply.
 
 
 

--- a/game/data/muckhelp.raw
+++ b/game/data/muckhelp.raw
@@ -1732,8 +1732,6 @@ typed in full.
 @TUNE %<param>
 @TUNE info <param>
 
-  This is a wizard-only command.
-
   View and modify tunable parameters that configure how the server operates,
 or provide help on a parameter.  Examples:
 
@@ -1744,7 +1742,8 @@ or provide help on a parameter.  Examples:
   @tune %foo         resets foo to the default system value
   @tune info foo     briefly describes foo
 
-  Some parameters may require a @RESTART or reload to apply.
+  Some parameters require wizard-level or higher to view or set, and some
+parameters may require a @RESTART or reload to apply.
 ~
 ~
 ~


### PR DESCRIPTION
Change help to indicate that some, not all, @tune parameters are wizard-only.

Servers may override @tune for non-wizard players, but in that case they'd need to change the help file anyways.  When releasing the next version, the changelog should note to update help.

(*Pardon the mistype and recent Windows build break; I'll try to test more options with future changes*)