### PR TITLE
Avoid referencing unloaded objects when loading lock props

### DIFF
--- a/src/boolexp.c
+++ b/src/boolexp.c
@@ -234,12 +234,7 @@ parse_boolexp_F(int descr, const char **parsebuf, dbref player, int dbloadp)
 		return TRUE_BOOLEXP;
 	    }
 	    b->thing = (dbref) atoi(buf + 1);
-	    if (!OkObj(b->thing)) {
-		free_boolnode(b);
-		return TRUE_BOOLEXP;
-	    } else {
-		return b;
-	    }
+            return b;
 	}
 	/* break */
     }


### PR DESCRIPTION
When we load lock properties, we currently check that any absolute DBRef in the lock is a non-garbage object. Since we haven't loaded objects yet, this check can access uninitialized memory and may erroneously detect garbage. This patch removes the check.