### PR TITLE
Fix help generation, formatting, add new tunable parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ restart
 # Debug files
 *.dSYM/
 
-# generated files
+# Generated files
 Makefile
 autom4te.cache/
 config.log
@@ -46,6 +46,7 @@ config.status
 include/autoconf.h
 include/defines.h
 src/version.c
+docs_html/
 
 # Windows build files
 compile

--- a/Makefile.in
+++ b/Makefile.in
@@ -6,6 +6,9 @@ RM=rm -f
 SSLTOP=@ssldir@
 RPMDIR="/usr/src/RPM/"
 
+HTML_DOCS_DIR=docs_html
+# Output directory for HTML source.  Relative to the current working directory.
+
 all:	Makefile
 	for d in ${subdirs}; do \
 		cd $${d} && ${MAKE} all; \
@@ -48,6 +51,7 @@ cert game/server.pem:
 	fi
 
 clean:
+	if [ -d ${HTML_DOCS_DIR} ]; then ${RM} -r ${HTML_DOCS_DIR}; fi
 	for d in ${subdirs}; do \
 		cd $${d} && ${MAKE} clean; \
 	done
@@ -78,11 +82,12 @@ Makefile: Makefile.in
 TMPPKGDIR=/tmp/tmp_fbmuck_pkg
 TMPREV=/tmp/tmp_fbmuck_rev
 
-#help:
-#	cd src && make prochelp
-#	cd game/data && ../../src/prochelp mpihelp.raw mpihelp.txt ../../docs/mpihelp.html
-#	cd game/data && ../../src/prochelp mufman.raw man.txt ../../docs/mufman.html
-#	cd game/data && ../../src/prochelp muckhelp.raw help.txt ../../docs/muckhelp.html
+help:
+	mkdir -p ${HTML_DOCS_DIR}
+	cd src && make prochelp
+	cd game/data && ../../src/prochelp mpihelp.raw mpihelp.txt ../../${HTML_DOCS_DIR}/mpihelp.html
+	cd game/data && ../../src/prochelp mufman.raw man.txt ../../${HTML_DOCS_DIR}/mufman.html
+	cd game/data && ../../src/prochelp muckhelp.raw help.txt ../../${HTML_DOCS_DIR}/muckhelp.html
 
 #package: help
 #	rm -rf ${TMPPKGDIR}

--- a/game/data/help.txt
+++ b/game/data/help.txt
@@ -140,7 +140,6 @@ whisper      who
 ~
 ~
 ~
-~
 STARTINGOUT|STARTING_OUT|STARTING OUT
 The word 'me' refers to yourself. Some things to do when starting out:
 1) give yourself a description with "@describe me=<description>", then
@@ -1882,7 +1881,6 @@ NOT save the database out to disk.  Use this ONLY when you suspect the
 database has been corrupted, and it would be a BAD thing to save the
 database out to disk.
 Also see: @SHUTDOWN and @RESTART
-~
 ~
 ~
 @RESTRICT

--- a/game/data/info/muckhelp
+++ b/game/data/info/muckhelp
@@ -11,7 +11,6 @@
 
 
 
-
 The word 'me' refers to yourself. Some things to do when starting out:
 1) give yourself a description with "@describe me=<description>", then
     look at yourself with "look me".
@@ -1547,7 +1546,6 @@ in full.
 NOT save the database out to disk.  Use this ONLY when you suspect the
 database has been corrupted, and it would be a BAD thing to save the
 database out to disk.
-
 
 
 @RESTRICT [on|off]

--- a/game/data/info/mufman1
+++ b/game/data/info/mufman1
@@ -3392,6 +3392,7 @@ Parameters available:
   (bool) secure_thing_movement - Moving things act like player (Wizbit only)
   (bool) do_mpi_parsing       - Parse MPI strings in messages
   (bool) lazy_mpi_istype_perm - Enable looser legacy perms for MPI {istype}
+  (bool) consistent_lock_source - Maintain trigger as lock source in TESTLOCK
   (bool) expanded_debug_trace - MUF debug trace shows array contents
   (bool) force_mlev1_name_notify - MUF notify prepends username for ML1 programs
   (bool) muf_comments_strict  - MUF comments are strict and not recursive

--- a/game/data/man.txt
+++ b/game/data/man.txt
@@ -4280,6 +4280,7 @@ Parameters available:
   (bool) secure_thing_movement - Moving things act like player (Wizbit only)
   (bool) do_mpi_parsing       - Parse MPI strings in messages
   (bool) lazy_mpi_istype_perm - Enable looser legacy perms for MPI {istype}
+  (bool) consistent_lock_source - Maintain trigger as lock source in TESTLOCK
   (bool) expanded_debug_trace - MUF debug trace shows array contents
   (bool) force_mlev1_name_notify - MUF notify prepends username for ML1 programs
   (bool) muf_comments_strict  - MUF comments are strict and not recursive

--- a/game/data/muckhelp.raw
+++ b/game/data/muckhelp.raw
@@ -9,7 +9,6 @@
 ~~section Basics|Basics
 ~
 ~
-~
 STARTINGOUT|STARTING_OUT|STARTING OUT
 The word 'me' refers to yourself. Some things to do when starting out:
 1) give yourself a description with "@describe me=<description>", then
@@ -1698,7 +1697,6 @@ database out to disk.
 ~~alsosee @SHUTDOWN,@RESTART
 ~
 ~
-~
 @RESTRICT
 @RESTRICT [on|off]
 
@@ -1739,6 +1737,7 @@ typed in full.
   View and modify tunable parameters that configure how the server operates,
 or provide help on a parameter.  Examples:
 
+~~code
   @tune              shows all parameters and their values
   @tune info         shows all parameters, values, and brief descriptions
   @tune foo          shows the value of foo
@@ -1747,6 +1746,7 @@ or provide help on a parameter.  Examples:
   @tune info foo     briefly describes foo
   @tune save         save all parameters to data/parmfile.cfg
   @tune load         load all parameters from data/parmfile.cfg
+~~endcode
 
   Some parameters may require a @RESTART or reload to apply.
 ~

--- a/game/data/mufman.raw
+++ b/game/data/mufman.raw
@@ -2,6 +2,7 @@
 ~~author Revar Desmera <revar@belfry.com>
 ~~doccmd man
 ~~sectlist
+~~secttopics
 ~~index
 ~~file info/mufman1
 ~
@@ -2526,7 +2527,7 @@ SMATCH ( s s2 -- i )
 if the string fits the pattern.  This is case insensitive.  In the pattern
 string, the following special characters will do as follows:
 
-~~code  
+~~code
   *  A '?' matches any single character.
   
   *  A '*' matches any number of any characters.

--- a/game/data/mufman.raw
+++ b/game/data/mufman.raw
@@ -3997,6 +3997,7 @@ Parameters available:
   (bool) secure_thing_movement - Moving things act like player (Wizbit only)
   (bool) do_mpi_parsing       - Parse MPI strings in messages
   (bool) lazy_mpi_istype_perm - Enable looser legacy perms for MPI {istype}
+  (bool) consistent_lock_source - Maintain trigger as lock source in TESTLOCK
   (bool) expanded_debug_trace - MUF debug trace shows array contents
   (bool) force_mlev1_name_notify - MUF notify prepends username for ML1 programs
   (bool) muf_comments_strict  - MUF comments are strict and not recursive


### PR DESCRIPTION
* Add new tunable parameter ```consistent_lock_source``` to ```mufman.raw``` and related generated help files (```mufman1```, ```man.txt```).
 * In the future, this portion of the help should be automatically generated, but for now keep it in sync so one can learn about it without reading the source or having a running server
* Re-add ```make help``` functionality using a new ```HTML_DOCS_DIR``` variable, currently set to ```docs_html```
 * This makes the generated help functionality more obvious to new contributors and hopefully reduces confusion
 * In the future, this should be cleaned up so all generated docs are made as part of ```make all```, and ```help.txt```/```man.txt``` should be removed from the repository (*don't forget to update ```Makefile.win```, too*)
* Update generated docs, including some formatting fixes