### PR TITLE
No repeat write

### DIFF
--- a/include/interface.h
+++ b/include/interface.h
@@ -89,6 +89,7 @@ struct descriptor_data {
     int is_starttls;
 #ifdef USE_SSL
     SSL *ssl_session;
+    int pending_ssl_write;
 #endif
     dbref player;
     int output_size;

--- a/src/interface.c
+++ b/src/interface.c
@@ -1317,6 +1317,7 @@ queue_immediate_and_flush(struct descriptor_data *d, const char *msg)
     }
 #endif
     queue_write(d, buf, strlen(buf));
+    d->block_writes = 0;
     process_output(d);
 }
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -1252,16 +1252,8 @@ socket_write(struct descriptor_data * d, const void *buf, size_t count)
 	i = SSL_write(d->ssl_session, buf, count);
 	if (i < 0) {
 	    i = SSL_get_error(d->ssl_session, i);
-            if (i == SSL_ERROR_WANT_WRITE) {
+            if (i == SSL_ERROR_WANT_WRITE || i == SSL_ERROR_WANT_READ) {
                 d->pending_ssl_write = 1;
-#ifdef WIN32
-		WSASetLastError(WSAEWOULDBLOCK);
-#else
-		errno = EWOULDBLOCK;
-#endif
-		return -1;
-	    } else if (i == SSL_ERROR_WANT_READ) {
-		/* log_ssl_error("write 0", d->descriptor, i); */
 #ifdef WIN32
 		WSASetLastError(WSAEWOULDBLOCK);
 #else

--- a/src/interface.c
+++ b/src/interface.c
@@ -1487,6 +1487,7 @@ initializesock(int s, const char *hostname, int is_ssl)
     d->descriptor = s;
 #ifdef USE_SSL
     d->ssl_session = NULL;
+    d->pending_ssl_write = 0;
 #endif
     d->connected = 0;
     d->booted = 0;


### PR DESCRIPTION
When a non-blocking SSL_write fails, OpenSSL requres the next write call to use the exact same buffer. We violate this requirement in some circumstances; in particular for QUIT and idle-boot messages and when output buffers fill up. This patch attempts to track whether an SSL_write failed with WANT_READ or WANT_WRITE and not discard the top element of the output queue in that case. This also modifies the idle-boot and leave message to use the output queue rather than calling socket_write() directly.

I created this while trying to diagnose issue #48, but I don't think it's likely to be that problem. (See also my 'tests' branch, in which I have some python scripts that start a MUCK and try to list a lot of MUF code, which is how I discovered this issue.)