### PR TITLE
avoid MININT/-1 and MININT%-1 in MUF implementation

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -3,6 +3,7 @@
 #include "compile.h"
 #include "db.h"
 #include "edit.h"
+#include "fbmath.h"
 #include "fbstrings.h"
 #include "game.h"
 #include "hashtab.h"
@@ -76,6 +77,7 @@ struct PROC_LIST {
 #define INTMEDFLG_DIVBYZERO 1
 #define INTMEDFLG_MODBYZERO 2
 #define INTMEDFLG_INTRY         4
+#define INTMEDFLG_OVERFLOW 8
 
 #define IMMFLAG_REFERENCED	1	/* Referenced by a jump */
 
@@ -1054,6 +1056,18 @@ OptimizeIntermediate(COMPSTATE * cstat, int force_err_display)
 				if (force_err_display) {
 				    compiler_warning(cstat,
 						     "Warning on line %i: Divide by zero",
+						     curr->next->next->in.line);
+				}
+			    }
+                        } else if (
+                            curr->next->in.data.number == -1 &&
+                            curr->in.data.number == MININT) {
+			    if (!(curr->next->next->flags & INTMEDFLG_OVERFLOW)) {
+				curr->next->next->flags |= INTMEDFLG_OVERFLOW;
+
+				if (force_err_display) {
+				    compiler_warning(cstat,
+						     "Warning on line %i: Integer overflow",
 						     curr->next->next->in.line);
 				}
 			    }

--- a/src/compile.c
+++ b/src/compile.c
@@ -1081,7 +1081,7 @@ OptimizeIntermediate(COMPSTATE * cstat, int force_err_display)
 			break;
 		    }
 
-		    /* Int Int %  ==>  Div  */
+		    /* Int Int %  ==>  Mod */
 		    if (IntermediateIsPrimitive(curr->next->next, ModNo)) {
 			if (curr->next->in.data.number == 0) {
 			    if (!(curr->next->next->flags & INTMEDFLG_MODBYZERO)) {
@@ -1090,6 +1090,18 @@ OptimizeIntermediate(COMPSTATE * cstat, int force_err_display)
 				if (force_err_display) {
 				    compiler_warning(cstat,
 						     "Warning on line %i: Modulus by zero",
+						     curr->next->next->in.line);
+				}
+			    }
+                        } else if (
+                            curr->next->in.data.number == -1 &&
+                            curr->in.data.number == MININT) {
+			    if (!(curr->next->next->flags & INTMEDFLG_OVERFLOW)) {
+				curr->next->next->flags |= INTMEDFLG_OVERFLOW;
+
+				if (force_err_display) {
+				    compiler_warning(cstat,
+						     "Warning on line %i: Integer overflow",
 						     curr->next->next->in.line);
 				}
 			    }

--- a/src/p_math.c
+++ b/src/p_math.c
@@ -225,7 +225,10 @@ prim_mod(PRIM_PROTOTYPE)
     if ((!arith_type(oper2->type, oper1->type)) || (oper1->type == PROG_FLOAT) ||
 	(oper2->type == PROG_FLOAT))
 	abort_interp("Invalid argument type.");
-    if (oper1->data.number)
+    if (oper1->data.number == -1 && oper2->data.number == MININT) {
+        result = 1;
+        fr->error.error_flags.i_bounds = 1;
+    } else if (oper1->data.number)
 	result = oper2->data.number % oper1->data.number;
     else
 	result = 0;

--- a/src/p_math.c
+++ b/src/p_math.c
@@ -197,7 +197,10 @@ prim_divide(PRIM_PROTOTYPE)
 	    }
 	}
     } else {
-	if (oper1->data.number) {
+	if (oper1->data.number == -1 && oper2->data.number == MININT) {
+	    result = 0;
+	    fr->error.error_flags.i_bounds = 1;
+        } else if (oper1->data.number) {
 	    result = oper2->data.number / oper1->data.number;
 	} else {
 	    result = 0;


### PR DESCRIPTION
Dividing MININT by -1 (including in taking the modulus) overflows, and on many systems, this overflow results in a fatal signal. This patch detect this situation instead in the implementation of prim_divide and prim_mod and constant folding for them.