### PR TITLE
Add help for @tune save, @tune load

### DIFF
--- a/game/data/help.txt
+++ b/game/data/help.txt
@@ -1917,6 +1917,8 @@ typed in full.
 @TUNE <param> [=<value>]
 @TUNE %<param>
 @TUNE info <param>
+@TUNE save
+@TUNE load
 
   This is a wizard-only command.
 
@@ -1929,6 +1931,8 @@ or provide help on a parameter.  Examples:
   @tune foo=bar      sets the value of foo to bar
   @tune %foo         resets foo to the default system value
   @tune info foo     briefly describes foo
+  @tune save         save all parameters to data/parmfile.cfg
+  @tune load         load all parameters from data/parmfile.cfg
 
   Some parameters may require a @RESTART or reload to apply.
 ~

--- a/game/data/info/muckhelp
+++ b/game/data/info/muckhelp
@@ -1578,6 +1578,8 @@ typed in full.
 @TUNE <param> [=<value>]
 @TUNE %<param>
 @TUNE info <param>
+@TUNE save
+@TUNE load
 
   This is a wizard-only command.
 
@@ -1590,6 +1592,8 @@ or provide help on a parameter.  Examples:
   @tune foo=bar      sets the value of foo to bar
   @tune %foo         resets foo to the default system value
   @tune info foo     briefly describes foo
+  @tune save         save all parameters to data/parmfile.cfg
+  @tune load         load all parameters from data/parmfile.cfg
 
   Some parameters may require a @RESTART or reload to apply.
 

--- a/game/data/muckhelp.raw
+++ b/game/data/muckhelp.raw
@@ -1731,6 +1731,8 @@ typed in full.
 @TUNE <param> [=<value>]
 @TUNE %<param>
 @TUNE info <param>
+@TUNE save
+@TUNE load
 
   This is a wizard-only command.
 
@@ -1743,6 +1745,8 @@ or provide help on a parameter.  Examples:
   @tune foo=bar      sets the value of foo to bar
   @tune %foo         resets foo to the default system value
   @tune info foo     briefly describes foo
+  @tune save         save all parameters to data/parmfile.cfg
+  @tune load         load all parameters from data/parmfile.cfg
 
   Some parameters may require a @RESTART or reload to apply.
 ~


### PR DESCRIPTION
Update ```help.txt```, ```muckhelp```, and ```muckhelp.raw``` with documentation on ```@tune save``` and ```@tune load```.

As ```data/parmfile.cfg``` is defined at compile-time, it should be safe to reference it in the help.  If changed locally, one should modify the help, too.