### PR TITLE
Reorganize README, add Windows information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-Fuzzball MUCK [![Build Status](https://travis-ci.org/fuzzball-muck/fuzzball.svg?branch=master)](https://travis-ci.org/fuzzball-muck/fuzzball)
+Fuzzball MUCK [![Linux Build Status](https://travis-ci.org/fuzzball-muck/fuzzball.svg?branch=master)](https://travis-ci.org/fuzzball-muck/fuzzball) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/ktwrfcsjbv4xt3op/branch/master?svg=true)](https://ci.appveyor.com/project/fuzzball-muck/fuzzball/branch/master)
 ===============
 
 Fuzzball is a [MUCK][wiki-muck] server, an online text-based multi-user chat and roleplaying game.  Multiple people may join, set up characters, talk, and interact, exploring and building a common world.  Nearly every aspect of the game can be customized via [MPI-driven descriptions][help-mpi] and [MUF programs][help-muf].
-
-This repository represents the ongoing development of the Fuzzball MUCK server software and related functionality.  More to come.
 
 ## Documentation
 
@@ -11,71 +9,34 @@ This repository represents the ongoing development of the Fuzzball MUCK server s
 * [MPI functions][help-mpi]
 * [MUF reference][help-muf]
 * [MINK - The Muck Information Kiosk][help-mink]
-* [Fuzzball website](https://www.fuzzball.org/)
+* [Fuzzball website][web-home]
 
-Fuzzball also offers a built-in help system.  Connect, then type ```help``` for assistance.
+Fuzzball also offers a built-in help system.  Connect, then type ```help``` for guidance.
 
-## Building
-Tools needed:
-* Make, a C compiler, and friends
-* Optionally, an SSL library, e.g. [OpenSSL](https://openssl.org/)
+## Downloads
+* **Stable**
+ * *Tested and supported, recommended for everyday usage*
+ * **Linux**: download from [the Fuzzball homepage][web-home], follow the steps in [the Linux README][docs-buildsrc-lin], skipping *Get Source*
+ * **Windows**: download from [the Fuzzball homepage][web-home], follow the steps under *Running* in [the Windows README](README_WINDOWS.md#running)
+* **Development**
+ * *Try out the latest features and help find issues, but if it breaks you get to keep all the pieces*
+ * **Linux**: follow the steps in [the Linux README][docs-buildsrc-lin].
+ * **Windows**: download a pre-built package from [the Appveyor build artifacts page](https://ci.appveyor.com/project/fuzzball-muck/fuzzball/branch/master/artifacts), follow the steps under *Running* in [the Windows README](README_WINDOWS.md#running).
 
-For an Ubuntu system, apt-get install the following packages
-```sh
-make gcc		# Make tools, compiler
-libssl-dev		# SSL library headers
-```
-
-### Get source
-* First time
-```sh
-cd ~          # Or any other desired directory
-git clone     https://github.com/fuzzball-muck/fuzzball.git
-cd fuzzball
-```
-* To update
-```sh
-cd ~/fuzzball  # Same path as above, plus the 'fuzzball' directory
-git pull
-```
-### Configure
-```sh
-./configure --with-ssl --enable-ipv6 # Or choose your own options
-```
-* See ```./configure --help```
-* Options may include ```--with-ssl```, ```--enable-ipv6```, etc
-* When testing, use a different ```--prefix```, e.g. ```./configure --prefix="$HOME/fuzzball-test"```
-
-### Build
-```sh
-make clean && make
-make cert                # Skip if SSL is not enabled, or you have your own certificate
-make install
-make install-sysv-inits  # Skip to not run at startup
-```
+### Building and Running from Source
+* [Linux README][docs-buildsrc-lin]
+* [Windows README](README_WINDOWS.md#building)
 
 ## Usage
 
-For a more comprehensive guide, check out [MINK - The Muck Information Kiosk][help-mink]
+For a comprehensive guide to running a muck, check out [MINK - The Muck Information Kiosk][help-mink].
 
-### Quick-start
-* **Follow the build directions above**
-* Copy the relevant databases (*alternatively, use ```fuzzball/scripts/fbmuck-add```*)
-```sh
-FB_DIR="$(pwd)"   # Directory containing Fuzzball
-PREFIX=""         # If installing to a different prefix, set it here
-mkdir --parents              "$PREFIX/var/fbmuck"                          # Create data directory
-cp -r "$FB_DIR/game/."       "$PREFIX/var/fbmuck"                          # Copy game information
-cp -r "$FB_DIR/dbs/basedb/." "$PREFIX/var/fbmuck"                          # Copy database
-mv "$PREFIX/var/fbmuck/data/basedb.db" "$PREFIX/var/fbmuck/data/std-db.db" # Rename database to standard
-```
-* Start Fuzzball
-```sh
-/usr/share/fbmuck/restart-script
-# If using a custom prefix, $PREFIX/share/fbmuck/restart-script
-```
+If you only need a quick test environment, read the instructions for your operating system in [Building and Running from Source][docs-buildsrc] right above.
 
-[wiki-muck]: https://en.wikipedia.org/wiki/MUCK
+[docs-buildsrc]: #building-and-running-from-source
+[docs-buildsrc-lin]: README_LINUX.md#building
 [help-mpi]: https://www.fuzzball.org/docs/mpihelp.html
 [help-muf]: https://www.fuzzball.org/docs/mufman.html
 [help-mink]: http://www.rdwarf.com/users/mink/muckman/
+[web-home]: https://www.fuzzball.org
+[wiki-muck]: https://en.wikipedia.org/wiki/MUCK

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -1,0 +1,69 @@
+Building and Running Fuzzball on Linux
+===============
+*For documentation and general help, see [the general README](README.md)*
+
+## Building
+Tools needed:
+* Make, a C compiler, and friends
+* Optionally, an SSL library, e.g. [OpenSSL](https://openssl.org/)
+* Optionally, the Git revision control system
+
+For an Ubuntu system, apt-get install these packages
+```sh
+make gcc        # Make tools, compiler
+libssl-dev      # SSL library headers
+git             # Git revision control system
+```
+
+### Get source
+* First time
+```sh
+cd ~          # Or any other desired directory
+git clone     https://github.com/fuzzball-muck/fuzzball.git
+cd fuzzball
+```
+* To update
+```sh
+cd ~/fuzzball  # Same path as above, plus the 'fuzzball' directory
+git pull
+```
+* Or [download a zip archive from Github](https://github.com/fuzzball-muck/fuzzball/archive/master.zip)
+
+### Configure
+```sh
+./configure --with-ssl --enable-ipv6 # Or choose your own options
+```
+* See ```./configure --help```
+ * Common options include ```--with-ssl```, ```--enable-ipv6```
+ * If needed, specify SSL headers via ```--with-ssl=/path/to/dir```, or PCRE headers via ```--with-pcre=/path/to/dir```
+* When testing, use a different ```--prefix```, e.g. ```./configure --prefix="$HOME/fuzzball-test"```
+
+### Build
+```sh
+make clean && make
+make cert                # Skip if SSL is not enabled, or you have your own certificate
+make install
+make install-sysv-inits  # Skip to not run at startup
+```
+
+## Running
+For a comprehensive guide to running a MUCK, check out [MINK - The Muck Information Kiosk][help-mink].
+
+### Quick-start
+* **Follow the build directions above**
+* Copy the relevant databases (*alternatively, use ```fuzzball/scripts/fbmuck-add```*)
+```sh
+FB_DIR="$(pwd)"   # Directory containing Fuzzball
+PREFIX=""         # If installing to a different prefix, set it here
+mkdir --parents              "$PREFIX/var/fbmuck"                          # Create data directory
+cp -r "$FB_DIR/game/."       "$PREFIX/var/fbmuck"                          # Copy game information
+cp -r "$FB_DIR/dbs/basedb/." "$PREFIX/var/fbmuck"                          # Copy database
+mv "$PREFIX/var/fbmuck/data/basedb.db" "$PREFIX/var/fbmuck/data/std-db.db" # Rename database to standard
+```
+* Start Fuzzball
+```sh
+/usr/share/fbmuck/restart-script
+# If using a custom prefix, $PREFIX/share/fbmuck/restart-script
+```
+
+[help-mink]: http://www.rdwarf.com/users/mink/muckman/

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -1,0 +1,72 @@
+Building and Running Fuzzball on Windows
+===============
+*For documentation and general help, see [the general README](README.md)*
+
+## Building
+Tools needed:
+* [Visual Studio 2015 or higher](https://www.visualstudio.com/downloads/download-visual-studio-vs)
+* [Conan.io package manager](https://www.conan.io/downloads), or a manually installed SSL library, e.g. [OpenSSL for Windows](https://wiki.openssl.org/index.php/Binaries)
+* Optionally, the [Git revision control system](https://git-scm.com/download/win)
+
+### Get source
+* First time
+ * Open a Git Bash shell in the desired folder (*if Windows Explorer integration is active, right-click, ```Git Bash```*)
+```sh
+cd ~          # Or any other desired directory
+git clone     https://github.com/fuzzball-muck/fuzzball.git
+cd fuzzball
+```
+* To update
+ * Open a Git Bash shell
+```sh
+cd ~/fuzzball  # Same path as above, plus the 'fuzzball' directory
+git pull
+```
+* Or [download a zip archive from Github](https://github.com/fuzzball-muck/fuzzball/archive/master.zip)
+
+### Configure
+*Use the Windows command prompt instead of Git Bash*
+* Set up Visual Studio environment variables
+ * Use ```Program Files``` instead of ```Program Files (x86)``` if on a 32-bit machine
+ * Fuzzball does not currently support compiling as 64-bit
+```bat
+"C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
+```
+* Set up dependencies with Conan.io
+```bat
+conan install -s arch=x86
+set OPENSSLDIR=C:\path\to\fuzzball\bin
+```
+* *Or*, use a manually-installed version of OpenSSL
+```bat
+set OPENSSLDIR=C:\path\to\openssl
+```
+
+### Build
+```bat
+nmake /f makefile.win
+```
+
+## Running
+* Install the [32-bit Visual C++ Redistributable for Visual Studio 2015][visual-runtime] (*Fuzzball currently does not support 64-bit*)
+* Manage the server with ```restart.exe```
+
+For a comprehensive guide to running a MUCK, check out [MINK - The Muck Information Kiosk][help-mink].
+
+### Quick-start
+* **Follow the build directions, or [download a pre-built package][docs-downloads]**
+* Set up configuration in ```restart.ini```
+```bat
+cd "path\to\fuzzball\folder"
+restart -c
+```
+* Edit and save ```restart.ini``` with your options, e.g. with ```notepad restart.ini```
+* If using SSL, save your certificate and key as ```data\server.pem```, or later configure ```@tune ssl_cert_file``` and ```@tune ssl_key_file```
+* Start the server
+```bat
+restart
+```
+
+[help-mink]: http://www.rdwarf.com/users/mink/muckman/
+[docs-downloads]: README.md#downloads
+[visual-runtime]: https://www.microsoft.com/en-us/download/details.aspx?id=48145


### PR DESCRIPTION
* Move Linux build information to ```README_LINUX.md```, removing clutter from the main README
* Add draft of Windows build information to ```README_WINDOWS.md```, documenting setting up a build environment
 * This information may be incomplete, feel free to change as needed.
* Update ```README.md``` to reference the stable downloads, additional help, and link to the new build pages as needed
* Add Appveyor build status to the top, right by the Travis tag

*For an example, see https://github.com/digitalcircuit/fuzzball/tree/ft-readme-windows*