### PR TITLE
Clean up AppVeyor builds, part 1

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
     # Set up Conan package manager
     - cmd: set PATH=%PATH%;%PYTHON%/Scripts/
     - cmd: pip.exe install conan
-    - cmd: set PATH=%PATH%;C:\Program Files (x86)\Conan\conan
+    - cmd: conan user # Create conan data directory
     - cmd: conan --version
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,8 +17,10 @@ build_script:
         # > For statically-linked OpenSSL, specify: -s compiler="Visual Studio" -s compiler.runtime=MT
         #   Then modify makefile.win to reference ..MT.lib instead.  Dynamic linking is preferred.
 
-        # Set up the OPENSSLDIR variable for makefile.win
-        $env:OPENSSLDIR = "$env:APPVEYOR_BUILD_FOLDER/bin"
+        # Set up the variables for makefile.win
+        $env:OUTDIR = "$env:APPVEYOR_BUILD_FOLDER/build"
+        # Conan.io exports outputs to here, including OpenSSL
+        $env:PACKAGE_DIR = "$env:APPVEYOR_BUILD_FOLDER/bin"
 
         # Build Fuzzball
         # > NMake writes to standard error for the version header when it's not actually an error.
@@ -36,7 +38,10 @@ build_script:
 
         echo "Preparing release artifact..."
         mkdir "$artifact_root"
+        # Copy game data
         cp -Recurse "$env:APPVEYOR_BUILD_FOLDER/game/*" "$artifact_root"
+        # Copy compiled binaries and libraries
+        cp -Recurse "$env:APPVEYOR_BUILD_FOLDER/build/*" "$artifact_root"
         if ((Test-Path "$artifact_root/fbmuck.exe") -And (Test-Path "$artifact_root/restart.exe")) {
             echo "Packaging release artifact..."
             7z a "$artifact_zip" "$artifact_root"

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -10,6 +10,6 @@ OpenSSL:shared=True
 # Copy .dll, .lib, and .h files according to the makefile expectations
 # This is specific to OpenSSL and NMake's makefile.win.  In the future, it'd be
 # easier to integrate the Conan package manager by using CMake, or similar.
-bin, *.dll -> ./game
+bin, *.dll -> ./build
 lib, *.lib* -> ./bin/lib/vc
 include, *.h* -> ./bin/include

--- a/makefile.win
+++ b/makefile.win
@@ -7,21 +7,35 @@ NULL=nul
 WINDIR=.\win32
 SRCDIR=.\src
 INCDIR=.\include
+# Compile output directory
+!IF "$(OUTDIR)" == ""
+!MESSAGE Compile output directory OUTDIR not specified, assuming default
 OUTDIR=.\game
+!ENDIF
+
 INTDIR=.\compile
+
+# Package includes (e.g. from conan.io)
+!IF "$(PACKAGE_DIR)" == ""
+!MESSAGE Package directory PACKAGE_DIR not specified, assuming default
+PACKAGE_DIR=.\win32
+!ENDIF
+
+# OpenSSL include directory
 !IF "$(OPENSSLDIR)" == ""
 !MESSAGE OpenSSL directory OPENSSLDIR not specified, assuming default
 OPENSSLDIR=e:\sandbox\openssl
 !ENDIF
 
+# Specify PACKAGE_DIR first so it takes priority, allowing easier overriding of any built-in binaries/libs
 CPP=cl.exe
-CPP_OPS=/nologo /EHsc /MT /W3 /O2 /c /D "WIN32" /D "FD_SETSIZE=4096" /D "_WINSOCK_DEPRECATED_NO_WARNINGS" /D "_CRT_SECURE_NO_DEPRECATE" /D "POSIX" /I"$(WINDIR)" /I"$(INCDIR)" /I"$(OPENSSLDIR)\include" /Fd"$(INTDIR)\\"
+CPP_OPS=/nologo /EHsc /MT /W3 /O2 /c /D "WIN32" /D "FD_SETSIZE=4096" /D "_WINSOCK_DEPRECATED_NO_WARNINGS" /D "_CRT_SECURE_NO_DEPRECATE" /D "POSIX" /I"$(PACKAGE_DIR)\include" /I"$(WINDIR)" /I"$(INCDIR)" /I"$(OPENSSLDIR)\include" /Fd"$(INTDIR)\\"
 LINK32=link.exe
-LINK32_OPS=/NODEFAULTLIB:libc /LIBPATH:".\win32" /LIBPATH:"$(OPENSSLDIR)\lib\vc" pcre.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib ws2_32.lib libeay32MD.lib ssleay32MD.lib winmm.lib /nologo /subsystem:console /incremental:no /machine:I386
+LINK32_OPS=/NODEFAULTLIB:libc /LIBPATH:"$(PACKAGE_DIR)\lib\vc" /LIBPATH:".\win32" /LIBPATH:"$(OPENSSLDIR)\lib\vc" pcre.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib ws2_32.lib libeay32MD.lib ssleay32MD.lib winmm.lib /nologo /subsystem:console /incremental:no /machine:I386
 
 # Enable These for debugging
-#CPP_OPS=/c /Od /D "_DEBUG" /Zi /EHsc /nologo /MTd /W3 /D "_X86_" /D "_WIN32_" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /D "FD_SETSIZE=4096" /D "_WINSOCK_DEPRECATED_NO_WARNINGS" /D "_CRT_SECURE_NO_WARNINGS" /D "_CRT_NONSTDC_NO_WARNINGS" /D "_CRT_SECURE_NO_DEPRECATE" /D "POSIX" /I"$(WINDIR)" /I"$(INCDIR)" /I"$(OPENSSLDIR)\include" /Fd"$(INTDIR)\\"
-#LINK32_OPS=/DEBUG /NODEFAULTLIB:libc /LIBPATH:".\win32" /LIBPATH:"$(OPENSSLDIR)\lib\vc" pcre.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib ws2_32.lib libeay32MD.lib ssleay32MD.lib winmm.lib /nologo /subsystem:console /incremental:no /machine:I386
+#CPP_OPS=/c /Od /D "_DEBUG" /Zi /EHsc /nologo /MTd /W3 /D "_X86_" /D "_WIN32_" /D "WIN32" /D "_CONSOLE" /D "_MBCS" /D "FD_SETSIZE=4096" /D "_WINSOCK_DEPRECATED_NO_WARNINGS" /D "_CRT_SECURE_NO_WARNINGS" /D "_CRT_NONSTDC_NO_WARNINGS" /D "_CRT_SECURE_NO_DEPRECATE" /D "POSIX" /I"$(PACKAGE_DIR)\include" /I"$(WINDIR)" /I"$(INCDIR)" /I"$(OPENSSLDIR)\include" /Fd"$(INTDIR)\\"
+#LINK32_OPS=/DEBUG /NODEFAULTLIB:libc /LIBPATH:"$(PACKAGE_DIR)\lib\vc" /LIBPATH:".\win32" /LIBPATH:"$(OPENSSLDIR)\lib\vc" pcre.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib ws2_32.lib libeay32MD.lib ssleay32MD.lib winmm.lib /nologo /subsystem:console /incremental:no /machine:I386
 
 
 ALL : "$(OUTDIR)\fbmuck.exe" "$(OUTDIR)\restart.exe"


### PR DESCRIPTION
## In short
* Clean up build system, using ```/build``` for binaries
  * Modify ```conanfile.txt``` to put OpenSSL in this folder
  * Allow modifying ```OUTDIR``` from ```makefile.win```, set this to ```/build``` in AppVeyor
* Modify ```makefile.win``` to optionally search for other packages
  * Simplifies OpenSSL if in the future other packages are bundled, e.g. PCRE
* Minor cleanups after switching to pip-based Conan install

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Fixes automated builds, essential to see if other things break
Risk | ★★☆ *2/3* | Might break build setups that differ from AppVeyor, though it shouldn't
Intrusiveness | ★☆☆ *1/3* | Build system changes, shouldn't interfere with other pull requests

## Rationale
Separating build system output and input helps with iterative development by making cleanup easier.  Though this isn't required for AppVeyor as it starts fresh each time, it's still useful to make it simpler to reorganize the repository in the future.