### PR TITLE
Be less picky about push checking when primitives error out

### DIFF
--- a/src/interp.c
+++ b/src/interp.c
@@ -1685,7 +1685,7 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
 		prim_func[pc->data.number - 1] (player, program, mlev, pc, arg, &tmp, fr);
 #ifdef DEBUG
                 assert(expect_pop == actual_pop);
-                assert(expect_push_to == -1 || expect_push_to == tmp);
+                assert(expect_push_to == -1 || expect_push_to == tmp || err);
                 assert(expect_push_to != -1 || tmp <= atop);
 #endif
 		atop = tmp;


### PR DESCRIPTION
This adjusts a previous patch that verified that the amount pushed matched CHECKOFLOW usage to not trigger when an error is signaled instead.