### PR TITLE
Enable Travis continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,54 @@
+sudo: false
+addons:
+  apt:
+    packages:
+    # For lint
+    - splint
+    # For OpenSSL support
+    - libssl-dev
+
+language: c
+
+compiler:
+  - clang
+  - gcc
+
+env:
+  global:
+    # Always run lint
+    - FLAG_LINT="--with-lint"
+  matrix:
+    # Test with/without SSL, and with/without IPv6
+    # Unfortunately Travis does not yet have a way to build a 2x2 matrix from environment variables
+    # https://stackoverflow.com/questions/22397300/travis-and-matrix-combinations
+    - FLAG_IPV6="--enable-ipv6"   FLAG_SSL="--with-ssl"
+    - FLAG_IPV6="--enable-ipv6"   FLAG_SSL=""
+    - FLAG_IPV6=""                FLAG_SSL="--with-ssl"
+    - FLAG_IPV6=""                FLAG_SSL=""
+
+script:
+  - ./configure $FLAG_LINT $FLAG_IPV6 $FLAG_SSL && make clean && make all
+
+# Currently, --enable-memprof and --enable-debug are ignored for that generates
+# 32 builds instead of 8.  If those need tested in the future, use the
+# following matrix and script:
+#env:
+#  matrix:
+#    - FLAG_IPV6="--enable-ipv6"   FLAG_SSL="--with-ssl"  FLAG_MEMPROF="--enable-memprof"   FLAG_DEBUG="--enable-debug"
+#    - FLAG_IPV6="--enable-ipv6"   FLAG_SSL=""            FLAG_MEMPROF="--enable-memprof"   FLAG_DEBUG="--enable-debug"
+#    - FLAG_IPV6=""                FLAG_SSL="--with-ssl"  FLAG_MEMPROF="--enable-memprof"   FLAG_DEBUG="--enable-debug"
+#    - FLAG_IPV6=""                FLAG_SSL=""            FLAG_MEMPROF="--enable-memprof"   FLAG_DEBUG="--enable-debug"
+#    - FLAG_IPV6="--enable-ipv6"   FLAG_SSL="--with-ssl"  FLAG_MEMPROF="--enable-memprof"   FLAG_DEBUG=""
+#    - FLAG_IPV6="--enable-ipv6"   FLAG_SSL=""            FLAG_MEMPROF="--enable-memprof"   FLAG_DEBUG=""
+#    - FLAG_IPV6=""                FLAG_SSL="--with-ssl"  FLAG_MEMPROF="--enable-memprof"   FLAG_DEBUG=""
+#    - FLAG_IPV6=""                FLAG_SSL=""            FLAG_MEMPROF="--enable-memprof"   FLAG_DEBUG=""
+#    - FLAG_IPV6="--enable-ipv6"   FLAG_SSL="--with-ssl"  FLAG_MEMPROF=""                   FLAG_DEBUG="--enable-debug"
+#    - FLAG_IPV6="--enable-ipv6"   FLAG_SSL=""            FLAG_MEMPROF=""                   FLAG_DEBUG="--enable-debug"
+#    - FLAG_IPV6=""                FLAG_SSL="--with-ssl"  FLAG_MEMPROF=""                   FLAG_DEBUG="--enable-debug"
+#    - FLAG_IPV6=""                FLAG_SSL=""            FLAG_MEMPROF=""                   FLAG_DEBUG="--enable-debug"
+#    - FLAG_IPV6="--enable-ipv6"   FLAG_SSL="--with-ssl"  FLAG_MEMPROF=""                   FLAG_DEBUG=""
+#    - FLAG_IPV6="--enable-ipv6"   FLAG_SSL=""            FLAG_MEMPROF=""                   FLAG_DEBUG=""
+#    - FLAG_IPV6=""                FLAG_SSL="--with-ssl"  FLAG_MEMPROF=""                   FLAG_DEBUG=""
+#    - FLAG_IPV6=""                FLAG_SSL=""            FLAG_MEMPROF=""                   FLAG_DEBUG=""
+#script:
+#  - ./configure $FLAG_LINT $FLAG_IPV6 $FLAG_SSL $FLAG_MEMPROF $FLAG_DEBUG && make clean && make all


### PR DESCRIPTION
### Rationale
Continuous integration allows for automated testing of commits and pull-requests, making it easier to verify if a set of changes breaks the build on some obscure configuration, while also a reliable way to build Fuzzball (*no confusion over "it works on my machine"*).

This pull-request enables the [Travis CI service](https://travis-ci.org/ ) for Linux-based building.  [Appveyor](http://www.appveyor.com/ ) or a similar service for Windows-based building will be addressed separately.

### Implementation
* Using the Travis continuous integration service, build with/without SSL and with/without IPv6 support using both GCC and Clang, resulting in a total of 8 different types of builds
 * For example, see https://travis-ci.org/digitalcircuit/fuzzball
* Unfortunately, Travis does not yet have a way to [build a 2x2 matrix](https://stackoverflow.com/questions/22397300/travis-and-matrix-combinations ), so it looks a bit messy

**If merged, Travis CI [will need enabled as per documentation](https://docs.travis-ci.com/user/getting-started/), skipping creating a ```.travis.yml``` and using the file from this commit.**