### PR TITLE
Check for integer overflow in prim_multiply with strings.

### DIFF
--- a/src/p_math.c
+++ b/src/p_math.c
@@ -123,6 +123,11 @@ prim_multiply(PRIM_PROTOTYPE)
 	    abort_interp("Must use a positive amount to repeat.");
 	}
 
+        /* this check avoids integer overflow with tmp * length */
+        if (string->length != 0 && string->length > MAXINT / tmp) {
+	    abort_interp("Operation would result in overflow.");
+        }
+
 	if (tmp * string->length > (BUFFER_LEN) - 1) {
 	    abort_interp("Operation would result in overflow.");
 	}


### PR DESCRIPTION
Some MUF like `"this is a long string" 200000000 *` can trigger an integer overflow in the length check for the resulting string, possibly resulting in a buffer overflow. This patch tests explicitly checks for this problem.