### PR TITLE
Update Linux README with PCRE package, website link

### DIFF
--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -4,13 +4,14 @@ Building and Running Fuzzball on Linux
 
 ## Building
 Tools needed:
-* Make, a C compiler, PCRE library, and friends
+* Make, a C compiler, [PCRE library](http://pcre.org/), and friends
 * Optionally, an SSL library, e.g. [OpenSSL](https://openssl.org/)
 * Optionally, the Git revision control system
 
 For an Ubuntu system, apt-get install these packages
 ```sh
 make gcc        # Make tools, compiler
+libpcre3-dev    # PCRE headers
 libssl-dev      # SSL library headers
 git             # Git revision control system
 ```


### PR DESCRIPTION
* Add the ```libpcre3-dev``` package to the Ubuntu ```apt-get install``` instructions.
* Make the PCRE library a link to the website
 * Saves a quick Internet search for those who don't know of it.