### PR TITLE
edithelp: resolve ambiguous option '-col' to '-column'

### DIFF
--- a/src/helptk/edithelp.tcl
+++ b/src/helptk/edithelp.tcl
@@ -216,13 +216,13 @@ tcl::OptProc entryedit {
 	grid columnconf $w 3 -weight 1
 	grid columnconf $w 4 -minsize 5
 
-	grid $w.topicsl -row 1 -col 1
-	grid $w.topics  -row 1 -col 3
-	grid $w.xrefl   -row 3 -col 1
-	grid $w.xref    -row 3 -col 3
-	grid $w.data    -row 5 -col 1 -columnspan 3
-	grid $w.ok      -row 7 -col 1
-	grid $w.cancel  -row 7 -col 3
+	grid $w.topicsl -row 1 -column 1
+	grid $w.topics  -row 1 -column 3
+	grid $w.xrefl   -row 3 -column 1
+	grid $w.xref    -row 3 -column 3
+	grid $w.data    -row 5 -column 1 -columnspan 3
+	grid $w.ok      -row 7 -column 1
+	grid $w.cancel  -row 7 -column 3
 
 	focus $w.topics
 	tkwait window $w


### PR DESCRIPTION
## In brief
Specify ```-col``` as ```-column``` to resolve an ambiguous option warning in Tk version 8.6 (specifically, ```8.6.0+6ubuntu3```).  Otherwise, the Edit button displays a warning instead of displaying a useful editing window.

This might potentially cause issues on older versions of Tk, however, anyone upgrading to the [latest version 8.6.x](http://tcl.tk/software/tcltk/download.html ) will encounter this, including [Ubuntu 14.04's version](http://packages.ubuntu.com/trusty/tk ).

## Examples
### Ambiguous warning
![edithelp ambiguous warning](https://dl.dropbox.com/u/839888/Hosting/Utilities/Fuzzball/Development/pr/bug-helptk-crash/edithelp%20-%20ambiguous%20warning.png#v1)

### Result after fix
![edithelp warning fixed](https://dl.dropbox.com/u/839888/Hosting/Utilities/Fuzzball/Development/pr/bug-helptk-crash/edithelp%20-%20warning%20fixed.png#v1 )