### PR TITLE
ArrCommas fix serial comma with < 3 terms

### DIFF
--- a/dbs/advancedb/muf/2.m
+++ b/dbs/advancedb/muf/2.m
@@ -92,7 +92,7 @@
         ", and " strcat
         swap strcat
     else
-        ", and " array_join
+        " and " array_join
     then
 ;
  


### PR DESCRIPTION
If only two terms are given, "Pyro and Muddypaw" then a comma isn't required before "and"