### PR TITLE
make first prop from next_prop_name always start with /

### DIFF
--- a/src/property.c
+++ b/src/property.c
@@ -654,7 +654,12 @@ next_prop_name(dbref player, char *outbuf, int outbuflen, char *name)
 	    *outbuf = '\0';
 	    return NULL;
 	}
-	strcpyn(outbuf, outbuflen, name);
+        if (!*name) {
+            outbuf[0] = PROPDIR_DELIMITER;
+            outbuf[1] = '\0';
+        } else {
+            strcpyn(outbuf, outbuflen, name);
+        }
 	strcatn(outbuf, outbuflen, PropName(p));
     } else {
 	l = DBFETCH(player)->properties;


### PR DESCRIPTION
next_prop_name(), which is used by the MUF primitive NEXTPROP, will give a property name not prefixed with / when given an empty string as starting property name, even though it returns a /-prefixed property name in all other cases. This means that `#1234 "" NEXTPROP` will give a property name that does not start with / except when a non-readable property/propdir was skipped over. This patch special-cases the empty string to add a slash to the returned property.

Since this changes user-visible behavior of NEXTPROP, this change may have compatibility issues.