### PR TITLE
potentially reap multiple processes per SIGCHLD handler call

### DIFF
--- a/src/fbsignal.c
+++ b/src/fbsignal.c
@@ -321,7 +321,7 @@ sig_reap(int i)
        process die at almost the same time. */
     do {
         reapedpid = waitpid(-1, &status, WNOHANG);
-        if (reapedpid) {
+        if (reapedpid != -1) {
             if (reapedpid == global_resolver_pid) {
                 log_status("resolver exited with status %d", status);
                 if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
@@ -366,7 +366,7 @@ sig_reap(int i)
                         reapedpid, status);
             }
         }
-    } while (reapedpid);
+    } while (reapedpid != -1);
     return RETSIGVAL;
 }
 #endif


### PR DESCRIPTION
When multiple child processes die, we can sometimes receive two SIGCHLDs which only result in one call to our SIGCHLD handler running. This is considerably more likely with the pselect() patch ensuring that SIGCHLD handler is only run during pselect(). This patch modifies the signal handler to call waitpid() in a loop. It also moves the respawning of the resolver after the loop so that if it crashes immediately, that does not keep the child reaping loop from finishing.