### PR TITLE
fix memory leak in insttotext

### DIFF
--- a/src/inst.c
+++ b/src/inst.c
@@ -90,7 +90,8 @@ insttotext(struct frame *fr, int lev, struct inst *theinst, char *buffer, int bu
 	    firstflag = 1;
 	    arrcount = 0;
 	    if (array_first(theinst->data.array, &temp1)) {
-		do {
+                int truncated_array = 1;
+                while (1) {
 		    char *inststr;
 
 		    if (arrcount++ >= 8) {
@@ -145,7 +146,14 @@ insttotext(struct frame *fr, int lev, struct inst *theinst, char *buffer, int bu
 			length--;
 			break;
 		    }
-		} while (array_next(theinst->data.array, &temp1));
+		    if (!array_next(theinst->data.array, &temp1)) {
+                        truncated_array = 0;
+                        break;
+                    }
+                }
+                if (truncated_array) {
+                    CLEAR(&temp1);
+                }
 	    }
 	    strcatn(buffer, buflen, "}");
 	} else {


### PR DESCRIPTION
When insttotext tries to output a dictionary keyed by strings but does not have enough space to show all the keys, it can leak memory for memory for the first key-value pair it did not completely show because it relied on array_next() cleaning up the struct inst.