### PR TITLE
SIGKILL resolver on panic().

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -215,6 +215,12 @@ panic(const char *message)
 	emergency_shutdown();
     }
 
+#ifdef SPAWN_HOST_RESOLVER
+    if (global_resolver_pid != 0) {
+        (void) kill(global_resolver_pid, SIGKILL);
+    }
+#endif
+
     /* dump panic file */
     snprintf(panicfile, sizeof(panicfile), "%s.PANIC", dumpfile);
     if ((f = fopen(panicfile, "wb")) == NULL) {


### PR DESCRIPTION
This keeps the resolver process from sticking around as a zombie on panic(). We could instead attempt an orderly shutdown of the resolver, but I'm not sure how we'd handle failures during this.