### PR TITLE
Clean up SSL logging, optionally log all errors

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -92,6 +92,15 @@
 #define MACRO_FILE  "muf/macros"
 #define PID_FILE    "fbmuck.pid"
 
+/*
+ * Debugging options (these may be removed or changed at any time)
+ */
+
+/* Define this to log all SSL connection messages, including those that
+   generally aren't problematic.  Undefined by default to avoid spamming
+   the status log. */
+#undef DEBUG_SSL_LOG_ALL
+
 /************************************************************************
   System Dependency Defines. 
 

--- a/include/interface_ssl.h
+++ b/include/interface_ssl.h
@@ -1,39 +1,39 @@
 #ifndef _INTERFACE_SSL_H
 #define _INTERFACE_SSL_H
 
-/* Needed for USE_SSL */
+// Needed for USE_SSL
 #include "config.h"
 
 #ifdef USE_SSL
 
 # ifdef HAVE_OPENSSL
 #  include <openssl/ssl.h>
-/* For nicer error messages */
+// For nicer error messages
 #  include <openssl/err.h>
 # else
 #  include <ssl.h>
-/* TODO: check if other SSL libraries provide this functionality */
+// TODO: check if other SSL libraries provide this functionality
 # endif
 
-/* Backwards-compatibility for valid SSL protocol versions that are not supported. */
+// Backwards-compatibility for valid SSL protocol versions that are not supported.
 # define SSL_UNSUPPORTED_PROTOCOL -2
 
-/* Build a lookup table to convert protocol version string to integer
-
-   Unfortunately OpenSSL lacks an easy way of pragmatically determining what protocols are
-   supported at runtime.  Thus, build a reference table according to compile-time constants.
-   Unavailable protocols are marked with SSL_UNSUPPORTED_PROTOCOL.
-
-   See 'set_protocol_version' in
-   https://github.com/openssl/openssl/blob/master/test/ssltest.c
-
-   To further complicate matters, OpenSSL plans to remove support for older SSL versions over time.
-   Fuzzball needs to provide a fallback to make sure existing setups specifying removed protocol
-   versions will get a useful error message pointing to the problem, instead of entirely failing to
-   compile.
-
-   FB_PROTOCOL_VERSION  Copy OpenSSL's PROTOCOL_VERSION if defined, otherwise SSL_UNSUPPORTED_PROTOCOL
-   FB_PROTOCOL_NAME     Friendly name for error messages, blank if not available */
+// Build a lookup table to convert protocol version string to integer
+//
+// Unfortunately OpenSSL lacks an easy way of pragmatically determining what protocols are
+// supported at runtime.  Thus, build a reference table according to compile-time constants.
+// Unavailable protocols are marked with SSL_UNSUPPORTED_PROTOCOL.
+//
+// See 'set_protocol_version' in
+// https://github.com/openssl/openssl/blob/master/test/ssltest.c
+//
+// To further complicate matters, OpenSSL plans to remove support for older SSL versions over time.
+// Fuzzball needs to provide a fallback to make sure existing setups specifying removed protocol
+// versions will get a useful error message pointing to the problem, instead of entirely failing to
+// compile.
+//
+// FB_PROTOCOL_VERSION  Copy OpenSSL's PROTOCOL_VERSION if defined, otherwise SSL_UNSUPPORTED_PROTOCOL
+// FB_PROTOCOL_NAME     Friendly name for error messages, blank if not available
 #ifdef SSL3_VERSION
 # define FB_SSL3_VERSION SSL3_VERSION
 # define FB_SSL3_NAME "SSLv3 "
@@ -63,32 +63,32 @@
 # define FB_TLS1_2_NAME ""
 #endif
 
-/* List of protocols supported at compile-time, used for error messages */
+// List of protocols supported at compile-time, used for error messages
 #define SSL_KNOWN_PROTOCOLS FB_SSL3_NAME FB_TLS1_NAME FB_TLS1_1_NAME FB_TLS1_2_NAME
 
-/** A single SSL protocol version */
+/// A single SSL protocol version
 struct ssl_protocol_version {
-    const char *name;
-    int version;
+	const char *name;
+	int version;
 };
 
-/** Valid SSL protocol versions */
+/// Valid SSL protocol versions
 static const struct ssl_protocol_version SSL_PROTOCOLS[] = {
-    {"None", 0},
-    {"SSLv3", FB_SSL3_VERSION},
-    {"TLSv1", FB_TLS1_VERSION},
-    {"TLSv1.1", FB_TLS1_1_VERSION},
-    {"TLSv1.2", FB_TLS1_2_VERSION}
+	{"None", 0},
+	{"SSLv3", FB_SSL3_VERSION},
+	{"TLSv1", FB_TLS1_VERSION},
+	{"TLSv1.1", FB_TLS1_1_VERSION},
+	{"TLSv1.2", FB_TLS1_2_VERSION}
 };
 
 static const size_t SSL_PROTOCOLS_SIZE = (sizeof(SSL_PROTOCOLS) / sizeof(SSL_PROTOCOLS[0]));
-/* end of lookup table */
+// End of lookup table
 
-/* SSL protocol management */
+// SSL protocol management
 int ssl_protocol_from_string(const char *);
 int set_ssl_ctx_min_version(SSL_CTX *, const char *);
 
 void ssl_log_error(SSL *, const int);
 
-#endif				/* USE_SSL */
-#endif				/* _INTERFACE_SSL_H */
+#endif                                // USE_SSL
+#endif                                // _INTERFACE_SSL_H

--- a/include/interface_ssl.h
+++ b/include/interface_ssl.h
@@ -6,6 +6,9 @@
 
 #ifdef USE_SSL
 
+// Needed for descriptor structure
+#include "interface.h"
+
 # ifdef HAVE_OPENSSL
 #  include <openssl/ssl.h>
 // For nicer error messages
@@ -24,8 +27,8 @@
 // supported at runtime.  Thus, build a reference table according to compile-time constants.
 // Unavailable protocols are marked with SSL_UNSUPPORTED_PROTOCOL.
 //
-// See 'set_protocol_version' in
-// https://github.com/openssl/openssl/blob/master/test/ssltest.c
+// See 'set_protocol_version' and 'protocol_from_string' in
+// https://github.com/openssl/openssl/blob/OpenSSL_1_1_0-stable/test/ssltest_old.c
 //
 // To further complicate matters, OpenSSL plans to remove support for older SSL versions over time.
 // Fuzzball needs to provide a fallback to make sure existing setups specifying removed protocol
@@ -84,11 +87,45 @@ static const struct ssl_protocol_version SSL_PROTOCOLS[] = {
 static const size_t SSL_PROTOCOLS_SIZE = (sizeof(SSL_PROTOCOLS) / sizeof(SSL_PROTOCOLS[0]));
 // End of lookup table
 
+/// SSL logging levels
+typedef enum {
+	SSL_LOGGING_NONE,
+	SSL_LOGGING_ERROR,
+	SSL_LOGGING_WARN,
+	SSL_LOGGING_DEBUG
+} ssl_logging_t;
+
+
+// Check if config.h specifies to log all SSL errors
+// TODO: This should be configurable at runtime, e.g. with an '@debug set ssl_logging'
+// command.
+#ifdef DEBUG_SSL_LOG_ALL
+/// SSL logging level for connection handling
+static const ssl_logging_t ssl_logging_connect = SSL_LOGGING_DEBUG;
+/// SSL logging level for socket reads/writes
+static const ssl_logging_t ssl_logging_stream = SSL_LOGGING_DEBUG;
+#else
+/// SSL logging level for connection handling
+static const ssl_logging_t ssl_logging_connect = SSL_LOGGING_WARN;
+/// SSL logging level for socket reads/writes
+static const ssl_logging_t ssl_logging_stream = SSL_LOGGING_NONE;
+#endif // DEBUG_SSL_LOG_ALL
+
 // SSL protocol management
 int ssl_protocol_from_string(const char *);
 int set_ssl_ctx_min_version(SSL_CTX *, const char *);
 
-void ssl_log_error(SSL *, const int);
+int ssl_check_error(struct descriptor_data *, const int, const ssl_logging_t);
+
+// SSL_ERROR_WANT_ACCEPT is not defined in OpenSSL v0.9.6i and before. This
+// fix allows to compile fbmuck on systems with an 'old' OpenSSL library, and
+// yet have the server recognize the WANT_ACCEPT error when ran on systems with
+// a newer OpenSSL version installed... Of course, should the value of the
+// define change in ssl.h in the future (unlikely but not impossible), the
+// define below would have to be changed too...
+#ifndef SSL_ERROR_WANT_ACCEPT
+#define SSL_ERROR_WANT_ACCEPT 8
+#endif
 
 #endif                                // USE_SSL
 #endif                                // _INTERFACE_SSL_H

--- a/src/interface.c
+++ b/src/interface.c
@@ -1150,49 +1150,6 @@ process_commands(void)
 
 #ifdef USE_SSL
 
-/* SSL_ERROR_WANT_ACCEPT is not defined in OpenSSL v0.9.6i and before. This
-   fix allows to compile fbmuck on systems with an 'old' OpenSSL library, and
-   yet have the server recognize the WANT_ACCEPT error when ran on systems with
-   a newer OpenSSL version installed... Of course, should the value of the
-   define change in ssl.h in the future (unlikely but not impossible), the
-   define below would have to be changed too...
- */
-#ifndef SSL_ERROR_WANT_ACCEPT
-#define SSL_ERROR_WANT_ACCEPT 8
-#endif
-
-static void
-log_ssl_error(const char *text, int descr, int errnum)
-{
-    switch (errnum) {
-    case SSL_ERROR_SSL:
-	log_status("SSL %s: sock %d, Error SSL_ERROR_SSL", text, descr);
-	break;
-    case SSL_ERROR_WANT_READ:
-	log_status("SSL %s: sock %d, Error SSL_ERROR_WANT_READ", text, descr);
-	break;
-    case SSL_ERROR_WANT_WRITE:
-	log_status("SSL %s: sock %d, Error SSL_ERROR_WANT_WRITE", text, descr);
-	break;
-    case SSL_ERROR_WANT_X509_LOOKUP:
-	log_status("SSL %s: sock %d, Error SSL_ERROR_WANT_X509_LOOKUP", text, descr);
-	break;
-    case SSL_ERROR_SYSCALL:
-	log_status("SSL %s: sock %d, Error SSL_ERROR_SYSCALL: %s", text, descr,
-		   strerror(errno));
-	break;
-    case SSL_ERROR_ZERO_RETURN:
-	log_status("SSL %s: sock %d, Error SSL_ERROR_ZERO_RETURN", text, descr);
-	break;
-    case SSL_ERROR_WANT_CONNECT:
-	log_status("SSL %s: sock %d, Error SSL_ERROR_WANT_CONNECT", text, descr);
-	break;
-    case SSL_ERROR_WANT_ACCEPT:
-	log_status("SSL %s: sock %d, Error SSL_ERROR_WANT_ACCEPT", text, descr);
-	break;
-    }
-}
-
 static ssize_t
 socket_read(struct descriptor_data *d, void *buf, size_t count)
 {
@@ -1207,9 +1164,9 @@ socket_read(struct descriptor_data *d, void *buf, size_t count)
     } else {
 	i = SSL_read(d->ssl_session, buf, count);
 	if (i < 0) {
-	    i = SSL_get_error(d->ssl_session, i);
+	    i = ssl_check_error(d, i, ssl_logging_stream);
 	    if (i == SSL_ERROR_WANT_READ || i == SSL_ERROR_WANT_WRITE) {
-		/* log_ssl_error("read 0", d->descriptor, i); */
+		// "read 0" error situation
 #ifdef WIN32
 		WSASetLastError(WSAEWOULDBLOCK);
 #else
@@ -1217,7 +1174,7 @@ socket_read(struct descriptor_data *d, void *buf, size_t count)
 #endif
 		return -1;
 	    } else if (d->is_starttls && (i == SSL_ERROR_ZERO_RETURN || i == SSL_ERROR_SSL)) {
-		/* log_ssl_error("read 1", d->descriptor, i); */
+		// "read 1" error situation
 		d->is_starttls = 0;
 		SSL_free(d->ssl_session);
 		d->ssl_session = NULL;
@@ -1228,7 +1185,7 @@ socket_read(struct descriptor_data *d, void *buf, size_t count)
 #endif
 		return -1;
 	    } else {
-		/* log_ssl_error("read 1", d->descriptor, i); */
+		// "read 1" error situation
 #ifndef WIN32
 		errno = EBADF;
 #endif
@@ -1254,7 +1211,7 @@ socket_write(struct descriptor_data * d, const void *buf, size_t count)
     } else {
 	i = SSL_write(d->ssl_session, buf, count);
 	if (i < 0) {
-	    i = SSL_get_error(d->ssl_session, i);
+	    i = ssl_check_error(d, i, ssl_logging_stream);
             if (i == SSL_ERROR_WANT_WRITE || i == SSL_ERROR_WANT_READ) {
 #ifdef WIN32
 		WSASetLastError(WSAEWOULDBLOCK);
@@ -1263,7 +1220,7 @@ socket_write(struct descriptor_data * d, const void *buf, size_t count)
 #endif
 		return -1;
 	    } else if (d->is_starttls && (i == SSL_ERROR_ZERO_RETURN || i == SSL_ERROR_SSL)) {
-		/* log_ssl_error("write 1", d->descriptor, i); */
+		// "write 1" error situation
 		d->is_starttls = 0;
 		SSL_free(d->ssl_session);
 		d->ssl_session = NULL;
@@ -1274,7 +1231,7 @@ socket_write(struct descriptor_data * d, const void *buf, size_t count)
 #endif
 		return -1;
 	    } else {
-		/* log_ssl_error("write 2", d->descriptor, i); */
+		// "write 2" error situation
 #ifndef WIN32
 		errno = EBADF;
 #endif
@@ -1957,8 +1914,12 @@ process_input(struct descriptor_data *d)
                         d->ssl_session = SSL_new(ssl_ctx);
                         SSL_set_fd(d->ssl_session, d->descriptor);
                         int ssl_ret_value = SSL_accept(d->ssl_session);
-                        if (ssl_ret_value != 0)
-                            ssl_log_error(d->ssl_session, ssl_ret_value);
+                        ssl_check_error(d, ssl_ret_value, ssl_logging_connect);
+                        // Eventually it might be nice to use the return value to close the
+                        // connection if SSL fails.  Unfortunately, OpenSSL makes this a proper
+                        // hassle, requiring inspecting a changing list of possible SSL_ERROR
+                        // defines.
+                        // See: https://www.openssl.org/docs/man1.1.0/ssl/SSL_accept.html#RETURN-VALUES
                         log_status("STARTTLS: %i", d->descriptor);
                     }
 		}
@@ -2601,8 +2562,12 @@ shovechars()
 			newd->ssl_session = SSL_new(ssl_ctx);
 			SSL_set_fd(newd->ssl_session, newd->descriptor);
 			cnt = SSL_accept(newd->ssl_session);
-			if (cnt != 0)
-			    ssl_log_error(newd->ssl_session, cnt);
+			ssl_check_error(newd, cnt, ssl_logging_connect);
+			// Eventually it might be nice to use the return value to close the
+			// connection if SSL fails.  Unfortunately, OpenSSL makes this a proper
+			// hassle, requiring inspecting a changing list of possible SSL_ERROR
+			// defines.
+			// See: https://www.openssl.org/docs/man1.1.0/ssl/SSL_accept.html#RETURN-VALUES
 			/* log_status("SSL accept1: %i\n", cnt ); */
 		    }
 		}
@@ -2627,8 +2592,12 @@ shovechars()
 			newd->ssl_session = SSL_new(ssl_ctx);
 			SSL_set_fd(newd->ssl_session, newd->descriptor);
 			cnt = SSL_accept(newd->ssl_session);
-			if (cnt != 0)
-			    ssl_log_error(newd->ssl_session, cnt);
+			ssl_check_error(newd, cnt, ssl_logging_connect);
+			// Eventually it might be nice to use the return value to close the
+			// connection if SSL fails.  Unfortunately, OpenSSL makes this a proper
+			// hassle, requiring inspecting a changing list of possible SSL_ERROR
+			// defines.
+			// See: https://www.openssl.org/docs/man1.1.0/ssl/SSL_accept.html#RETURN-VALUES
 			/* log_status("SSL accept1: %i\n", cnt ); */
 		    }
 		}

--- a/src/interface_ssl.c
+++ b/src/interface_ssl.c
@@ -8,8 +8,8 @@
 ///
 /// Converts an SSL protocol version string to a version number
 ///
-/// Inspired by 'set_protocol_version' in
-/// https://github.com/openssl/openssl/blob/master/test/ssltest.c
+/// Inspired by 'set_protocol_version' and 'protocol_from_string' in
+/// https://github.com/openssl/openssl/blob/OpenSSL_1_1_0-stable/test/ssltest_old.c
 ///
 /// @param[in] value Name of SSL protocol version
 /// @returns   Version number if found, SSL_UNSUPPORTED_PROTOCOL if unsupported, or -1 if not found
@@ -65,7 +65,7 @@ set_ssl_ctx_min_version(SSL_CTX * ssl_ctx, const char *min_version)
 		           min_version);
 #if defined(SSL_CTX_set_min_proto_version)
 		// Added in OpenSSL >= 1.1.0
-		// See: https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_set_min_proto_version.html
+		// See: https://www.openssl.org/docs/man1.1.0/ssl/SSL_CTX_set_min_proto_version.html
 		return SSL_CTX_set_min_proto_version(ssl_ctx, min_version_num);
 #elif defined(SSL_CTX_set_options)
 		// Easy way not implemented, manually turn off protocols to match the minimum version.
@@ -96,53 +96,132 @@ set_ssl_ctx_min_version(SSL_CTX * ssl_ctx, const char *min_version)
 	}
 }
 
-/** Records the last SSL error to the log
- *
- *  Ignores irrelevant error conditions to avoid spamming the log, only handling a small subset.
- *
- *  @param[in,out] ssl       SSL structure
- *  @param[in]     ret_value Return value from SSL function call
- */
-void
-ssl_log_error(SSL * ssl, const int ret_value)
+///
+/// Checks for the last SSL error, if any, recording it to the log
+///
+/// If log_all is set to 0, this ignores any usually irrelevant error conditions to avoid spamming
+/// the log, only handling a small subset.
+///
+/// @param[in,out] d          Connection descriptor data
+/// @param[in]     ret_value  Return value from SSL function call
+/// @param[in]     log_level  Amount of logging to do according to ssl_logging_t
+/// @returns       SSL_ERROR_NONE if successful or unknown, otherwise value from SSL_get_error()
+///
+int
+ssl_check_error(struct descriptor_data *d, const int ret_value, const ssl_logging_t log_level)
 {
-    /* Errors require a valid SSL structure, and errors only occur when ret_value is not 1.
-       Bail out early if these conditions aren't met.
-       See https://www.openssl.org/docs/manmaster/ssl/SSL_accept.html */
-    if (!ssl || ret_value == 0)
-	return;
+	// Errors require a valid SSL structure, and errors only occur when ret_value is not 1.
+	// Bail out early if these conditions aren't met.
+	// See https://www.openssl.org/docs/man1.1.0/ssl/SSL_accept.html
+	if (!d->ssl_session || ret_value == 1) {
+		return SSL_ERROR_NONE;
+	}
 
-    /* Get the error value first for requesting the error reason clears the error */
-    int ssl_error_value = SSL_get_error(ssl, ret_value);
+	// Get the error value first; otherwise, requesting the error reason clears the error
+	int ssl_error_value = SSL_get_error(d->ssl_session, ret_value);
 
+	// Only log if logging is enabled, avoiding any performance impact when the value's not used
+	if (log_level != SSL_LOGGING_NONE) {
 #ifdef HAVE_OPENSSL
-    /* OpenSSL has support for getting the error reason string... */
-    const char *reason_str_buf = ERR_reason_error_string(ERR_get_error());
+		// OpenSSL has support for getting the error reason string...
+		const char *reason_str_buf = ERR_reason_error_string(ERR_get_error());
+		// Use the specific error message if available, or fall back to a generic error if not
+		// available (assumptions could mislead an unwary sysadmin).
+		if (reason_str_buf == NULL) {
+			reason_str_buf = "unknown reason";
+		}
 #else
-    /* ...but other SSL libraries might not, so assume an unknown error.  Remove this check if
-       not actually needed. */
-    const char *reason_str_buf = NULL;
+		// ...but other SSL libraries might not, so assume an unknown error.  Remove this check if
+		// not actually needed.
+		const char *reason_str_buf = "unknown reason";
 #endif
 
-    /* In the future, additional logging may be desired.  Just add new cases.
-       See https://www.openssl.org/docs/manmaster/ssl/SSL_get_error.html */
-    switch (ssl_error_value) {
-    case SSL_ERROR_SSL:
-	/* Use the specific error message if available, or fall back to a generic error if not
-	   available (assumptions could mislead an unwary sysadmin). */
-	log_status("SSL: Error negotiating encrypted connection (%s)",
-		   (reason_str_buf != NULL) ? reason_str_buf : "unknown error");
-	break;
-    case SSL_ERROR_SYSCALL:
-	/* Use the specific error message if available, or fall back to a generic error if not
-	   available (assumptions could mislead an unwary sysadmin). */
-	log_status("SSL: Error with input/output of encrypted connection (%s)",
-		   (reason_str_buf != NULL) ? reason_str_buf : "unknown error");
-	break;
-    default:
-	/* Don't log by default to avoid spamming the system log */
-	break;
-    }
+		// Handle each possible case for SSL logging
+		switch (ssl_error_value) {
+		case SSL_ERROR_NONE:
+			// No error, no need to log anything.  This shouldn't happen, but just in case...
+			break;
+		// Errors that usually mean bad things happened
+		case SSL_ERROR_SSL:
+			if (log_level < SSL_LOGGING_ERROR)
+				break;
+			// These are logged even when SSL protocol considers it intentional.  This allows
+			// tracking when clients connect that don't support the latest protocols
+			// (e.g. when SSLv3 is disabled).
+			log_status("SSL: Error negotiating encrypted connection (%s, SSL_ERROR_SSL)"
+			           " on descriptor %d from %s(%s)",
+			           reason_str_buf, d->descriptor, d->hostname, d->username);
+			break;
+		case SSL_ERROR_SYSCALL:
+			if (log_level < SSL_LOGGING_ERROR)
+				break;
+			log_status("SSL: Error with input/output of connection (%s, SSL_ERROR_SYSCALL)"
+			           " on descriptor %d from %s(%s)",
+			           reason_str_buf, d->descriptor, d->hostname, d->username);
+			// The original log_ssl_error function called this instead...
+			//   log_status("SSL %s: sock %d, Error SSL_ERROR_SYSCALL: %s", text, descr,
+			//   strerror(errno));
+			// However, errno is specific to interface.c, and might be redundant now that
+			// reason_str exists.  If it's actually needed, just modify this function, passing it
+			// in here.
+			break;
+		case SSL_ERROR_ZERO_RETURN:
+			if (log_level < SSL_LOGGING_ERROR)
+				break;
+			log_status("SSL: Error connection is already closed (%s, SSL_ERROR_ZERO_RETURN)"
+			           " on descriptor %d from %s(%s)",
+			           reason_str_buf, d->descriptor, d->hostname, d->username);
+			break;
+		// Errors that might occur during normal operation (only logged at DEBUG or higher)
+		case SSL_ERROR_WANT_READ:
+			if (log_level < SSL_LOGGING_DEBUG)
+				break;
+			log_status("SSL: Error pending read operation, retry later (%s, SSL_ERROR_WANT_READ)"
+			           " on descriptor %d from %s(%s)",
+			           reason_str_buf, d->descriptor, d->hostname, d->username);
+			break;
+		case SSL_ERROR_WANT_WRITE:
+			if (log_level < SSL_LOGGING_DEBUG)
+				break;
+			log_status("SSL: Error pending write operation, retry later (%s, SSL_ERROR_WANT_WRITE)"
+			           " on descriptor %d from %s(%s)",
+			           reason_str_buf, d->descriptor, d->hostname, d->username);
+			break;
+		case SSL_ERROR_WANT_X509_LOOKUP:
+			if (log_level < SSL_LOGGING_DEBUG)
+				break;
+			log_status("SSL: Error pending X509 lookup, retry later (%s, SSL_ERROR_WANT_X509_LOOKUP)"
+			           " on descriptor %d from %s(%s)",
+			           reason_str_buf, d->descriptor, d->hostname, d->username);
+			break;
+		case SSL_ERROR_WANT_CONNECT:
+			if (log_level < SSL_LOGGING_DEBUG)
+				break;
+			log_status("SSL: Error pending connection, retry later (%s, SSL_ERROR_WANT_CONNECT)"
+			           " on descriptor %d from %s(%s)",
+			           reason_str_buf, d->descriptor, d->hostname, d->username);
+			break;
+		case SSL_ERROR_WANT_ACCEPT:
+			if (log_level < SSL_LOGGING_DEBUG)
+				break;
+			log_status("SSL: Error pending connection accept, retry later (%s, SSL_ERROR_WANT_ACCEPT)"
+			           " on descriptor %d from %s(%s)",
+			           reason_str_buf, d->descriptor, d->hostname, d->username);
+			break;
+		// Unknown errors - something bad happened, or it's a version of SSL with new error messages
+		default:
+			if (log_level < SSL_LOGGING_WARN)
+				break;
+			log_status("SSL: Unknown error (%s)"
+			           " on descriptor %d from %s(%s)",
+			           reason_str_buf, d->descriptor, d->hostname, d->username);
+			break;
+		}
+	}
+	// Do post-logging things here that don't rely on logging being enabled
+
+	// Pass on the SSL error value so the calling function can use it
+	return ssl_error_value;
 }
 
 #endif				// USE_SSL

--- a/src/interface_ssl.c
+++ b/src/interface_ssl.c
@@ -5,90 +5,95 @@
 #include "interface_ssl.h"
 #include "log.h"
 
-/** Converts an SSL protocol version string to a version number
- *
- *  Inspired by 'set_protocol_version' in
- *  https://github.com/openssl/openssl/blob/master/test/ssltest.c
- *
- *  @param[in] value Name of SSL protocol version
- *  @returns   Version number if found, SSL_UNSUPPORTED_PROTOCOL if unsupported, or -1 if not found
- */
+///
+/// Converts an SSL protocol version string to a version number
+///
+/// Inspired by 'set_protocol_version' in
+/// https://github.com/openssl/openssl/blob/master/test/ssltest.c
+///
+/// @param[in] value Name of SSL protocol version
+/// @returns   Version number if found, SSL_UNSUPPORTED_PROTOCOL if unsupported, or -1 if not found
+///
 int
 ssl_protocol_from_string(const char *value)
 {
-    /* Find the desired version */
-    for (size_t i = 0; i < SSL_PROTOCOLS_SIZE; i++)
-	if (strcmp(SSL_PROTOCOLS[i].name, value) == 0)
-	    return SSL_PROTOCOLS[i].version;
+	// Find the desired version
+	for (size_t i = 0; i < SSL_PROTOCOLS_SIZE; i++)
+		if (strcmp(SSL_PROTOCOLS[i].name, value) == 0)
+			return SSL_PROTOCOLS[i].version;
 
-    /* Not found, return failure */
-    return -1;
+	// Not found, return failure
+	return -1;
 }
 
-/** Sets the minimum SSL protocol version given a version string
- *
- *  If None, no change will be made to the SSL context.  If version string is invalid or unsupported
- *  in this build (see SSL_PROTOCOLS), an error is logged to offer guidance on fixing the problem.
- *
- *  @param[in,out] ssl_ctx     SSL context
- *  @param[in]     min_version Name of minimum required SSL protocol version, or "None"
- *  @returns       1 if successful, otherwise 0
- */
+///
+/// Sets the minimum SSL protocol version given a version string
+///
+/// If None, no change will be made to the SSL context.  If version string is invalid or unsupported
+/// in this build (see SSL_PROTOCOLS), an error is logged to offer guidance on fixing the problem.
+///
+/// @param[in,out] ssl_ctx      SSL context
+/// @param[in]     min_version  Name of minimum required SSL protocol version, or "None"
+/// @returns       1 if successful, otherwise 0
+///
 int
 set_ssl_ctx_min_version(SSL_CTX * ssl_ctx, const char *min_version)
 {
-    int min_version_num = ssl_protocol_from_string(min_version);
-    switch (min_version_num) {
-    case 0:
-	/* None specified, no changes needed */
-	return 1;
-    case -1:
-	log_status("ERROR: Unknown ssl_min_protocol_version '%s'.  Specify one of: %s",
-		   min_version, SSL_KNOWN_PROTOCOLS);
-	fprintf(stderr, "ERROR: Unknown ssl_min_protocol_version '%s'.  Specify one of: %s\n",
-		min_version, SSL_KNOWN_PROTOCOLS);
-	return 0;
-    case SSL_UNSUPPORTED_PROTOCOL:
-	log_status
-		("ERROR: ssl_min_protocol_version '%s' not supported by the SSL library in this build.  Specify one of: %s",
-		 min_version, SSL_KNOWN_PROTOCOLS);
-	fprintf(stderr,
-		"ERROR: ssl_min_protocol_version '%s' not supported by the SSL library in this build.  Specify one of: %s\n",
-		min_version, SSL_KNOWN_PROTOCOLS);
-	return 0;
-    default:
-	log_status("Requiring SSL protocol version '%s' or higher for encrypted connections",
-		   min_version);
+	int min_version_num = ssl_protocol_from_string(min_version);
+	switch (min_version_num) {
+	case 0:
+		// None specified, no changes needed
+		return 1;
+	case -1:
+		log_status("ERROR: Unknown ssl_min_protocol_version '%s'.  Specify one of: %s",
+		           min_version, SSL_KNOWN_PROTOCOLS);
+		fprintf(stderr,
+		        "ERROR: Unknown ssl_min_protocol_version '%s'.  Specify one of: %s\n",
+		        min_version, SSL_KNOWN_PROTOCOLS);
+		return 0;
+	case SSL_UNSUPPORTED_PROTOCOL:
+		log_status("ERROR: ssl_min_protocol_version '%s' not supported by the SSL library "
+		           "in this build.  Specify one of: %s",
+		           min_version, SSL_KNOWN_PROTOCOLS);
+		fprintf(stderr,
+		        "ERROR: ssl_min_protocol_version '%s' not supported by the SSL library "
+		        "in this build.  Specify one of: %s\n",
+		        min_version, SSL_KNOWN_PROTOCOLS);
+		return 0;
+	default:
+		log_status("Requiring SSL protocol version '%s' or higher for encrypted connections",
+		           min_version);
 #if defined(SSL_CTX_set_min_proto_version)
-	/* Added in OpenSSL >= 1.1.0
-	   See: https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_set_min_proto_version.html */
-	return SSL_CTX_set_min_proto_version(ssl_ctx, min_version_num);
+		// Added in OpenSSL >= 1.1.0
+		// See: https://www.openssl.org/docs/manmaster/ssl/SSL_CTX_set_min_proto_version.html
+		return SSL_CTX_set_min_proto_version(ssl_ctx, min_version_num);
 #elif defined(SSL_CTX_set_options)
-	/* Easy way not implemented, manually turn off protocols to match the minimum version.
-	   FB_*_VERSION macros are guaranteed to be defined regardless of OpenSSL version,
-	   either as a real version or SSL_UNSUPPORTED_PROTOCOL, which will never be greater
-	   than min_version_num. */
-	if (min_version_num > FB_SSL3_VERSION)
-	    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv3);
-	if (min_version_num > FB_TLS1_VERSION)
-	    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_TLSv1);
-	if (min_version_num > FB_TLS1_1_VERSION)
-	    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_TLSv1_1);
-	if (min_version_num > FB_TLS1_2_VERSION)
-	    SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_TLSv1_2);
-	/* No need to add newer versions as OpenSSL >= 1.1.0 supports the much-nicer
-	   SSL_CTX_set_min_proto_version - see above */
-	return 1;
+		// Easy way not implemented, manually turn off protocols to match the minimum version.
+		// FB_*_VERSION macros are guaranteed to be defined regardless of OpenSSL version,
+		// either as a real version or SSL_UNSUPPORTED_PROTOCOL, which will never be greater
+		// than min_version_num.
+		if (min_version_num > FB_SSL3_VERSION)
+			SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_SSLv3);
+		if (min_version_num > FB_TLS1_VERSION)
+			SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_TLSv1);
+		if (min_version_num > FB_TLS1_1_VERSION)
+			SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_TLSv1_1);
+		if (min_version_num > FB_TLS1_2_VERSION)
+			SSL_CTX_set_options(ssl_ctx, SSL_OP_NO_TLSv1_2);
+		// No need to add newer versions as OpenSSL >= 1.1.0 supports the much-nicer
+		// SSL_CTX_set_min_proto_version - see above
+		return 1;
 #else
-	/* A minimum version was requested, but the SSL library doesn't support specifying that.
-	   Error out with some advice. */
-	log_status
-		("ERROR: specifying ssl_min_protocol_version is not supported by the SSL library used in this build.  Set to 'None', or maybe use OpenSSL?");
-	fprintf(stderr,
-		"specifying ssl_min_protocol_version is not supported by the SSL library used in this build.  Set to 'None', or maybe use OpenSSL?\n");
-	return 0;
+		// A minimum version was requested, but the SSL library doesn't support specifying that.
+		// Error out with some advice.
+		log_status("ERROR: specifying ssl_min_protocol_version is not supported by the SSL "
+		           "library used in this build.  Set to 'None', or maybe use OpenSSL?");
+		fprintf(stderr,
+		        "specifying ssl_min_protocol_version is not supported by the SSL "
+		        "library used in this build.  Set to 'None', or maybe use OpenSSL?\n");
+		return 0;
 #endif
-    }
+	}
 }
 
 /** Records the last SSL error to the log
@@ -140,4 +145,4 @@ ssl_log_error(SSL * ssl, const int ret_value)
     }
 }
 
-#endif				/* USE_SSL */
+#endif				// USE_SSL


### PR DESCRIPTION
## In short
* Unify SSL logging
  * Change `ssl_log_error()` into `ssl_check_error()`, replace `SSL_get_error` calls elsewhere
  * Add `DEBUG_SSL_LOG_ALL` `#define` to `config.h` to control level of SSL logging
  * Remove now-unneeded `log_ssl_error()` function from `interface.c`
* Unify `socket_read`/`socket_write`
  * Move `#defines` into `socket_read()`/`socket_write()` functions
  * Use `#ifdef`'s for SSL logic
  * Fixes `last_pinged_at` not getting set to `null` when compiled without SSL
* Clean up comments, indentation
  * Migrate `interface_ssl.(c|h)` to tabs for indenting, spacing for alignment
  * Use `//` for comments, `///` for variabl and functions headers, [Doxygen style](http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html )
  * Update OpenSSL links to fix 404 errors

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Fixes automated builds, essential to see if other things break
Risk | ★★☆ *2/3* | Might break build setups that differ from AppVeyor, though it shouldn't
Intrusiveness | ★★☆ *2/3* | Modifies socket-handling, may interfere with network pull requests

## Implementation
* `ssl_check_error()` takes a `log_level` specifying logging level
  * Values are `SSL_LOGGING_NONE`, `SSL_LOGGING_ERROR`, `SSL_LOGGING_WARN`, `SSL_LOGGING_DEBUG`
  * Allows hiding internal SSL errors, e.g. `SSL_WANT_READ` and `SSL_WANT_WRITE`
  * Shows connection details in logs for troubleshooting
* In `config.h`, a new define is added `DEBUG_SSL_LOG_ALL`
  * Should later be migrated to a runtime `@debug` setting when that system is in place
  * **Connection logging** applies to `SSL_accept()` and `STARTTLS`, **Read/write logging** applies to `socket_read()`/`socket_write()`

Log level | Connection logging | Read/write logging
----------|--------------------|-------------------
Default | Warnings and above | Nothing
Debug | Everything | Everything

*Read/write logging is disabled by default to avoid redundant warnings as seen in **Examples**.  Detecting errors in order to `shutdownsock()` seemed too complex and risky to be worth it.*

## Examples
All examples used the following:
```
@tune ssl_min_protocol_version=TLSv1.2
@reconfiguressl
```

### Default SSL logging
In `config.h`, `DEBUG_SSL_LOG_ALL` **is not** defined.

**Valid, `openssl s_client -connect localhost:8882`**
```
2017-01-27T22:14:32: ACCEPT: 127.0.0.1(49198) on descriptor 9
2017-01-27T22:14:32: CONCOUNT: There are now 1 open connections.
2017-01-27T22:14:42: CONNECTED: One(1) on descriptor 9
2017-01-27T22:14:50: DISCONNECT: descriptor 9 player One(1) from 127.0.0.1(49198)
2017-01-27T22:14:50: CONCOUNT: There are now 0 open connections.
```

**Old protocol, `openssl s_client -tls1 -connect localhost:8882`**
```
2017-01-27T22:14:56: ACCEPT: 127.0.0.1(49202) on descriptor 9
2017-01-27T22:14:56: CONCOUNT: There are now 1 open connections.
2017-01-27T22:14:56: SSL: Error negotiating encrypted connection (unknown protocol, SSL_ERROR_SSL) on descriptor 9 from 127.0.0.1(49202)
2017-01-27T22:14:56: DISCONNECT: descriptor 9 from 127.0.0.1(49202) never connected.
2017-01-27T22:14:56: CONCOUNT: There are now 0 open connections.
```

### Debug SSL logging
In `config.h`, `DEBUG_SSL_LOG_ALL` **is** defined.

**Valid, `openssl s_client -connect localhost:8882`**
```
2017-01-27T22:25:31: ACCEPT: 127.0.0.1(49244) on descriptor 9
2017-01-27T22:25:31: CONCOUNT: There are now 1 open connections.
2017-01-27T22:25:31: SSL: Error pending read operation, retry later (unknown reason, SSL_ERROR_WANT_READ) on descriptor 9 from 127.0.0.1(49244)
2017-01-27T22:25:31: SSL: Error pending read operation, retry later (unknown reason, SSL_ERROR_WANT_READ) on descriptor 9 from 127.0.0.1(49244)
2017-01-27T22:25:41: CONNECTED: One(1) on descriptor 9
2017-01-27T22:25:51: DISCONNECT: descriptor 9 player One(1) from 127.0.0.1(49244)
2017-01-27T22:25:51: CONCOUNT: There are now 0 open connections.
```

**Old protocol, `openssl s_client -tls1 -connect localhost:8882`**
```
2017-01-27T22:26:25: ACCEPT: 127.0.0.1(49250) on descriptor 9
2017-01-27T22:26:25: CONCOUNT: There are now 1 open connections.
2017-01-27T22:26:25: SSL: Error negotiating encrypted connection (unknown protocol, SSL_ERROR_SSL) on descriptor 9 from 127.0.0.1(49250)
2017-01-27T22:26:25: SSL: Error negotiating encrypted connection (unknown protocol, SSL_ERROR_SSL) on descriptor 9 from 127.0.0.1(49250)
2017-01-27T22:26:25: SSL: Error negotiating encrypted connection (unknown protocol, SSL_ERROR_SSL) on descriptor 9 from 127.0.0.1(49250)
2017-01-27T22:26:25: SSL: Error negotiating encrypted connection (unknown protocol, SSL_ERROR_SSL) on descriptor 9 from 127.0.0.1(49250)
2017-01-27T22:26:25: DISCONNECT: descriptor 9 from 127.0.0.1(49250) never connected.
2017-01-27T22:26:25: CONCOUNT: There are now 0 open connections.
```