### PR TITLE
Use pselect() for SIGCHLD, SIGUSR1

### DIFF
--- a/configure
+++ b/configure
@@ -660,7 +660,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -737,7 +736,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -990,15 +988,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1136,7 +1125,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1289,7 +1278,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]

--- a/configure
+++ b/configure
@@ -660,6 +660,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -736,6 +737,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -988,6 +990,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1125,7 +1136,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1278,6 +1289,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -4712,7 +4724,7 @@ $as_echo "#define HAVE_STRUCT_TM_TM_GMTOFF /**/" >>confdefs.h
 
 fi
 
-for ac_func in mallinfo getrlimit getrusage random snprintf vsnprintf
+for ac_func in mallinfo getrlimit getrusage random snprintf vsnprintf pselect
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure.ac
+++ b/configure.ac
@@ -239,7 +239,7 @@ if test "$rb_cv_member_struct_tm_tm_gmtoff" = yes; then
   AC_DEFINE(HAVE_STRUCT_TM_TM_GMTOFF, [], [Define to 1 if 'tm_gmtoff' is a member of 'struct tm'.])
 fi
 
-AC_CHECK_FUNCS(mallinfo getrlimit getrusage random snprintf vsnprintf)
+AC_CHECK_FUNCS(mallinfo getrlimit getrusage random snprintf vsnprintf pselect)
 AC_CHECK_MEMBER([struct mallinfo.hblks])
 AC_CHECK_MEMBER([struct mallinfo.keepcost])
 AC_CHECK_MEMBER([struct mallinfo.treeoverhead])

--- a/include/autoconf.h.in
+++ b/include/autoconf.h.in
@@ -67,6 +67,9 @@
 /* PCRE headers are under pcre dir. */
 #undef HAVE_PCREINCDIR
 
+/* Define to 1 if you have the `pselect' function. */
+#undef HAVE_PSELECT
+
 /* Define to 1 if you have the `random' function. */
 #undef HAVE_RANDOM
 

--- a/include/fbsignal.h
+++ b/include/fbsignal.h
@@ -7,4 +7,9 @@ void set_console(void);
 void set_dumper_signals(void);
 void set_signals(void);
 
+#ifdef HAVE_PSELECT
+#include <signal.h>
+extern sigset_t pselect_signal_mask;
+#endif
+
 #endif				/* _FBSIGNAL_H */


### PR DESCRIPTION
Our handlers for signals do async-signal-unsafe things, which might be the root cause of MUCK freezes on futex() calls reported in issue #40. One solution to this is to ensure the signal handler only runs at a safe time, such as when we would call select(), rather than processing it immediately. This patch tries to implement that solution for SIGUSR1 and SIGCHLD on systems that support pselect().

SIGUSR1 and SIGCHLD are masked out of the process except during a call to pselect() (which replaces calls to select()), so the signal handler should only run during the call to select(). I only do this for SIGUSR1 and SIGCHLD because these are signals we expect the MUCK to continue running after; for signals like SIGSEGV or SIGTERM it seems more important to attempt to do something right away.