### PR TITLE
Enable Appveyor Windows continuous integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,71 @@
+version: '{build}'
+
+install:
+    # Set up Visual Studio build environment, 32-bit output with a 64-bit builder
+    # > Increment version number when newer version of Visual Studio supported by Appveyor
+    - cmd: '"C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/vcvarsall.bat" amd64_x86'
+    # Set up Conan package manager
+    - cmd: echo Downloading Conan package manager...
+    - ps: wget http://downloads.conan.io/latest_windows -OutFile conan_installer.exe
+    - cmd: conan_installer.exe /VERYSILENT
+    - cmd: set PATH=%PATH%;C:\Program Files (x86)\Conan\conan
+    - cmd: conan --version
+
+build_script:
+    - ps: |
+        # Install Conan dependencies for 32-bit (x86)
+        conan install -s arch=x86
+        # > For statically-linked OpenSSL, specify: -s compiler="Visual Studio" -s compiler.runtime=MT
+        #   Then modify makefile.win to reference ..MT.lib instead.  Dynamic linking is preferred.
+
+        # Set up the OPENSSLDIR variable for makefile.win
+        $env:OPENSSLDIR = "$env:APPVEYOR_BUILD_FOLDER/bin"
+
+        # Build Fuzzball
+        # > NMake writes to standard error for the version header when it's not actually an error.
+        #   Treat all output as standard output instead.
+        #   See https://stackoverflow.com/questions/2095088/error-when-calling-3rd-party-executable-from-powershell-when-using-an-ide
+        cmd /c 'nmake /f %APPVEYOR_BUILD_FOLDER%/makefile.win 2>&1'
+
+        # Package and store the build results
+        # > File name of compressed output
+        $artifact_name = "fuzzball-win32"
+        # > Folder name stored inside compressed output
+        $artifact_root = "$env:APPVEYOR_BUILD_FOLDER/$artifact_name-$env:APPVEYOR_BUILD_VERSION"
+        # > Exact filename for compressed output (change extension for different format)
+        $artifact_zip = "$artifact_name.zip"
+
+        echo "Preparing release artifact..."
+        mkdir "$artifact_root"
+        cp -Recurse "$env:APPVEYOR_BUILD_FOLDER/game/*" "$artifact_root"
+        if ((Test-Path "$artifact_root/fbmuck.exe") -And (Test-Path "$artifact_root/fbhelp.exe") -And (Test-Path "$artifact_root/restart.exe")) {
+            echo "Packaging release artifact..."
+            7z a "$artifact_zip" "$artifact_root"
+            Push-AppveyorArtifact "$artifact_zip"
+            echo "Packaging successful!"
+        } else {
+            echo "Could not find compiled Fuzzball or related executables, build failed"
+            Exit 1
+        }
+
+# Guidance for future maintainers: Powershell versus Windows Command Interpreter
+# Environment variables
+# > Powershell:  $env:NAME
+# > cmd:         %NAME%
+# Quoting
+# > Powershell:  $env:NAME = "TEST"
+#                echo "Test message"
+# > cmd:         set NAME=TEST
+#                echo Test message
+# Running programs with spaces
+# > Powershell:  & "C:\path to\app.exe" Argument1 Argument2
+# > cmd:         "C:\path to\app.exe" Argument1 Argument2
+# (No difference if without spaces)
+# Running programs in current directory
+# > Powershell:  .\app.exe
+# > cmd:         app.exe
+# Paths
+# > Powershell:  'C:/path/to/file' or 'C:\path\to\file'
+# > cmd:         'C:\path\to\file' only
+
+# Thanks to TheOneRing (Freenode #quassel, Github) for initial help with setting up Appveyor

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,15 @@
+[requires]
+# Update version whenever a new release of OpenSSL comes out
+OpenSSL/1.0.2g@lasote/stable
+
+[options]
+# Use shared .dll libraries (MD instead of MT)
+OpenSSL:shared=True
+
+[imports]
+# Copy .dll, .lib, and .h files according to the makefile expectations
+# This is specific to OpenSSL and NMake's makefile.win.  In the future, it'd be
+# easier to integrate the Conan package manager by using CMake, or similar.
+bin, *.dll -> ./game
+lib, *.lib* -> ./bin/lib/vc
+include, *.h* -> ./bin/include

--- a/makefile.win
+++ b/makefile.win
@@ -10,7 +10,10 @@ SRCDIR=.\src
 INCDIR=.\include
 OUTDIR=.\game
 INTDIR=.\compile
+!IF "$(OPENSSLDIR)" == ""
+!MESSAGE OpenSSL directory OPENSSLDIR not specified, assuming default
 OPENSSLDIR=e:\sandbox\openssl
+!ENDIF
 
 CPP=cl.exe
 CPP_OPS=/nologo /EHsc /MT /W3 /O2 /c /D "_X86_" /D "_WIN32_" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /D "FD_SETSIZE=4096" /D "_WINSOCK_DEPRECATED_NO_WARNINGS" /D "_CRT_SECURE_NO_WARNINGS" /D "_CRT_NONSTDC_NO_WARNINGS" /D "_CRT_SECURE_NO_DEPRECATE" /D "POSIX" /I"$(WINDIR)" /I"$(INCDIR)" /I"$(OPENSSLDIR)\include" /Fd"$(INTDIR)\\"


### PR DESCRIPTION
### Rationale
Continuous integration allows for automated testing of commits and pull-requests, making it easier to verify if a set of changes breaks the build on some obscure configuration, while also a reliable way to build Fuzzball (*no confusion over "it works on my machine"*).

This pull-request enables the [Appveyor CI service](http://www.appveyor.com/ ) for Windows-based building, complementing the existing [Travis](https://travis-ci.org/ ) implementation.

### Implementation
* Using the Appveyor continuous integration service, build with NMake from Visual Studio 2015 (v14.0), with OpenSSL and other defaults specified in ```makefile.win```
 * For example, see https://ci.appveyor.com/project/digitalcircuit/fuzzball
* Publish a compressed bundle of the latest build results, simplifying testing of development releases
 * Build output goes to the ```/game``` subfolder alongside the OpenSSL libraries; messy, but it requires minimal changes to the existing build system
 * For example, see https://ci.appveyor.com/project/digitalcircuit/fuzzball/build/artifacts
* Use the Conan.io package manager for [automated downloads of OpenSSL](https://www.conan.io/search?q=OpenSSL ) for Windows builds
 * The [```conanfile```](http://docs.conan.io/en/latest/manage_deps/conanfile_txt.html ) dumps package files into a ```/bin``` folder to simplify handling in NMake
 * This will need updated when the Linux and Windows build systems are merged, perhaps with CMake
* Add support for an ```OPENSSLDIR``` environment variable to ```makefile.win```, letting Appveyor override the search directory when building

**If merged, Appveyor CI [will need enabled as per documentation](http://www.appveyor.com/docs ), skipping creating an ```appveyor.yml``` and using the file from this commit.**