### PR TITLE
Fix prochelp build, add to CI, rename @dbginfo docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,12 @@ env:
     - FLAG_IPV6=""                FLAG_SSL=""
 
 script:
-  - ./configure $FLAG_LINT $FLAG_IPV6 $FLAG_SSL && make clean && make all
+  # Set up configure flags
+  - ./configure $FLAG_LINT $FLAG_IPV6 $FLAG_SSL
+  # Clean up build directory
+  - make clean
+  # Make Fuzzball and all related code
+  - make all
 
 # Currently, --enable-memprof and --enable-debug are ignored for that generates
 # 32 builds instead of 8.  If those need tested in the future, use the

--- a/game/data/help.txt
+++ b/game/data/help.txt
@@ -35,7 +35,7 @@ Symbols
   @action            @armageddon        @attach            @bless
   @boot              @chown             @chown_lock        @clone
   @conlock           @contents          @create            @credits
-  @dbginfo           @describe          @dig               @doing
+  @debug             @describe          @dig               @doing
   @drop              @dump              @edit              @entrances
   @examine           @fail              @find              @force
   @force_lock        @hashes            @idescribe         @kill
@@ -1923,7 +1923,7 @@ Wizardly Commands|WizCmds
 Wizardly Commands
 
 @armageddon        @bless             @boot              @credits
-@dbginfo           @dump              @examine           @force
+@debug             @dump              @examine           @force
 @hashes            @memory            @mpitops           @muftops
 @newpassword       @pcreate           @reconfiguressl    @restart
 @restrict          @sanchange         @sanfix            @sanity
@@ -2164,11 +2164,15 @@ Also see: @CREDITS and @VERSION
 Also see: @CREDITS and @HASHES
 ~
 ~
-@DBGINFO
-@DBGINFO
+@DEBUG
+@DEBUG
 
   Wizard only command that gives database usage stats for
 'diskbase'-style databases.  Only available if compiled with DISKBASE.
+More options will be added in the future.
+
+  Examples:
+    @debug display propcache    display database property cache
 Also see: @MEMORY, @MPITOPS, @MUFTOPS, @TOPS and @USAGE
 ~
 ~
@@ -2187,7 +2191,7 @@ blank, it uses the default of '10'.
     @tops              show default amount of profiling statistics
     @tops 5            show 5 rows of profiling statistics
     @tops reset        reset all collected profiling statistics
-Also see: @DBGINFO, @MEMORY, @MPITOPS, @MUFTOPS and @USAGE
+Also see: @DEBUG, @MEMORY, @MPITOPS, @MUFTOPS and @USAGE
 ~
 ~
 @MEMORY
@@ -2196,7 +2200,7 @@ Also see: @DBGINFO, @MEMORY, @MPITOPS, @MUFTOPS and @USAGE
   Wizard only command that gives detailed memory stats for the muck
 server process.  If HAVE_MALLINFO is used, this command shows more
 information.
-Also see: @DBGINFO, @MPITOPS, @MUFTOPS, @TOPS and @USAGE
+Also see: @DEBUG, @MPITOPS, @MUFTOPS, @TOPS and @USAGE
 ~
 ~
 @MPITOPS
@@ -2214,7 +2218,7 @@ uses the default of '10'.
     @mpitops           show default amount of profiling statistics
     @mpitops 5         show 5 rows of profiling statistics
     @mpitops reset     reset collected MPI profiling statistics
-Also see: @DBGINFO, @MEMORY, @MUFTOPS, @TOPS and @USAGE
+Also see: @DEBUG, @MEMORY, @MUFTOPS, @TOPS and @USAGE
 ~
 ~
 @MUFTOPS
@@ -2232,7 +2236,7 @@ uses the default of '10'.
     @muftops           show default amount of profiling statistics
     @muftops 5         show 5 rows of profiling statistics
     @muftops reset     reset collected MUF profiling statistics
-Also see: @DBGINFO, @MEMORY, @MPITOPS, @TOPS and @USAGE
+Also see: @DEBUG, @MEMORY, @MPITOPS, @TOPS and @USAGE
 ~
 ~
 @USAGE
@@ -2240,7 +2244,7 @@ Also see: @DBGINFO, @MEMORY, @MPITOPS, @TOPS and @USAGE
 
   Wizard only command that gives system resource usage stats for the
 muck server process.
-Also see: @DBGINFO, @MEMORY, @MPITOPS, @MUFTOPS and @TOPS
+Also see: @DEBUG, @MEMORY, @MPITOPS, @MUFTOPS and @TOPS
 ~
 ~
 @EXAMINE

--- a/game/data/info/muckhelp
+++ b/game/data/info/muckhelp
@@ -1777,10 +1777,14 @@ hashes are only available if Git was installed during compilation.
   Show the version information, build time, and compile options used.
 
 
-@DBGINFO
+@DEBUG
 
   Wizard only command that gives database usage stats for
 'diskbase'-style databases.  Only available if compiled with DISKBASE.
+More options will be added in the future.
+
+  Examples:
+    @debug display propcache    display database property cache
 
 
 @TOPS

--- a/game/data/muckhelp.raw
+++ b/game/data/muckhelp.raw
@@ -1991,11 +1991,17 @@ hashes are only available if Git was installed during compilation.
 ~~alsosee @CREDITS,@HASHES
 ~
 ~
-@DBGINFO
-@DBGINFO
+@DEBUG
+@DEBUG
 
   Wizard only command that gives database usage stats for
 'diskbase'-style databases.  Only available if compiled with DISKBASE.
+More options will be added in the future.
+
+  Examples:
+~~code
+    @debug display propcache    display database property cache
+~~endcode
 ~~alsosee @MEMORY,@MPITOPS,@MUFTOPS,@TOPS,@USAGE
 ~
 ~
@@ -2016,7 +2022,7 @@ blank, it uses the default of '10'.
     @tops 5            show 5 rows of profiling statistics
     @tops reset        reset all collected profiling statistics
 ~~endcode
-~~alsosee @DBGINFO,@MEMORY,@MPITOPS,@MUFTOPS,@USAGE
+~~alsosee @DEBUG,@MEMORY,@MPITOPS,@MUFTOPS,@USAGE
 ~
 ~
 @MEMORY
@@ -2025,7 +2031,7 @@ blank, it uses the default of '10'.
   Wizard only command that gives detailed memory stats for the muck
 server process.  If HAVE_MALLINFO is used, this command shows more
 information.
-~~alsosee @DBGINFO,@MPITOPS,@MUFTOPS,@TOPS,@USAGE
+~~alsosee @DEBUG,@MPITOPS,@MUFTOPS,@TOPS,@USAGE
 ~
 ~
 @MPITOPS
@@ -2045,7 +2051,7 @@ uses the default of '10'.
     @mpitops 5         show 5 rows of profiling statistics
     @mpitops reset     reset collected MPI profiling statistics
 ~~endcode
-~~alsosee @DBGINFO,@MEMORY,@MUFTOPS,@TOPS,@USAGE
+~~alsosee @DEBUG,@MEMORY,@MUFTOPS,@TOPS,@USAGE
 ~
 ~
 @MUFTOPS
@@ -2065,7 +2071,7 @@ uses the default of '10'.
     @muftops 5         show 5 rows of profiling statistics
     @muftops reset     reset collected MUF profiling statistics
 ~~endcode
-~~alsosee @DBGINFO,@MEMORY,@MPITOPS,@TOPS,@USAGE
+~~alsosee @DEBUG,@MEMORY,@MPITOPS,@TOPS,@USAGE
 ~
 ~
 @USAGE
@@ -2073,7 +2079,7 @@ uses the default of '10'.
 
   Wizard only command that gives system resource usage stats for the
 muck server process.
-~~alsosee @DBGINFO,@MEMORY,@MPITOPS,@MUFTOPS,@TOPS
+~~alsosee @DEBUG,@MEMORY,@MPITOPS,@MUFTOPS,@TOPS
 ~
 ~
 @EXAMINE

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -137,8 +137,8 @@ MOBJ= interface.o resolver.o
 SRC= ${MISCSRC} ${CSRC} ${MSRC}
 OBJ= ${COBJ} ${ROBJ} ${MOBJ}
 
-TARGETS= fbmuck fb-resolver
-OLDTARGETS = fbmuck~ fb-resolver~
+TARGETS= fbmuck fb-resolver prochelp
+OLDTARGETS = fbmuck~ fb-resolver~ prochelp~
 HELPFILES= man.txt help.txt mpihelp.txt
 
 .c.o:
@@ -168,6 +168,9 @@ fbmuck: $(INCLUDE)/defines.h ${P} ${COBJ} ${MALLOBJ} interface.o Makefile
 
 fb-resolver: resolver.o ${MALLOBJ} Makefile
 	${PRE} ${CC} ${CFLAGS} ${INCL} ${DEFS} -o fb-resolver resolver.o ${MALLOBJ} ${LIBR} -lpthread
+
+prochelp: prochelp.o Makefile
+	${PRE} ${CC} ${CFLAGS} ${INCL} ${DEFS} -o prochelp prochelp.o
 
 #############################################################
 # Funky stuff for debugging and coding work.
@@ -212,10 +215,10 @@ Makefile: Makefile.in
 #
 
 clean:
-	-${RM} ${OBJ} core version.o mkversion.o ${SOBJ} ${MALLOBJ} resolver.o ${TARGETS} ${OLDTARGETS}
+	-${RM} ${OBJ} core version.o mkversion.o ${SOBJ} ${MALLOBJ} resolver.o ${TARGETS} ${OLDTARGETS} prochelp.o
 
 cleaner: clean
-	-${RM} Makefile config.status config.cache config.log ${INCLUDE}/autoconf.h ${TARGETS} version.c mkversion prochelp ${INCLUDE}/defines.h
+	-${RM} Makefile config.status config.cache config.log ${INCLUDE}/autoconf.h ${TARGETS} version.c mkversion ${INCLUDE}/defines.h
 
 distclean: cleaner
 


### PR DESCRIPTION
## In short
* Fix `prochelp` build
  * Add an explicit makefile rule for `prochelp` so includes apply
  * Fixes `db.h` not found errors [after token replacement was added](https://github.com/fuzzball-muck/fuzzball/commit/3b32f2d8315e14c98df9efef76210e2faeb67f15 )
* Add `prochelp` to `make all`, ensuring CI tests it can build
  * Remove `prochelp` as part of `make clean`
* Rename `@dbginfo` to `@debug`
  * Include example usage
  * Adds on to [commit 6ae4c9a](https://github.com/fuzzball-muck/fuzzball/commit/6ae4c9a820967e42147b4763340f37cbf4d7045d )

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★★☆ *2/3* | Fixes help generation, improves tests, updates docs
Risk | ★★☆ *2/3* | Might break generating help on other non-standard build setups
Intrusiveness | ★★☆ *2/3* | Modifies build and help docs, may interfere with other pull requests

*To make it easier to revert or find in the future with `git bisect`, I'd suggest not squashing the commits - one deals with the build system, the other changes documentation.*

## Examples
### Before
```
sly@kyuubi-desktop:~/Source/Chat/Fuzzball/fuzzball$ make help
mkdir -p docs_html
cd src && make prochelp
make[1]: Entering directory '/home/sly/Source/Chat/Fuzzball/fuzzball/src'
gcc -std=gnu99 -g    prochelp.c   -o prochelp
prochelp.c:6:16: fatal error: db.h: No such file or directory
compilation terminated.
<builtin>: recipe for target 'prochelp' failed
make[1]: *** [prochelp] Error 1
make[1]: Leaving directory '/home/sly/Source/Chat/Fuzzball/fuzzball/src'
Makefile:75: recipe for target 'help' failed
make: *** [help] Error 2
```

### After
*`make` now has `-I../include  -I/usr/include -I/usr/include` specified to `gcc` when building `prochelp`*

```
sly@kyuubi-desktop:~/Source/Chat/Fuzzball/fuzzball$ make help
mkdir -p docs_html
cd src && make prochelp
make[1]: Entering directory '/home/sly/Source/Chat/Fuzzball/fuzzball/src'
gcc -std=gnu99 -g -I../include  -I/usr/include -I/usr/include  -c prochelp.c
gcc -std=gnu99 -g -I../include  -I/usr/include -I/usr/include  -o prochelp prochelp.o
make[1]: Leaving directory '/home/sly/Source/Chat/Fuzzball/fuzzball/src'
cd game/data && ../../src/prochelp mpihelp.raw mpihelp.txt ../../docs_html/mpihelp.html
cd game/data && ../../src/prochelp mufman.raw man.txt ../../docs_html/mufman.html
cd game/data && ../../src/prochelp muckhelp.raw help.txt ../../docs_html/muckhelp.html
```