### PR TITLE
Tidy up sync_legacy_prop references

### DIFF
--- a/dbs/advancedb/data/advancedb.db
+++ b/dbs/advancedb/data/advancedb.db
@@ -1,7 +1,7 @@
 ***Foxen9 TinyMUCK DUMP Format***
 164
 1
-123
+122
 autolook_cmd=look
 cpennies=Pennies
 cpenny=Penny
@@ -118,7 +118,6 @@ playermax=no
 lock_envcheck=no
 look_propqueues=no
 show_legacy_props=no
-sync_legacy_props=no
 registration=yes
 %server_cipher_preference=yes
 periodic_program_purge=yes

--- a/dbs/basedb/data/basedb.db
+++ b/dbs/basedb/data/basedb.db
@@ -1,7 +1,7 @@
 ***Foxen9 TinyMUCK DUMP Format***
 69
 1
-123
+122
 autolook_cmd=look
 cpennies=Pennies
 cpenny=Penny
@@ -118,7 +118,6 @@ playermax=no
 lock_envcheck=no
 look_propqueues=no
 show_legacy_props=no
-sync_legacy_props=no
 registration=no
 %server_cipher_preference=yes
 periodic_program_purge=yes

--- a/dbs/fb-base/data/fb-base.db
+++ b/dbs/fb-base/data/fb-base.db
@@ -1,7 +1,7 @@
 ***Foxen9 TinyMUCK DUMP Format***
 27
 1
-123
+122
 autolook_cmd=look
 cpennies=Pennies
 cpenny=Penny
@@ -118,7 +118,6 @@ playermax=no
 lock_envcheck=no
 look_propqueues=no
 show_legacy_props=no
-sync_legacy_props=no
 registration=yes
 %server_cipher_preference=yes
 periodic_program_purge=yes

--- a/dbs/minimal/data/minimal.db
+++ b/dbs/minimal/data/minimal.db
@@ -1,7 +1,7 @@
 ***Foxen9 TinyMUCK DUMP Format***
 2
 1
-123
+122
 autolook_cmd=look
 cpennies=Pennies
 cpenny=Penny
@@ -118,7 +118,6 @@ playermax=no
 lock_envcheck=no
 look_propqueues=no
 show_legacy_props=no
-sync_legacy_props=no
 registration=yes
 %server_cipher_preference=yes
 periodic_program_purge=yes

--- a/dbs/regressions/data/regressions.db
+++ b/dbs/regressions/data/regressions.db
@@ -1,7 +1,7 @@
 ***Foxen9 TinyMUCK DUMP Format***
 31
 1
-124
+123
 autolook_cmd=look
 cpennies=Pennies
 cpenny=Penny
@@ -119,7 +119,6 @@ playermax=no
 lock_envcheck=no
 look_propqueues=no
 show_legacy_props=no
-sync_legacy_props=no
 registration=yes
 %server_cipher_preference=yes
 periodic_program_purge=yes

--- a/game/data/info/mufman1
+++ b/game/data/info/mufman1
@@ -3414,7 +3414,6 @@ Parameters available:
   (bool) lock_envcheck        - Locks check environment for properties
   (bool) look_propqueues      - Trigger _look/ propqueues when a player looks
   (bool) show_legacy_props    - Examining objects lists legacy props
-  (bool) sync_legacy_props    - Setting properties also sets associated legacy props
   (bool) registration         - Require new players to register manually
   (bool) server_cipher_preference - Honor server cipher preference order over client's (Wizbit only)
   (bool) periodic_program_purge - Periodically free unused MUF programs

--- a/game/data/man.txt
+++ b/game/data/man.txt
@@ -4308,7 +4308,6 @@ Parameters available:
   (bool) lock_envcheck        - Locks check environment for properties
   (bool) look_propqueues      - Trigger _look/ propqueues when a player looks
   (bool) show_legacy_props    - Examining objects lists legacy props
-  (bool) sync_legacy_props    - Setting properties also sets associated legacy props
   (bool) registration         - Require new players to register manually
   (bool) server_cipher_preference - Honor server cipher preference order over client's (Wizbit only)
   (bool) periodic_program_purge - Periodically free unused MUF programs

--- a/game/data/minimal.db
+++ b/game/data/minimal.db
@@ -1,7 +1,7 @@
 ***Foxen9 TinyMUCK DUMP Format***
 2
 1
-123
+122
 autolook_cmd=look
 cpennies=Pennies
 cpenny=Penny
@@ -118,7 +118,6 @@ playermax=no
 lock_envcheck=no
 look_propqueues=no
 show_legacy_props=no
-sync_legacy_props=no
 registration=yes
 %server_cipher_preference=yes
 periodic_program_purge=yes

--- a/game/data/mufman.raw
+++ b/game/data/mufman.raw
@@ -4024,7 +4024,6 @@ Parameters available:
   (bool) lock_envcheck        - Locks check environment for properties
   (bool) look_propqueues      - Trigger _look/ propqueues when a player looks
   (bool) show_legacy_props    - Examining objects lists legacy props
-  (bool) sync_legacy_props    - Setting properties also sets associated legacy props
   (bool) registration         - Require new players to register manually
   (bool) server_cipher_preference - Honor server cipher preference order over client's (Wizbit only)
   (bool) periodic_program_purge - Periodically free unused MUF programs


### PR DESCRIPTION
Follow-up to [removing ```sync_legacy_prop```](https://github.com/fuzzball-muck/fuzzball/commit/1896990c5e27e90bb2c505abded3777039bb6767 ).
* Remove from ```mufman.raw``` and generated help files
* Remove from starter and test databases
 * No harm caused as unknown properties are ignored, but makes things a little more clean

*Pardon if you intended to get to this; no ill will meant*