### PR TITLE
Fix some small property handling memory leaks

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -462,12 +462,9 @@ copy_one_prop(dbref source, dbref destination, char *propname)
 	/* flags can be copied. */
 	newprop.flags = currprop->flags;
 
-	/* data, however, must be cloned in case it's a string or a
-	   lock. */
+	/* data, however, must be cloned if it's a lock. */
 	switch (PropType(currprop)) {
 	case PROP_STRTYP:
-	    newprop.data.str = alloc_string((currprop->data).str);
-	    break;
 	case PROP_INTTYP:
 	case PROP_FLTTYP:
 	case PROP_REFTYP:

--- a/src/look.c
+++ b/src/look.c
@@ -398,15 +398,15 @@ listprops_wildcard(dbref player, dbref thing, const char *dir, const char *wild)
     propadr = first_prop(thing, (char *) dir, &pptr, propname, sizeof(propname));
     while (propadr) {
 	if (equalstr(wldcrd, propname)) {
-	    char *current, *tmpname;
-	    static char *legacy_gender;
-	    static char *legacy_guest;
-	    current = strdup(tp_gender_prop);
-	    legacy_gender = strdup(LEGACY_GENDER_PROP);
-	    legacy_guest = strdup(LEGACY_GUEST_PROP);
+	    const char *current, *tmpname;
+	    static const char *legacy_gender;
+	    static const char *legacy_guest;
+	    current = tp_gender_prop;
+	    legacy_gender = LEGACY_GENDER_PROP;
+	    legacy_guest = LEGACY_GUEST_PROP;
 
 	    snprintf(buf, sizeof(buf), "%s%c%s", dir, PROPDIR_DELIMITER, propname);
-	    tmpname = strdup(buf);
+	    tmpname = buf;
 
 	    while (*current == PROPDIR_DELIMITER)
 		current++;


### PR DESCRIPTION
In copy_one_prop, we call alloc_string() before calling set_property, but set_property calls alloc_string again (in set_property_nofetch), so this leaks memory.

In listprops_wildcard, we make copies of global strings (representing gender/etc. property names) rather than just reading the original. We also make a heap copy of the stack copy of current property name for no reason I can ascertain.