### PR TITLE
Remove assertion that avl != NULL in array_tree_find

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -150,7 +150,6 @@ array_tree_find(array_tree * avl, array_iter * key)
 {
     int cmpval;
 
-    assert(avl != NULL);
     assert(key != NULL);
 
     while (avl) {


### PR DESCRIPTION
avl == NULL appears to be how empty dictionaries are supposed to be represented, and array_tree_find behaves correctly for them (returning NULL).

May fix issue #44.