### PR TITLE
Don't overwrite initialized properties/fields in COPYPLAYER

### DIFF
--- a/include/props.h
+++ b/include/props.h
@@ -108,6 +108,7 @@ PropPtr alloc_propnode(const char *name);
 void clear_property_flags(dbref player, const char *type, int flags);
 void clear_propnode(PropPtr p);
 struct plist *copy_prop(dbref old);
+void copy_properties_onto(dbref from, dbref to);
 void copy_proplist(dbref obj, PropPtr * newer, PropPtr old);
 void db_dump_props(FILE * f, dbref obj);
 int db_get_single_prop(FILE * f, dbref obj, long pos, PropPtr pnode, const char *pdir);

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -1745,8 +1745,8 @@ prim_copyplayer(PRIM_PROTOTYPE)
     /* initialize everything */
     FLAGS(newplayer) = FLAGS(ref);
 
+    copy_properties_onto(ref, newplayer);
     newp = DBFETCH(newplayer);
-    newp->properties = copy_prop(ref);
     newp->exits = NOTHING;
     newp->contents = NOTHING;
     newp->next = NOTHING;

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -1746,18 +1746,6 @@ prim_copyplayer(PRIM_PROTOTYPE)
     FLAGS(newplayer) = FLAGS(ref);
 
     copy_properties_onto(ref, newplayer);
-    newp = DBFETCH(newplayer);
-    newp->exits = NOTHING;
-    newp->contents = NOTHING;
-    newp->next = NOTHING;
-#ifdef DISKBASE
-    newp->propsfpos = 0;
-    newp->propsmode = PROPS_UNLOADED;
-    newp->propstime = 0;
-    newp->nextold = NOTHING;
-    newp->prevold = NOTHING;
-    dirtyprops(newplayer);
-#endif
 
     PLAYER_SET_HOME(newplayer, PLAYER_HOME(ref));
     SETVALUE(newplayer, GETVALUE(newplayer) + GETVALUE(ref));

--- a/src/property.c
+++ b/src/property.c
@@ -534,6 +534,20 @@ copy_prop(dbref old)
     return (n);
 }
 
+void
+copy_properties_onto(dbref from, dbref to)
+{
+    PropPtr from_props;
+#ifdef DISKBASE
+    fetchprops(from, NULL);
+    fetchprops(to, NULL);
+#endif
+
+    from_props = DBFETCH(from)->properties;
+
+    copy_proplist(from, &DBFETCH(to)->properties, from_props);
+}
+
 /* Return a pointer to the first property in a propdir and duplicates the
    property name into 'name'.  Returns NULL if the property list is empty
    or does not exist. */


### PR DESCRIPTION
create_player overwrites player fields. This includes overwriting some default properties, like `@/value`, which causes memory to be leaked if the 'properties' field of the `struct object` is replaced. This patch instead sets up a function to copy the properties over the existing properties. It also includes setting `next`, which corrupts the location list of player_start.

