### PR TITLE
fix off-by-one error in prim_subst

### DIFF
--- a/src/p_strings.c
+++ b/src/p_strings.c
@@ -1677,7 +1677,7 @@ prim_subst(PRIM_PROTOTYPE)
 		    i += oper1->data.string->length;
 		    j += k;
 		} else {
-		    if ((j + 1) > BUFFER_LEN)
+		    if ((j + 2) > BUFFER_LEN)
 			abort_interp("Operation would result in overflow.");
 		    buf[j++] = xbuf[i++];
 		    buf[j] = '\0';


### PR DESCRIPTION
prim_subst checks whether j + 1 > BUFFER_LEN before writing to index j + 1, allowing it to write one past the end of the buffer.