### PR TITLE
Fix several memory leaks

### DIFF
--- a/include/db.h
+++ b/include/db.h
@@ -479,7 +479,7 @@ dbref reverse(dbref);
 void set_source(dbref player, dbref action, dbref source);
 long size_object(dbref i, int load);
 const char *unparse_flags(dbref thing);
-const char *unparse_object(dbref player, dbref object);
+void unparse_object(dbref player, dbref object, char *buffer, size_t size);
 int unset_source(dbref player, dbref action);
 
 #endif				/* _DB_H */

--- a/src/boolexp.c
+++ b/src/boolexp.c
@@ -456,8 +456,10 @@ unparse_boolexp1(dbref player, struct boolexp *b, short outer_type, int fullname
 	    break;
 	case BOOLEXP_CONST:
 	    if (fullname) {
+                char unparse_buf[BUFFER_LEN];
+                unparse_object(player, b->thing, unparse_buf, sizeof(unparse_buf));
 		strcpyn(buftop, sizeof(boolexp_buf) - (buftop - boolexp_buf),
-			unparse_object(player, b->thing));
+                        unparse_buf);
 	    } else {
 		snprintf(buftop, sizeof(boolexp_buf) - (buftop - boolexp_buf), "#%d",
 			 b->thing);

--- a/src/compile.c
+++ b/src/compile.c
@@ -3802,20 +3802,22 @@ free_prog_real(dbref prog, const char *file, const int line)
     int siz = PROGRAM_SIZ(prog);
 
     if (c) {
+        char unparse_buf[BUFFER_LEN];
+        unparse_object(GOD, prog, unparse_buf, sizeof(unparse_buf));
 	if (PROGRAM_INSTANCES(prog)) {
 	    log_status("WARNING: freeing program %s with %d instances reported from %s:%d",
-		       unparse_object(GOD, prog), PROGRAM_INSTANCES(prog), file, line);
+		       unparse_buf, PROGRAM_INSTANCES(prog), file, line);
 	}
 	i = scan_instances(prog);
 	if (i) {
 	    log_status("WARNING: freeing program %s with %d instances found from %s:%d",
-		       unparse_object(GOD, prog), i, file, line);
+		       unparse_buf, i, file, line);
 	}
 	for (i = 0; i < siz; i++) {
 	    if (c[i].type == PROG_ADD) {
 		if (c[i].data.addr->links != 1) {
 		    log_status("WARNING: Freeing address in %s with link count %d from %s:%d",
-			       unparse_object(GOD, prog), c[i].data.addr->links, file, line);
+			      unparse_buf, c[i].data.addr->links, file, line);
 		}
 		free(c[i].data.addr);
 	    } else {

--- a/src/create.c
+++ b/src/create.c
@@ -342,8 +342,10 @@ do_dig(int descr, dbref player, const char *name, const char *pname)
 	    if (!can_link_to(player, Typeof(room), parent) || room == parent) {
 		notify(player, "Permission denied.  Parent set to default.");
 	    } else {
+                char unparse_buf[BUFFER_LEN];
 		moveto(room, parent);
-		notifyf(player, "Parent set to %s.", unparse_object(player, parent));
+                unparse_object(player, parent, unparse_buf, sizeof(unparse_buf));
+		notifyf(player, "Parent set to %s.", unparse_buf);
 	    }
 	}
     }
@@ -365,6 +367,7 @@ do_prog(int descr, dbref player, const char *name)
 {
     dbref i;
     dbref newprog;
+    char unparse_buf[BUFFER_LEN];
     struct match_data md;
 
     if (!*name) {
@@ -388,8 +391,9 @@ do_prog(int descr, dbref player, const char *name)
 	    return;
 	}
 	newprog = create_program(player, name);
+        unparse_object(player, newprog, unparse_buf, sizeof(unparse_buf));
 	notifyf(player, "Entering editor for new program %s.",
-		unparse_object(player, newprog));
+                unparse_buf);
     } else if (i == AMBIGUOUS) {
 	notify(player, "I don't know which one you mean!");
 	return;
@@ -406,7 +410,8 @@ do_prog(int descr, dbref player, const char *name)
 	PROGRAM_SET_FIRST(i, read_program(i));
 	FLAGS(i) |= INTERNAL;
 	PLAYER_SET_CURR_PROG(player, i);
-	notifyf(player, "Entering editor for %s.", unparse_object(player, i));
+        unparse_object(player, i, unparse_buf, sizeof(unparse_buf));
+	notifyf(player, "Entering editor for %s.", unparse_buf);
 	/* list current line */
 	list_program(player, i, NULL, 0);
 	DBDIRTY(i);
@@ -419,6 +424,7 @@ void
 do_edit(int descr, dbref player, const char *name)
 {
     dbref i;
+    char unparse_buf[BUFFER_LEN];
     struct match_data md;
 
     if (!*name) {
@@ -447,7 +453,8 @@ do_edit(int descr, dbref player, const char *name)
     FLAGS(i) |= INTERNAL;
     PROGRAM_SET_FIRST(i, read_program(i));
     PLAYER_SET_CURR_PROG(player, i);
-    notifyf(player, "Entering editor for %s.", unparse_object(player, i));
+    unparse_object(player, i, unparse_buf, sizeof(unparse_buf));
+    notifyf(player, "Entering editor for %s.", unparse_buf);
     /* list current line */
     list_program(player, i, NULL, 0);
     FLAGS(player) |= INTERACTIVE;
@@ -609,7 +616,9 @@ do_clone(int descr, dbref player, char *name)
 	return;
     } else {
 	if (tp_verbose_clone) {
-	    notifyf(player, "Now cloning %s...", unparse_object(player, thing));
+            char unparse_buf[BUFFER_LEN];
+            unparse_object(player, thing, unparse_buf, sizeof(unparse_buf));
+	    notifyf(player, "Now cloning %s...", unparse_buf);
 	}
 
 	/* create the object */

--- a/src/edit.c
+++ b/src/edit.c
@@ -441,7 +441,9 @@ do_delete(dbref player, dbref program, int arg[], int argc)
 static void
 do_quit(dbref player, dbref program)
 {
-    log_status("PROGRAM SAVED: %s by %s(%d)", unparse_object(player, program),
+    char unparse_buf[BUFFER_LEN];
+    unparse_object(player, program, unparse_buf, sizeof(unparse_buf));
+    log_status("PROGRAM SAVED: %s by %s(%d)", unparse_buf,
 	       NAME(player), player);
     write_program(PROGRAM_FIRST(program), program);
 

--- a/src/fbsignal.c
+++ b/src/fbsignal.c
@@ -171,7 +171,9 @@ set_sigs_intern(int bail)
     our_signal(SIGSYS, SET_BAIL);
 #endif
     our_signal(SIGFPE, SET_BAIL);
+#if 0
     our_signal(SIGSEGV, SET_BAIL);
+#endif
     our_signal(SIGTERM, bail ? SET_BAIL : sig_shutdown);
 #ifdef SIGXCPU
     our_signal(SIGXCPU, SET_BAIL);
@@ -234,6 +236,10 @@ bailout(int sig)
     snprintf(message, sizeof(message), "BAILOUT: caught signal %d", sig);
 
     panic(message);
+
+    /* keep failing */
+    volatile char *x = 0;
+    *x = 1;
     exit(7);
 
 #if !defined(SYSV) && !defined(_POSIX_VERSION) && !defined(ULTRIX)

--- a/src/game.c
+++ b/src/game.c
@@ -435,6 +435,7 @@ process_command(int descr, dbref player, char *command)
     if ((tp_log_commands || Wizard(OWNER(player)))) {
 	if (!(FLAGS(player) & (INTERACTIVE | READMODE))) {
 	    if (!*command) {
+                free(log_name);
 		return;
 	    }
 	    log_command("%s: %s", whowhere(player), command);

--- a/src/interface.c
+++ b/src/interface.c
@@ -1428,6 +1428,10 @@ shutdownsock(struct descriptor_data *d)
 #ifdef MCP_SUPPORT
     mcp_frame_clear(&d->mcpframe);
 #endif
+#ifdef USE_SSL
+    if (d->ssl_session)
+        SSL_free(d->ssl_session);
+#endif
     FREE(d);
     ndescriptors--;
     log_status("CONCOUNT: There are now %d open connections.", ndescriptors);

--- a/src/interface.c
+++ b/src/interface.c
@@ -3245,8 +3245,10 @@ do_armageddon(dbref player, const char *msg)
     char buf[BUFFER_LEN];
 
     if (!Wizard(player) || Typeof(player) != TYPE_PLAYER) {
+        char unparse_buf[BUFFER_LEN];
+        unparse_object(player, player, unparse_buf, sizeof(unparse_buf));
 	notify(player, "Sorry, but you don't look like the god of War to me.");
-	log_status("ILLEGAL ARMAGEDDON: tried by %s", unparse_object(player, player));
+	log_status("ILLEGAL ARMAGEDDON: tried by %s", unparse_buf);
 	return;
     }
     snprintf(buf, sizeof(buf), "\r\nImmediate shutdown initiated by %s.\r\n", NAME(player));

--- a/src/interface.c
+++ b/src/interface.c
@@ -1324,30 +1324,30 @@ idleboot_user(struct descriptor_data *d)
 }
 
 static void
-freeqs(struct descriptor_data *d)
+free_queue(struct text_queue *q)
 {
     struct text_block *cur, *next;
 
-    cur = d->output.head;
+    cur = q->head;
     while (cur) {
 	next = cur->nxt;
 	free_text_block(cur);
 	cur = next;
     }
-    d->output.lines = 0;
-    d->output.head = 0;
-    d->output.tail = &d->output.head;
+    q->lines = 0;
+    q->head = NULL;
+    q->tail = &q->head;
+}
 
-    cur = d->input.head;
-    while (cur) {
-	next = cur->nxt;
-	free_text_block(cur);
-	cur = next;
-    }
-    d->input.lines = 0;
-    d->input.head = 0;
-    d->input.tail = &d->input.head;
-
+static void
+freeqs(struct descriptor_data *d)
+{
+#ifdef USE_SSL
+    free_queue(&d->pending_ssl_write);
+#endif
+    free_queue(&d->priority_output);
+    free_queue(&d->output);
+    free_queue(&d->input);
     if (d->raw_input)
 	FREE(d->raw_input);
     d->raw_input = 0;

--- a/src/interface.c
+++ b/src/interface.c
@@ -369,9 +369,12 @@ dump_users(struct descriptor_data *e, char *user)
 	user++;
     }
 
-    if (wizard)
+    if (wizard) {
+        char *log_name = whowhere(e->player);
 	/* S/he is connected and not quelled. Okay; log it. */
-	log_command("%s: %s", whowhere(e->player), "WHO");
+	log_command("%s: %s", log_name, "WHO");
+        free(log_name);
+    }
 
     if (!*user)
 	user = NULL;

--- a/src/log.c
+++ b/src/log.c
@@ -124,6 +124,7 @@ log_program_text(struct line *first, dbref player, dbref i)
 {
     FILE *f;
     char fname[BUFFER_LEN];
+    char unparse_buf[BUFFER_LEN];
     char tbuf[24];
     time_t lt = time(NULL);
 
@@ -137,8 +138,9 @@ log_program_text(struct line *first, dbref player, dbref i)
     format_time(tbuf, sizeof(tbuf), "%Y-%m-%dT%H:%M:%S", MUCK_LOCALTIME(lt));
     fputs("#######################################", f);
     fputs("#######################################\n", f);
+    unparse_object(player, i, unparse_buf, sizeof(unparse_buf));
     fprintf(f, "%s: %s SAVED BY %s(#%d)\n",
-            tbuf, unparse_object(player, i), NAME(player), player);
+            tbuf, unparse_buf, NAME(player), player);
     fputs("#######################################", f);
     fputs("#######################################\n\n", f);
 

--- a/src/mcppkgs.c
+++ b/src/mcppkgs.c
@@ -200,6 +200,7 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
 	    struct line *tmpline;
 	    struct line *curr = NULL;
 	    struct line *new_line;
+            char unparse_buf[BUFFER_LEN];
 
 	    if (!OkObj(obj)) {
 		show_mcp_error(mfr, "simpleedit-set", "Bad reference object.");
@@ -238,8 +239,9 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
 		curr = new_line;
 	    }
 
+            unparse_object(player, obj, unparse_buf, sizeof(unparse_buf));
 	    log_status("PROGRAM SAVED: %s by %s(%d)",
-		       unparse_object(player, obj), NAME(player), player);
+		       unparse_buf, NAME(player), player);
 
 	    write_program(PROGRAM_FIRST(obj), obj);
 

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -2420,6 +2420,7 @@ prim_program_getlines(PRIM_PROTOTYPE)
 void
 prim_program_setlines(PRIM_PROTOTYPE)
 {
+    char unparse_buf[BUFFER_LEN];
     struct line *lines = 0;
     struct line *prev = 0;
     array_iter idx;
@@ -2472,7 +2473,8 @@ prim_program_setlines(PRIM_PROTOTYPE)
 
     write_program(lines, oper1->data.objref);
 
-    log_status("PROGRAM SAVED: %s by %s(%d)", unparse_object(player, oper1->data.objref),
+    unparse_object(player, oper1->data.objref, unparse_buf, sizeof(unparse_buf));
+    log_status("PROGRAM SAVED: %s by %s(%d)", unparse_buf,
 	       NAME(player), player);
 
     if (tp_log_programs)

--- a/src/property.c
+++ b/src/property.c
@@ -732,6 +732,7 @@ char *
 displayprop(dbref player, dbref obj, const char *name, char *buf, size_t bufsiz)
 {
     char mybuf[BUFFER_LEN];
+    char unparse_buf[BUFFER_LEN];
     int pdflag;
     char blesschar = '-';
     PropPtr p = get_property(obj, name);
@@ -754,8 +755,8 @@ displayprop(dbref player, dbref obj, const char *name, char *buf, size_t bufsiz)
 		 PropDataStr(p));
 	break;
     case PROP_REFTYP:
-	snprintf(buf, bufsiz, "%c ref %s:%s", blesschar, mybuf,
-		 unparse_object(player, PropDataRef(p)));
+        unparse_object(player, PropDataRef(p), unparse_buf, sizeof(unparse_buf));
+	snprintf(buf, bufsiz, "%c ref %s:%s", blesschar, mybuf, unparse_buf);
 	break;
     case PROP_INTTYP:
 	snprintf(buf, bufsiz, "%c int %s:%d", blesschar, mybuf, PropDataVal(p));

--- a/src/sanity.c
+++ b/src/sanity.c
@@ -15,7 +15,6 @@
 
 #include <stdarg.h>
 
-#define unparse(x) ((char*)unparse_object(GOD, (x)))
 #define SanFixed(ref, fixed) san_fixed_log((fixed), 1, (ref), -1)
 #define SanFixed2(ref, ref2, fixed) san_fixed_log((fixed), 1, (ref), (ref2))
 #define SanFixedRef(ref, fixed) san_fixed_log((fixed), 0, (ref), -1)
@@ -64,6 +63,15 @@ SanPrint(dbref player, const char *format, ...)
     va_end(args);
 }
 
+static void
+SanPrintObject(dbref player, const char *prefix, dbref ref)
+{
+    char unparse_buf[16384];
+    unparse_object(NOTHING, ref, unparse_buf, sizeof(unparse_buf));
+    SanPrint(player, "%s%s\n", prefix, unparse_buf);
+}
+
+
 void
 do_examine_sanity(dbref player, const char *arg)
 {
@@ -84,27 +92,27 @@ do_examine_sanity(dbref player, const char *arg)
     if (Typeof(d) == TYPE_GARBAGE) {
 	SanPrint(player, "Object:         *GARBAGE* #%d", d);
     } else {
-	SanPrint(player, "Object:         %s", unparse(d));
+        SanPrintObject(player, "Object:         ", d);
     }
 
-    SanPrint(player, "  Owner:          %s", unparse(OWNER(d)));
-    SanPrint(player, "  Location:       %s", unparse(LOCATION(d)));
-    SanPrint(player, "  Contents Start: %s", unparse(CONTENTS(d)));
-    SanPrint(player, "  Exits Start:    %s", unparse(EXITS(d)));
-    SanPrint(player, "  Next:           %s", unparse(NEXTOBJ(d)));
+    SanPrintObject(player, "  Owner:          ", OWNER(d));
+    SanPrintObject(player, "  Location:       ", LOCATION(d));
+    SanPrintObject(player, "  Contents Start: ", CONTENTS(d));
+    SanPrintObject(player, "  Exits Start:    ", EXITS(d));
+    SanPrintObject(player, "  Next:           ", NEXTOBJ(d));
 
     switch (Typeof(d)) {
     case TYPE_THING:
-	SanPrint(player, "  Home:           %s", unparse(THING_HOME(d)));
+	SanPrintObject(player, "  Home:           ", THING_HOME(d));
 	SanPrint(player, "  Value:          %d", GETVALUE(d));
 	break;
 
     case TYPE_ROOM:
-	SanPrint(player, "  Drop-to:        %s", unparse(DBFETCH(d)->sp.room.dropto));
+	SanPrintObject(player, "  Drop-to:        ", DBFETCH(d)->sp.room.dropto);
 	break;
 
     case TYPE_PLAYER:
-	SanPrint(player, "  Home:           %s", unparse(PLAYER_HOME(d)));
+	SanPrintObject(player, "  Home:           ", PLAYER_HOME(d));
 	SanPrint(player, "  Pennies:        %d", GETVALUE(d));
 	if (player < 0) {
 	    SanPrint(player, "  Password MD5:   %s", PLAYER_PASSWORD(d));
@@ -114,7 +122,7 @@ do_examine_sanity(dbref player, const char *arg)
     case TYPE_EXIT:
 	SanPrint(player, "  Links:");
 	for (int i = 0; i < DBFETCH(d)->sp.exit.ndest; i++)
-	    SanPrint(player, "    %s", unparse(DBFETCH(d)->sp.exit.dest[i]));
+	    SanPrintObject(player, "    ", DBFETCH(d)->sp.exit.dest[i]);
 	break;
 
     case TYPE_PROGRAM:
@@ -125,13 +133,13 @@ do_examine_sanity(dbref player, const char *arg)
     SanPrint(player, "Referring Objects:");
     for (dbref i = 0; i < db_top; i++) {
 	if (CONTENTS(i) == d) {
-	    SanPrint(player, "  By contents field: %s", unparse(i));
+	    SanPrintObject(player, "  By contents field: ", i);
 	}
 	if (EXITS(i) == d) {
-	    SanPrint(player, "  By exits field:    %s", unparse(i));
+	    SanPrintObject(player, "  By exits field:    ", i);
 	}
 	if (NEXTOBJ(i) == d) {
-	    SanPrint(player, "  By next field:     %s", unparse(i));
+	    SanPrintObject(player, "  By next field:     ", i);
 	}
     }
 
@@ -141,7 +149,9 @@ do_examine_sanity(dbref player, const char *arg)
 static void
 violate(dbref player, dbref i, const char *s)
 {
-    SanPrint(player, "Object \"%s\" %s!", unparse(i), s);
+    char unparse_buf[16384];
+    unparse_object(NOTHING, i, unparse_buf, sizeof(unparse_buf));
+    SanPrint(player, "Object \"%s\" %s!", unparse_buf, s);
     sanity_violated = 1;
 }
 
@@ -466,10 +476,10 @@ san_fixed_log(char *format, int unparse, dbref ref1, dbref ref2)
 
     if (unparse) {
 	if (ref1 >= 0) {
-	    strcpyn(buf1, sizeof(buf1), unparse(ref1));
+            unparse_object(NOTHING, ref1, buf1, sizeof(buf1));
 	}
 	if (ref2 >= 0) {
-	    strcpyn(buf2, sizeof(buf2), unparse(ref2));
+            unparse_object(NOTHING, ref2, buf2, sizeof(buf2));
 	}
 	log2file("logs/sanfixed", format, buf1, buf2);
     } else {
@@ -623,6 +633,7 @@ static void
 create_lostandfound(dbref * player, dbref * room)
 {
     char player_name[PLAYER_NAME_LIMIT + 2] = "lost+found";
+    char unparse_buf[16384];
     int temp = 0;
 
     *room = new_object();
@@ -638,8 +649,9 @@ create_lostandfound(dbref * player, dbref * room)
 	snprintf(player_name, sizeof(player_name), "lost+found%d", ++temp);
     }
     if (strlen(player_name) >= PLAYER_NAME_LIMIT) {
+        unparse_object(NOTHING, GOD, unparse_buf, sizeof(unparse_buf));
 	log2file("logs/sanfixed", "WARNING: Unable to get lost+found player, "
-		 "using %s", unparse(GOD));
+		 "using %s", unparse_buf);
 	*player = GOD;
     } else {
 	const char *rpass;
@@ -660,8 +672,9 @@ create_lostandfound(dbref * player, dbref * room)
 	PUSH(*player, CONTENTS(*room));
 	DBDIRTY(*player);
 	add_player(*player);
+        unparse_object(NOTHING, *player, unparse_buf, sizeof(unparse_buf));
 	log2file("logs/sanfixed", "Using %s (with password %s) to resolve "
-		 "unknown owner", unparse(*player), rpass);
+		 "unknown owner", unparse_buf, rpass);
     }
     OWNER(*room) = *player;
     DBDIRTY(*room);
@@ -960,6 +973,7 @@ do_sanchange(dbref player, const char *command)
     char field[50];
     char which[1000];
     char value[1000];
+    char unparse_buf[1000];
     int *ip;
     int results;
 
@@ -985,35 +999,37 @@ do_sanchange(dbref player, const char *command)
 	return;
     }
 
+    unparse_object(NOTHING, v, unparse_buf, sizeof(unparse_buf));
+
     if (!strcasecmp(field, "next")) {
-	strcpyn(buf2, sizeof(buf2), unparse(NEXTOBJ(d)));
+        unparse_object(NOTHING, NEXTOBJ(d), buf2, sizeof(buf2));
 	NEXTOBJ(d) = v;
 	DBDIRTY(d);
-	SanPrint(player, "## Setting #%d's next field to %s", d, unparse(v));
+	SanPrint(player, "## Setting #%d's next field to %s", d, unparse_buf);
 
     } else if (!strcasecmp(field, "exits")) {
-	strcpyn(buf2, sizeof(buf2), unparse(EXITS(d)));
+        unparse_object(NOTHING, EXITS(d), buf2, sizeof(buf2));
 	EXITS(d) = v;
 	DBDIRTY(d);
-	SanPrint(player, "## Setting #%d's Exits list start to %s", d, unparse(v));
+	SanPrint(player, "## Setting #%d's next field to %s", d, unparse_buf);
 
     } else if (!strcasecmp(field, "contents")) {
-	strcpyn(buf2, sizeof(buf2), unparse(CONTENTS(d)));
+        unparse_object(NOTHING, CONTENTS(d), buf2, sizeof(buf2));
 	CONTENTS(d) = v;
 	DBDIRTY(d);
-	SanPrint(player, "## Setting #%d's Contents list start to %s", d, unparse(v));
+	SanPrint(player, "## Setting #%d's Contents list start to %s", d, unparse_buf);
 
     } else if (!strcasecmp(field, "location")) {
-	strcpyn(buf2, sizeof(buf2), unparse(LOCATION(d)));
+        unparse_object(NOTHING, LOCATION(d), buf2, sizeof(buf2));
 	LOCATION(d) = v;
 	DBDIRTY(d);
-	SanPrint(player, "## Setting #%d's location to %s", d, unparse(v));
+	SanPrint(player, "## Setting #%d's location to %s", d, unparse_buf);
 
     } else if (!strcasecmp(field, "owner")) {
-	strcpyn(buf2, sizeof(buf2), unparse(OWNER(d)));
+        unparse_object(NOTHING, OWNER(d), buf2, sizeof(buf2));
 	OWNER(d) = v;
 	DBDIRTY(d);
-	SanPrint(player, "## Setting #%d's owner to %s", d, unparse(v));
+	SanPrint(player, "## Setting #%d's owner to %s", d, unparse_buf);
 
     } else if (!strcasecmp(field, "home")) {
 	switch (Typeof(d)) {
@@ -1026,14 +1042,14 @@ do_sanchange(dbref player, const char *command)
 	    break;
 
 	default:
-	    printf("%s has no home to set.\n", unparse(d));
+	    printf("%s has no home to set.\n", unparse_buf);
 	    return;
 	}
 
-	strcpyn(buf2, sizeof(buf2), unparse(*ip));
+        unparse_object(NOTHING, *ip, buf2, sizeof(buf2));
 	*ip = v;
 	DBDIRTY(d);
-	printf("Setting home to: %s\n", unparse(v));
+	SanPrint(player, "## Setting #%d's home to: %s\n", d, unparse_buf);
 
     } else {
 	if (player > NOTHING) {
@@ -1166,6 +1182,8 @@ extract_program(FILE * f, dbref obj)
 static void
 extract_object(FILE * f, dbref d)
 {
+    char unparse_buf[1024];
+#define unparse(x) (unparse_object(NOTHING, (x), unparse_buf, sizeof(unparse_buf)), unparse_buf)
     fprintf(f, "  #%d\n", d);
     fprintf(f, "  Object:         %s\n", unparse(d));
     fprintf(f, "  Owner:          %s\n", unparse(OWNER(d)));
@@ -1205,6 +1223,7 @@ extract_object(FILE * f, dbref d)
     default:
 	break;
     }
+#undef unparse
 
 #ifdef DISKBASE
     fetchprops(d, NULL);
@@ -1372,14 +1391,17 @@ hack_it_up(void)
 void
 san_main(void)
 {
+    char unparse_buf[1024];
     printf("\nEntering the Interactive Sanity DB editor.\n");
     printf("Good luck!\n\n");
 
     printf("Number of objects in DB is: %d\n", db_top - 1);
-    printf("Global Environment is: %s\n", unparse(GLOBAL_ENVIRONMENT));
+    unparse_object(NOTHING, GLOBAL_ENVIRONMENT, unparse_buf, sizeof(unparse_buf));
+    printf("Global Environment is: %s\n", unparse_buf);
 
 #ifdef GOD_PRIV
-    printf("God is: %s\n", unparse(GOD));
+    unparse_object(NOTHING, GOD, unparse_buf, sizeof(unparse_buf));
+    printf("God is: %s\n", unparse_buf);
     printf("\n");
 #endif
 

--- a/src/set.c
+++ b/src/set.c
@@ -375,7 +375,9 @@ do_chown(int descr, dbref player, const char *name, const char *newowner)
     if (owner == player)
 	notify(player, "Owner changed to you.");
     else {
-	notifyf(player, "Owner changed to %s.", unparse_object(player, owner));
+        char unparse_buf[BUFFER_LEN];
+        unparse_object(player, owner, unparse_buf, sizeof(unparse_buf));
+	notifyf(player, "Owner changed to %s.", unparse_buf);
     }
     DBDIRTY(thing);
 }

--- a/src/tune.c
+++ b/src/tune.c
@@ -591,8 +591,10 @@ tune_display_parms(dbref player, char *name, int mlev, int show_extended)
 	}
 	strcpyn(buf, sizeof(buf), tref->name);
 	if (!*name || equalstr(name, buf)) {
+            char unparse_buf[BUFFER_LEN];
+            unparse_object(player, *tref->ref, unparse_buf, sizeof(unparse_buf));
 	    notifyf(player, "(ref)  %-20s = %s%s%s",
-		    tref->name, unparse_object(player, *tref->ref),
+		    tref->name, unparse_buf,
 		    MOD_ENABLED(tref->module) ? "" : " [inactive]",
 		    (tref->isdefault) ? " [default]" : "");
 	    if (show_extended)

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -34,6 +34,8 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
     dbref victim;
     dbref destination;
     const char *to;
+    char victim_name_buf[BUFFER_LEN];
+    char destination_name_buf[BUFFER_LEN];
     struct match_data md;
 
     /* get victim, destination */
@@ -74,7 +76,9 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
 	match_neighbor(&md);
 	match_player(&md);
     }
-    switch (destination = match_result(&md)) {
+    destination = match_result(&md);
+    unparse_object(player, victim, victim_name_buf, sizeof(victim_name_buf));
+    switch (destination) {
     case NOTHING:
 	notify(player, "Send it where?");
 	break;
@@ -134,9 +138,10 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
 		break;
 	    }
 	    notify(victim, "You feel a wrenching sensation...");
+            unparse_object(player, destination, destination_name_buf, sizeof(destination_name_buf));
 	    enter_room(descr, victim, destination, LOCATION(victim));
-	    notifyf(player, "%s teleported to %s.", unparse_object(player, victim),
-		    unparse_object(player, destination));
+	    notifyf(player, "%s teleported to %s.", victim_name_buf,
+                    destination_name_buf);
 	    break;
 	case TYPE_THING:
 	    if (parent_loop_check(victim, destination)) {
@@ -169,8 +174,9 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
 	    } else {
 		moveto(victim, destination);
 	    }
-	    notifyf(player, "%s teleported to %s.", unparse_object(player, victim),
-		    unparse_object(player, destination));
+            unparse_object(player, destination, destination_name_buf, sizeof(destination_name_buf));
+	    notifyf(player, "%s teleported to %s.", victim_name_buf,
+		    destination_name_buf);
 	    break;
 	case TYPE_ROOM:
 	    if (Typeof(destination) != TYPE_ROOM) {
@@ -189,8 +195,9 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
 		break;
 	    }
 	    moveto(victim, destination);
-	    notifyf(player, "Parent of %s set to %s.", unparse_object(player, victim),
-		    unparse_object(player, destination));
+            unparse_object(player, destination, destination_name_buf, sizeof(destination_name_buf));
+	    notifyf(player, "Parent of %s set to %s.", victim_name_buf,
+		    destination_name_buf);
 	    break;
 	case TYPE_GARBAGE:
 	    notify(player, "That object is in a place where magic cannot reach it.");
@@ -879,9 +886,11 @@ do_muf_topprofs(dbref player, char *arg1)
     }
     notify(player, "     %CPU   TotalTime  UseCount  Program");
     while (tops) {
+        char unparse_buf[BUFFER_LEN];
 	curr = tops;
+        unparse_object(player, curr->prog, unparse_buf, sizeof(unparse_buf));
 	notifyf(player, "%10.3f %10.3f %9ld %s", curr->pcnt, curr->proftime, curr->usecount,
-		unparse_object(player, curr->prog));
+                unparse_buf);
 	tops = tops->next;
 	free(curr);
     }
@@ -972,9 +981,11 @@ do_mpi_topprofs(dbref player, char *arg1)
     }
     notify(player, "     %CPU   TotalTime  UseCount  Object");
     while (tops) {
+        char unparse_buf[BUFFER_LEN];
 	curr = tops;
+        unparse_object(player, curr->prog, unparse_buf, sizeof(unparse_buf));
 	notifyf(player, "%10.3f %10.3f %9ld %s", curr->pcnt, curr->proftime, curr->usecount,
-		unparse_object(player, curr->prog));
+                unparse_buf);
 	tops = tops->next;
 	free(curr);
     }
@@ -1125,10 +1136,11 @@ do_topprofs(dbref player, char *arg1)
     }
     notify(player, "     %CPU   TotalTime  UseCount  Type  Object");
     while (tops) {
+        char unparse_buf[BUFFER_LEN];
 	curr = tops;
+        unparse_object(player, curr->prog, unparse_buf, sizeof(unparse_buf));
 	notifyf(player, "%10.3f %10.3f %9ld%5s   %s", curr->pcnt, curr->proftime,
-		curr->usecount, curr->type ? "MUF" : "MPI", unparse_object(player,
-									   curr->prog));
+		curr->usecount, curr->type ? "MUF" : "MPI", unparse_buf);
 	tops = tops->next;
 	free(curr);
     }


### PR DESCRIPTION
This patch fixes several memory leaks:
- my last patch didn't free the new priority_output or pending_ssl_write queue if a connection was dropped with pending output;
- unparse_object() calls strdup() sometimes, but none of the code using it free()'d the result (and sometimes unparse_object() returned a pointer to a constant, so they couldn't)
- whowhere() was called without free()ing the result
- SSL_free() wasn't called on closed ssl_session objects.