### PR TITLE
Refactor output handling to use multiple queues.

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -230,6 +230,20 @@ update_quotas(struct timeval last, struct timeval current)
     return msec_add(last, nslices * tp_command_time_msec);
 }
 
+static int
+has_output(struct descriptor_data *d)
+{
+#ifdef USE_SSL
+    if (d->pending_ssl_write.head)
+        return 1;
+#endif
+    if (d->priority_output.head)
+        return 1;
+    if (!d->block_writes && d->output.head)
+        return 1;
+    return 0;
+}
+
 static void
 free_text_block(struct text_block *t)
 {
@@ -253,7 +267,7 @@ make_text_block(const char *s, int n)
 }
 
 static int
-flush_queue(struct text_queue *q, int n, int skip_head, int add_flushed_message)
+flush_queue(struct text_queue *q, int n, int add_flushed_message)
 {
     struct text_block *p;
     struct text_block *save_head;
@@ -261,11 +275,6 @@ flush_queue(struct text_queue *q, int n, int skip_head, int add_flushed_message)
 
     if (add_flushed_message) {
         n += strlen(flushed_message);
-    }
-
-    if (skip_head) {
-        save_head = q->head;
-        q->head = q->head->nxt;
     }
 
     while (n > 0 && (p = q->head)) {
@@ -276,22 +285,10 @@ flush_queue(struct text_queue *q, int n, int skip_head, int add_flushed_message)
 	free_text_block(p);
     }
 
-    if (skip_head) {
-        save_head->nxt = q->head;
-        q->head = save_head;
-        if (!save_head->nxt) {
-            q->tail = &save_head->nxt;
-        }
-    }
     if (add_flushed_message) {
         p = make_text_block(flushed_message, strlen(flushed_message));
-        if (skip_head) {
-            p->nxt = q->head->nxt;
-            q->head->nxt = p;
-        } else {
-            p->nxt = q->head;
-            q->head = p;
-        }
+        p->nxt = q->head;
+        q->head = p;
         q->lines++;
         if (!p->nxt)
             q->tail = &p->nxt;
@@ -304,9 +301,6 @@ static void
 add_to_queue(struct text_queue *q, const char *b, int n)
 {
     struct text_block *p;
-
-    if (n == 0)
-	return;
 
     p = make_text_block(b, n);
     p->nxt = 0;
@@ -321,21 +315,19 @@ flush_output_queue(struct descriptor_data *d, int include_message, int size_limi
 
     space = size_limit - d->output_size;
     if (space < 0) {
-#ifdef USE_SSL
-	d->output_size -= flush_queue(&d->output, -space, d->pending_ssl_write, 1);
-#else
-	d->output_size -= flush_queue(&d->output, -space, 0, 1);
-#endif
+	d->output_size -= flush_queue(&d->output, -space, 1);
     }
 }
 
-int
+void
 queue_write(struct descriptor_data *d, const char *b, int n)
 {
+    if (n == 0)
+        return;
     flush_output_queue(d, 1, tp_max_output - n);
     add_to_queue(&d->output, b, n);
     d->output_size += n;
-    return n;
+    return;
 }
 
 static int
@@ -1248,12 +1240,10 @@ socket_write(struct descriptor_data * d, const void *buf, size_t count)
 	return write(d->descriptor, buf, count);
 #endif
     } else {
-        d->pending_ssl_write = 0;
 	i = SSL_write(d->ssl_session, buf, count);
 	if (i < 0) {
 	    i = SSL_get_error(d->ssl_session, i);
             if (i == SSL_ERROR_WANT_WRITE || i == SSL_ERROR_WANT_READ) {
-                d->pending_ssl_write = 1;
 #ifdef WIN32
 		WSASetLastError(WSAEWOULDBLOCK);
 #else
@@ -1285,6 +1275,12 @@ socket_write(struct descriptor_data * d, const void *buf, size_t count)
 #endif
 
 static int
+queue_immediate_raw(struct descriptor_data *d, const char *msg)
+{
+    add_to_queue(&d->priority_output, msg, strlen(msg));
+}
+
+static int
 queue_immediate_and_flush(struct descriptor_data *d, const char *msg)
 {
     char buf[BUFFER_LEN + 8];
@@ -1304,12 +1300,10 @@ queue_immediate_and_flush(struct descriptor_data *d, const char *msg)
 #ifdef MCP_SUPPORT
     if (d->mcpframe.enabled
         && !(strncmp(buf, MCP_MESG_PREFIX, 3) && strncmp(buf, MCP_QUOTE_PREFIX, 3))) {
-        quote_len = strlen(MCP_QUOTE_PREFIX);
-        queue_write(d, MCP_QUOTE_PREFIX, quote_len);
+        queue_immediate_raw(d, MCP_QUOTE_PREFIX);
     }
 #endif
-    queue_write(d, buf, strlen(buf));
-    d->block_writes = 0;
+    queue_immediate_raw(d, buf);
     process_output(d);
 }
 
@@ -1479,7 +1473,9 @@ initializesock(int s, const char *hostname, int is_ssl)
     d->descriptor = s;
 #ifdef USE_SSL
     d->ssl_session = NULL;
-    d->pending_ssl_write = 0;
+    d->pending_ssl_write.lines = 0;
+    d->pending_ssl_write.head = 0;
+    d->pending_ssl_write.tail = &d->pending_ssl_write.head;
 #endif
     d->connected = 0;
     d->booted = 0;
@@ -1490,6 +1486,9 @@ initializesock(int s, const char *hostname, int is_ssl)
     d->connected_at = time(NULL);
     make_nonblocking(s);
     d->output_size = 0;
+    d->priority_output.lines = 0;
+    d->priority_output.head = 0;
+    d->priority_output.tail = &d->priority_output.head;
     d->output.lines = 0;
     d->output.head = 0;
     d->output.tail = &d->output.head;
@@ -1530,7 +1529,7 @@ initializesock(int s, const char *hostname, int is_ssl)
 	unsigned char telnet_do_starttls[] = {
 	    TELNET_IAC, TELNET_DO, TELOPT_STARTTLS, '\0'
 	};
-	socket_write(d, telnet_do_starttls, 3);
+	queue_immediate_raw(d, telnet_do_starttls);
 	queue_write(d, "\r\n", 2);
     }
 #endif
@@ -1825,7 +1824,8 @@ new_connection(int port, int sock, int is_ssl)
     }
 }
 
-static int
+/* sends keppalive; depends on process_output to set booted if connection is dead */
+static void 
 send_keepalive(struct descriptor_data *d)
 {
     int cnt;
@@ -1839,29 +1839,11 @@ send_keepalive(struct descriptor_data *d)
     }
 
     if (d->telnet_enabled) {
-	cnt = socket_write(d, telnet_nop, 2);
+        queue_immediate_raw(d, telnet_nop);
     } else {
-	cnt = socket_write(d, "", 0);
+        queue_immediate_raw(d, "");
     }
-#ifdef WIN32
-    /* We expect a 0 return */
-    if (cnt < 0 || cnt == SOCKET_ERROR) {
-	if (WSAGetLastError() == WSAEWOULDBLOCK)
-	    return 1;
-	return 0;
-    }
-#else
-    /* We expect a 0 return */
-    if (cnt < 0) {
-	if (errno == EWOULDBLOCK)
-	    return 1;
-	if (errno == 0)
-	    return 1;
-	log_status("keepalive socket write descr=%i, errno=%i", d->descriptor, errno);
-	return 0;
-    }
-#endif
-    return 1;
+    process_output(d);
 }
 
 static int
@@ -1932,7 +1914,7 @@ process_input(struct descriptor_data *d)
 	    case TELNET_AYT:	/* AYT */
 		{
 		    char sendbuf[] = "[Yes]\r\n";
-		    socket_write(d, sendbuf, strlen(sendbuf));
+                    queue_immediate_raw(d, sendbuf);
 		    d->telnet_state = TELNET_STATE_NORMAL;
 		    break;
 		}
@@ -1966,18 +1948,18 @@ process_input(struct descriptor_data *d)
 		break;
 	    case TELNET_SE:	/* Go Ahead */
 #ifdef USE_SSL
-		if (d->telnet_sb_opt == TELOPT_STARTTLS) {
-		    d->block_writes = 0;
-		    d->short_reads = 0;
-		    if (tp_starttls_allow) {
-			d->is_starttls = 1;
-			d->ssl_session = SSL_new(ssl_ctx);
-			SSL_set_fd(d->ssl_session, d->descriptor);
-			int ssl_ret_value = SSL_accept(d->ssl_session);
-			if (ssl_ret_value != 0)
-			    ssl_log_error(d->ssl_session, ssl_ret_value);
-			log_status("STARTTLS: %i", d->descriptor);
-		    }
+		if (d->telnet_sb_opt == TELOPT_STARTTLS && !d->ssl_session) {
+                    d->block_writes = 0;
+                    d->short_reads = 0;
+                    if (tp_starttls_allow) {
+                        d->is_starttls = 1;
+                        d->ssl_session = SSL_new(ssl_ctx);
+                        SSL_set_fd(d->ssl_session, d->descriptor);
+                        int ssl_ret_value = SSL_accept(d->ssl_session);
+                        if (ssl_ret_value != 0)
+                            ssl_log_error(d->ssl_session, ssl_ret_value);
+                        log_status("STARTTLS: %i", d->descriptor);
+                    }
 		}
 #endif
 		d->telnet_state = TELNET_STATE_NORMAL;
@@ -2007,9 +1989,10 @@ process_input(struct descriptor_data *d)
 		sendbuf[4] = TELNET_IAC;
 		sendbuf[5] = TELNET_SE;
 		sendbuf[6] = '\0';
-		socket_write(d, sendbuf, 6);
+                queue_immediate_raw(d, sendbuf);
 		d->block_writes = 1;
 		d->short_reads = 1;
+                process_output(d);
 	    } else
 #endif
 		/* Otherwise, we don't negotiate: send back DONT option */
@@ -2018,7 +2001,7 @@ process_input(struct descriptor_data *d)
 		sendbuf[1] = TELNET_DONT;
 		sendbuf[2] = *q;
 		sendbuf[3] = '\0';
-		socket_write(d, sendbuf, 3);
+                queue_immediate_raw(d, sendbuf);
 	    }
 	    d->telnet_state = TELNET_STATE_NORMAL;
 	    d->telnet_enabled = 1;
@@ -2029,7 +2012,7 @@ process_input(struct descriptor_data *d)
 	    sendbuf[1] = TELNET_WONT;
 	    sendbuf[2] = *q;
 	    sendbuf[3] = '\0';
-	    socket_write(d, sendbuf, 3);
+            queue_immediate_raw(d, sendbuf);
 	    d->telnet_state = TELNET_STATE_NORMAL;
 	    d->telnet_enabled = 1;
 	} else if (d->telnet_state == TELNET_STATE_WONT) {
@@ -2043,7 +2026,7 @@ process_input(struct descriptor_data *d)
 	    sendbuf[1] = TELNET_WONT;
 	    sendbuf[2] = *q;
 	    sendbuf[3] = '\0';
-	    socket_write(d, sendbuf, 3);
+            queue_immediate_raw(d, sendbuf);
 	    d->telnet_state = TELNET_STATE_NORMAL;
 	    d->telnet_enabled = 1;
 	} else if (d->telnet_state == TELNET_STATE_SB) {
@@ -2416,7 +2399,6 @@ shovechars()
 		if (d->booted == 2) {
 		    goodbye_user(d);
 		}
-		d->booted = 0;
 		process_output(d);
 		shutdownsock(d);
 	    }
@@ -2461,13 +2443,13 @@ shovechars()
 #endif
 	}
 	for (struct descriptor_data *d = descriptor_list; d; d = d->next) {
-	    if (d->input.lines > 100)
+	    if (d->input.lines > 0)
 		timeout = slice_timeout;
-	    else
+            if (d->input.lines < 100)
 		FD_SET(d->descriptor, &input_set);
 
 #ifdef USE_SSL
-	    if (d->output.head && !d->block_writes) {
+	    if (has_output(d)) {
 		/*
 		 * If SSL isn't already in place, give TELNET STARTTLS
 		 * handshaking a couple seconds to respond, to start it.
@@ -2500,7 +2482,7 @@ shovechars()
 		}
 	    }
 #else
-	    if (d->output.head && !d->block_writes) {
+	    if (has_output(d)) {
 		FD_SET(d->descriptor, &output_set);
 	    }
 #endif
@@ -2668,9 +2650,7 @@ shovechars()
 		    }
 		}
 		if (FD_ISSET(d->descriptor, &output_set)) {
-		    if (!process_output(d)) {
-			d->booted = 1;
-		    }
+		    process_output(d);
 		}
 		if (d->connected) {
 		    cnt++;
@@ -2688,9 +2668,9 @@ shovechars()
 		if (d->connected && tp_idle_ping_enable && (tp_idle_ping_time > 0)
 		    && ((now - d->last_pinged_at) > tp_idle_ping_time)) {
 		    const char *tmpptr = get_property_class(d->player, NO_IDLE_PING_PROP);
-		    if (!tmpptr && !send_keepalive(d)) {
-			d->booted = 1;
-		    }
+		    if (!tmpptr) {
+                        send_keepalive(d);
+                    }
 		}
 	    }
 	    if (cnt > con_players_max) {
@@ -3040,10 +3020,7 @@ wall_and_flush(const char *msg)
     for (struct descriptor_data *d = descriptor_list; d; d = dnext) {
 	dnext = d->next;
 	queue_ansi(d, buf);
-	/* queue_write(d, "\r\n", 2); */
-	if (!process_output(d)) {
-	    d->booted = 1;
-	}
+	process_output(d);
     }
 }
 
@@ -3060,64 +3037,113 @@ wall_wizards(const char *msg)
 	dnext = d->next;
 	if (d->connected && Wizard(d->player)) {
 	    queue_ansi(d, buf);
-	    if (!process_output(d)) {
-		d->booted = 1;
-	    }
+	    process_output(d);
 	}
     }
 }
 
-int
+/* write a text block from a queue, advancing the queue if needed;
+   adding the block to d->pending_ssl_write if needed;
+   returns 1 if something incomplete written, 0 if write started blocking,
+   -1 if I/O error
+*/
+static int
+write_text_block(struct descriptor_data *d, struct text_block **qp)
+{
+    int count;
+    struct text_block *cur = *qp;
+    int was_wouldblock = 0, was_error = 0;
+
+    if (!cur)
+        return 1;
+
+    count = socket_write(d, cur->start, cur->nchars);
+
+#ifdef WIN32
+    if (count <= 0 || count == SOCKET_ERROR) {
+        if (WSAGetLastError() == WSAEWOULDBLOCK) {
+            was_wouldblock = 1;
+        else
+            was_error = 1;
+    }
+#else
+    if (count <= 0) {
+        if (errno == EWOULDBLOCK)
+            was_wouldblock = 1;
+        else
+            was_error = 1;
+    }
+#endif
+    if (was_error) {
+        return -1;
+    } else if (was_wouldblock) {
+        count = 0;
+    }
+    d->output_size -= count;
+    if (count == cur->nchars) {
+        *qp = cur->nxt;
+        free_text_block(cur);
+        return 0;
+    }
+    cur->nchars -= count;
+    cur->start += count;
+#ifdef USE_SSL
+    if (cur != d->pending_ssl_write.head) {
+        assert(!d->pending_ssl_write.head);
+        d->pending_ssl_write.head = cur;
+        d->pending_ssl_write.tail = &cur->nxt;
+        d->pending_ssl_write.lines = 1;
+        *qp = cur->nxt;
+        cur->nxt = 0;
+    }
+#endif
+    return 1;
+}
+
+static int
+write_queue(struct descriptor_data * d, struct text_queue *queue)
+{
+    int result = 0;
+    struct text_block **qp = &queue->head;
+    while (*qp && result == 0) {
+        result = write_text_block(d, qp);
+        if (result == 0) {
+            queue->lines--;
+        }
+    }
+    if (!*qp) {
+        queue->tail = &queue->head;
+    }
+    if (result == -1) {
+        if (!d->booted) {
+            d->booted = 1;
+        }
+        result = 1;
+    }
+    return result;
+}
+
+void
 process_output(struct descriptor_data *d)
 {
-    struct text_block **qp, *cur;
-    int cnt;
+    int result;
 
     /* drastic, but this may give us crash test data */
     if (!d || !d->descriptor) {
 	panic("process_output(): bad descriptor or connect struct !");
     }
 
-    if (d->output.lines == 0) {
-	return 1;
-    }
 
-    if (d->block_writes) {
-	return 1;
-    }
-
-    for (qp = &d->output.head; (cur = *qp);) {
-	cnt = socket_write(d, cur->start, cur->nchars);
-
-#ifdef WIN32
-	if (cnt <= 0 || cnt == SOCKET_ERROR) {
-	    if (WSAGetLastError() == WSAEWOULDBLOCK)
-		return 1;
-	    return 0;
-	}
-#else
-	if (cnt <= 0) {
-	    if (errno == EWOULDBLOCK)
-		return 1;
-	    return 0;
-	}
+#ifdef USE_SSL
+    if (write_queue(d, &d->pending_ssl_write))
+        return;
 #endif
-	d->output_size -= cnt;
-	if (cnt == cur->nchars) {
-	    d->output.lines--;
-	    if (!cur->nxt) {
-		d->output.tail = qp;
-		d->output.lines = 0;
-	    }
-	    *qp = cur->nxt;
-	    free_text_block(cur);
-	    continue;		/* do not adv ptr */
-	}
-	cur->nchars -= cnt;
-	cur->start += cnt;
-	break;
-    }
-    return 1;
+    if (write_queue(d, &d->priority_output))
+        return;
+    if (d->block_writes)
+	return;
+    if (write_queue(d, &d->output))
+        return;
 }
 
 int
@@ -3166,6 +3192,10 @@ close_sockets(const char *msg)
 	if (d->connected) {
 	    forget_player_descr(d->player, d->descriptor);
 	}
+#ifdef USE_SSL
+        if (d->pending_ssl_write.head)
+            socket_write(d, d->pending_ssl_write.head->start, d->pending_ssl_write.head->nchars);
+#endif
 	socket_write(d, msg, strlen(msg));
 	socket_write(d, shutdown_message, strlen(shutdown_message));
 	if (shutdown(d->descriptor, 2) < 0)
@@ -3687,16 +3717,12 @@ pdescrflush(int c)
     if (c != -1) {
 	d = descrdata_by_descr(c);
 	if (d) {
-	    if (!process_output(d)) {
-		d->booted = 1;
-	    }
+	    process_output(d);
 	    i++;
 	}
     } else {
 	for (d = descriptor_list; d; d = d->next) {
-	    if (!process_output(d)) {
-		d->booted = 1;
-	    }
+	    process_output(d);
 	    i++;
 	}
     }

--- a/src/mcp.c
+++ b/src/mcp.c
@@ -356,9 +356,8 @@ static void
 FlushText(McpFrame * mfr)
 {
     struct descriptor_data *d = (struct descriptor_data *) mfr->descriptor;
-    if (d && !process_output(d)) {
-	d->booted = 1;
-    }
+    if (d)
+        process_output(d);
 }
 
 int

--- a/src/sanity.c
+++ b/src/sanity.c
@@ -32,8 +32,8 @@ flush_user_output(dbref player)
     darr = get_player_descrs(OWNER(player), &dcount);
     for (int di = 0; di < dcount; di++) {
         d = descrdata_by_descr(darr[di]);
-        if (d && !process_output(d)) {
-            d->booted = 1;
+        if (d) {
+            process_output(d);
         }
     }
 }


### PR DESCRIPTION
Refactor output handling to use multiple queues.

This adds two things to the descriptor struct:
- A queue representing a pending ssl write, which is populated
  by process_output when SSL_write returns want_read/want_write.
- A queue for priority output, which includes telnet messages
  and boot messages.
- A queue for normal output.

To enable STARTTLS negotiation, block_writes is modified to block
writing from the normal output queue but not the priority output queue.

This also modifies process_output to return void, moving the handling of setting d->booted into it (and making it occur regardless of where process_output is used).