### PR TITLE
Add debugging-only code to check stack underflow/overflow checking.

### DIFF
--- a/src/interp.c
+++ b/src/interp.c
@@ -311,6 +311,11 @@ RCLEAR(struct inst *oper, char *file, int line)
 
 int top_pid = 1;
 int nargs = 0;
+#ifdef DEBUG
+int expect_pop = 0;
+int actual_pop = 0;
+int expect_push_to = 0;
+#endif
 int prim_count = 0;
 
 static struct frame *free_frames_list = NULL;
@@ -1671,9 +1676,18 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
 
 	    default:
 		nargs = 0;
+#ifdef DEBUG
+                expect_pop = actual_pop = 0;
+                expect_push_to = -1;
+#endif
 		reload(fr, atop, stop);
 		tmp = atop;
 		prim_func[pc->data.number - 1] (player, program, mlev, pc, arg, &tmp, fr);
+#ifdef DEBUG
+                assert(expect_pop == actual_pop);
+                assert(expect_push_to == -1 || expect_push_to == tmp);
+                assert(expect_push_to != -1 || tmp <= atop);
+#endif
 		atop = tmp;
 		pc++;
 		break;

--- a/src/p_array.c
+++ b/src/p_array.c
@@ -648,8 +648,7 @@ prim_array_n_intersection(PRIM_PROTOTYPE)
     CLEAR(oper1);
     nargs = 0;
 
-    if (*top < result)
-	abort_interp("Stack underflow.");
+    EXPECT_POP_STACK(result);
 
     if (result > 0) {
 	new_mash = new_array_dictionary();
@@ -694,8 +693,7 @@ prim_array_n_difference(PRIM_PROTOTYPE)
     CLEAR(oper1);
     nargs = 0;
 
-    if (*top < result)
-	abort_interp("Stack underflow.");
+    EXPECT_POP_STACK(result);
 
     if (result > 0) {
 	new_mash = new_array_dictionary();

--- a/src/p_stack.c
+++ b/src/p_stack.c
@@ -72,8 +72,7 @@ prim_dupn(PRIM_PROTOTYPE)
     if (result < 0)
 	abort_interp("Operand is negative.");
     CLEAR(oper1);
-    CHECKOP(result);
-    nargs = 0;
+    EXPECT_READ_STACK(result);
     CHECKOFLOW(result);
     for (int i = result; i > 0; i--) {
 	copyinst(&arg[*top - result], &arg[*top]);
@@ -96,8 +95,7 @@ prim_ldup(PRIM_PROTOTYPE)
 	abort_interp("Operand is negative.");
 
     result++;
-    CHECKOP_READONLY(result);
-    nargs = 0;
+    EXPECT_READ_STACK(result);
     CHECKOFLOW(result);
 
     for (int i = result; i > 0; i--) {
@@ -255,7 +253,7 @@ prim_put(PRIM_PROTOTYPE)
     if (oper1->type != PROG_INTEGER || oper1->data.number <= 0)
 	abort_interp("Operand not a positive integer.");
     tmp = oper1->data.number;
-    CHECKOP(tmp);
+    EXPECT_WRITE_STACK(tmp);
     CLEAR(&arg[*top - tmp]);
     copyinst(oper2, &arg[*top - tmp]);
     CLEAR(oper1);
@@ -746,6 +744,7 @@ prim_findmark(PRIM_PROTOTYPE)
 	    arg[*top - depth] = arg[*top - depth + 1];
 	arg[*top - 1] = temp2;
     }
+    EXPECT_POP_STACK(1);
     oper1 = POP();
     CLEAR(oper1);
     PushInt(count);
@@ -981,7 +980,7 @@ prim_reverse(PRIM_PROTOTYPE)
     tmp = oper1->data.number;	/* Depth on stack */
     if (tmp < 0)
 	abort_interp("Argument must be positive.");
-    CHECKOP(tmp);
+    EXPECT_WRITE_STACK(tmp);
     if (tmp > 0) {
 	for (int i = 0; i < (tmp / 2); i++) {
 	    temp2 = arg[*top - (tmp - i)];


### PR DESCRIPTION
Before and after each primitive, check that we've used one of the macros in interp.h to verify that we  could pop and push the stack as much as we did. This also splits up those macros to provide options for some stack manipulation primitives that do something strange and to provide versions that don't set `nargs`, which needs to be synchronized with how many of the oper{1,2,3,4} variables are in use.