### PR TITLE
Send newline-terminated resolver commands, cleanup resolver process QUIT procedure

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -2208,6 +2208,7 @@ static kill_resolver(void)
     int i;
 
     write(resolver_sock[1], "QUIT\n", 5);
+    shutdown(resolver_sock[1], 2);
     wait(&i);
 }
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -1704,7 +1704,7 @@ addrout(int lport, long a, unsigned short prt)
     a = ntohl(a);
 
 #ifdef SPAWN_HOST_RESOLVER
-    snprintf(buf, sizeof(buf), "%ld.%ld.%ld.%ld(%u)%u",
+    snprintf(buf, sizeof(buf), "%ld.%ld.%ld.%ld(%u)%u\n",
 	     (a >> 24) & 0xff, (a >> 16) & 0xff, (a >> 8) & 0xff, a & 0xff, prt, lport);
     if (tp_hostnames) {
 	write(resolver_sock[1], buf, strlen(buf));


### PR DESCRIPTION
This fixes two problems with the external resolver code:
- addrout() in interface.c did not terminate resolver commands with a \n, so IPv4 resolutions generally wouldn't happen;
- the resolver code depended on fclose()ing stdin resulting fgets() returning an error, but I do not believe this happens consistently. This code checks the return value of fgets() under a lock to hopefully ensure that, when the resolver should shutdown, no other thread attempts to call fgets(). It also manipulated the shared variable shutdown_was_requested without a lock, which is illegal even though it is declared volatile.

This may fix a cause of issue #42.
