### PR TITLE
More descriptive AppVeyor build numbers

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,20 @@ install:
     - cmd: conan user # Create conan data directory
     - cmd: conan --version
 
+init:
+    # Set "build version number" to "short-commit-hash" or when tagged to "tag name" (Travis style)
+    # Thanks to @jakoch and @ronaldbarendse
+    # Modified to also include the build number, distinguishes rebuilds of the same commit
+    # See comments on https://github.com/appveyor/ci/issues/691
+    - ps: |
+        if ($env:APPVEYOR_REPO_TAG -eq "true")
+        {
+            # Trim any starting 'v' from tags
+            Update-AppveyorBuild -Version "$($env:APPVEYOR_REPO_TAG_NAME.TrimStart("v"))-$env:APPVEYOR_BUILD_NUMBER"
+        } else {
+            Update-AppveyorBuild -Version "dev-$($env:APPVEYOR_REPO_COMMIT.Substring(0, 8))-$env:APPVEYOR_BUILD_NUMBER"
+        }
+
 build_script:
     - ps: |
         # Install Conan dependencies for 32-bit (x86)
@@ -30,9 +44,10 @@ build_script:
 
         # Package and store the build results
         # > File name of compressed output
-        $artifact_name = "fuzzball-win32"
+        $artifact_name = "fuzzball-win32-$env:APPVEYOR_BUILD_VERSION"
         # > Folder name stored inside compressed output
-        $artifact_root = "$env:APPVEYOR_BUILD_FOLDER/$artifact_name-$env:APPVEYOR_BUILD_VERSION"
+        #   Don't include "...-$env:APPVEYOR_BUILD_VERSION" as that's now part of the artifact name
+        $artifact_root = "$env:APPVEYOR_BUILD_FOLDER/$artifact_name"
         # > Exact filename for compressed output (change extension for different format)
         $artifact_zip = "$artifact_name.zip"
 


### PR DESCRIPTION
## In short
* For version, use tag if available or short commit hash if not
  * Simplifies associating downloads and builds to a particular commit or tag
* Update the artifact name to include the build version
  * Allows distinguishing downloads

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Dev. quality-of-life improvement, easier tracking of bad builds
Risk | ★☆☆ *1/3* | Easily reverted, only changes build packaging
Intrusiveness | ★☆☆ *1/3* | Minor changes, shouldn't interfere with other pull requests

## Example
### Before
* AppVeyor interface
  * URL: https://ci.appveyor.com/project/digitalcircuit/fuzzball/build/207
* Downloads
  * File: `fuzzball-win32.zip`
  * Folder inside: `fuzzball-win32-207/`

### After - tagged build
*Tagged builds are now handled differently from regular commits.  Tag is `7.00a1-test`*

* AppVeyor interface
  * URL: https://ci.appveyor.com/project/digitalcircuit/fuzzball/build/7.00a1-test-211
* Downloads
  * File: `fuzzball-win32-7.00a1-test-211.zip`
  * Folder inside: `fuzzball-win32-7.00a1-test-211/`
  
### After - regular commit
* AppVeyor interface
  * URL: https://ci.appveyor.com/project/digitalcircuit/fuzzball/build/dev-f0449bf2-210
* Downloads
  * File: `fuzzball-win32-dev-697d6ff3-210.zip`
  * Folder inside: `fuzzball-win32-dev-697d6ff3-210/`