### PR TITLE
Fix various stack overflow/underflow/premature CLEAR problems.

### DIFF
--- a/src/p_array.c
+++ b/src/p_array.c
@@ -197,6 +197,7 @@ prim_array_first(PRIM_PROTOTYPE)
     result = array_first(oper1->data.array, &temp1);
 
     CLEAR(oper1);
+    CHECKOFLOW(2);
     if (result) {
 	copyinst(&temp1, &arg[((*top)++)]);
     } else {
@@ -219,6 +220,7 @@ prim_array_last(PRIM_PROTOTYPE)
     result = array_last(oper1->data.array, &temp1);
 
     CLEAR(oper1);
+    CHECKOFLOW(2);
     if (result) {
 	copyinst(&temp1, &arg[((*top)++)]);
     } else {
@@ -244,6 +246,8 @@ prim_array_prev(PRIM_PROTOTYPE)
 
     CLEAR(oper1);
     CLEAR(oper2);
+
+    CHECKOFLOW(2);
 
     if (result) {
 	copyinst(&temp1, &arg[((*top)++)]);
@@ -657,6 +661,7 @@ prim_array_n_intersection(PRIM_PROTOTYPE)
 	    oper1 = POP();
 	    if (oper1->type != PROG_ARRAY) {
 		array_free(new_mash);
+                CLEAR(oper1);
 		abort_interp("Argument not an array.");
 	    }
 	    temp_mash = new_array_dictionary();
@@ -703,6 +708,7 @@ prim_array_n_difference(PRIM_PROTOTYPE)
 	oper1 = POP();
 	if (oper1->type != PROG_ARRAY) {
 	    array_free(new_mash);
+            CLEAR(oper1);
 	    abort_interp("Argument not an array.");
 	}
 	array_mash(oper1->data.array, &new_mash, 1);

--- a/src/p_misc.c
+++ b/src/p_misc.c
@@ -89,7 +89,7 @@ prim_systime_precise(PRIM_PROTOTYPE)
 
     CHECKOP(0);
     gettimeofday(&fulltime, (struct timezone *) 0);
-    CHECKOFLOW(2);
+    CHECKOFLOW(1);
     dbltime = fulltime.tv_sec + (((double) fulltime.tv_usec) / 1.0e6);
     PushFloat(dbltime);
 }

--- a/src/p_stack.c
+++ b/src/p_stack.c
@@ -51,9 +51,9 @@ prim_popn(PRIM_PROTOTYPE)
     if (oper1->type != PROG_INTEGER)
 	abort_interp("Operand not an integer.");
     count = oper1->data.number;
-    CLEAR(oper1);
     if (count < 0)
 	abort_interp("Operand is negative.");
+    CLEAR(oper1);
     for (int i = count; i > 0; i--) {
 	CHECKOP(1);
 	oper1 = POP();

--- a/src/p_strings.c
+++ b/src/p_strings.c
@@ -2563,7 +2563,7 @@ prim_md5hash(PRIM_PROTOTYPE)
     char hash[33];
     const char *p;
 
-    CHECKOFLOW(1);
+    CHECKOP(1);
     oper1 = POP();
 
     if (oper1->type != PROG_STRING)
@@ -2587,7 +2587,7 @@ prim_sha1hash(PRIM_PROTOTYPE)
     char hash[41];
     const char *p;
 
-    CHECKOFLOW(1);
+    CHECKOP(1);
     oper1 = POP();
 
     if (oper1->type != PROG_STRING)


### PR DESCRIPTION
Fix various places where stack underflow/overflow is not properly checked and where operands may be CLEAR'd the wrong number of times if abort_interp() happens.