### PR TITLE
Set next_char to NULL when line_copy is set to NULL.

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -266,6 +266,7 @@ do_abort_compile(COMPSTATE * cstat, const char *c)
     if (cstat->line_copy) {
 	free((void *) cstat->line_copy);
 	cstat->line_copy = NULL;
+        cstat->next_char = NULL;
     }
     if (((FLAGS(cstat->player) & INTERACTIVE) && !(FLAGS(cstat->player) & READMODE)) ||
 	cstat->force_err_display) {


### PR DESCRIPTION
This fixes a use-after-free when trying to compile the following MUF program:
```

$
```