### PR TITLE
Make STOD return #-1 from non-numbers

### DIFF
--- a/src/p_strings.c
+++ b/src/p_strings.c
@@ -1147,7 +1147,7 @@ prim_stod(PRIM_PROTOTYPE)
 	nptr = ptr;
 	if (*nptr == '-')
 	    nptr++;
-	while (*nptr && !isspace(*nptr) && (*nptr >= '0' || *nptr <= '9')) {
+	while (*nptr && !isspace(*nptr) && (*nptr >= '0' && *nptr <= '9')) {
 	    nptr++;
 	}			/* while */
 	if (*nptr && !isspace(*nptr)) {


### PR DESCRIPTION
STOD tries to return #-1 (nothing) for non-numbers, but it doesn't correctly identify most non-number strings.