### PR TITLE
Fix off-by-one in MPI variable/function parsing

### DIFF
--- a/src/msgparse.c
+++ b/src/msgparse.c
@@ -758,11 +758,11 @@ mesg_parse(int descr, dbref player, dbref what, dbref perms,
 		s = 0;
 		while (wbuf[p] && wbuf[p] != MFUN_LEADCHAR &&
 		       !isspace(wbuf[p]) && wbuf[p] != MFUN_ARGSTART &&
-		       wbuf[p] != MFUN_ARGEND && s < MAX_MFUN_NAME_LEN) {
+		       wbuf[p] != MFUN_ARGEND && s <= MAX_MFUN_NAME_LEN) {
 		    p++;
 		    s++;
 		}
-		if (s < MAX_MFUN_NAME_LEN &&
+		if ( ( s <= MAX_MFUN_NAME_LEN || ( s <= MAX_MFUN_NAME_LEN + 1 && *ptr == '&' ) ) &&
 		    (wbuf[p] == MFUN_ARGSTART || wbuf[p] == MFUN_ARGEND)) {
 		    int varflag;
 


### PR DESCRIPTION
An off-by-one error in msgparse.c breaks access to MPI functions whose names are exactly MAX_MFUN_NAME_LEN characters in length (default 16), and shorthand {&var} access to variables whose names are one less (15).