### PR TITLE
check if object is program before trying to compile it from $ifcancall

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -2649,7 +2649,7 @@ do_directive(COMPSTATE * cstat, char *direct)
 	    i = cstat->program;
 	}
 	free(tmpname);
-	if (!OkObj(i))
+	if (!OkObj(i) || Typeof(i) != TYPE_PROGRAM)
 	    v_abort_compile(cstat,
 			    "I don't understand what program you want to check in ifcancall.");
 	tmpname = (char *) next_token_raw(cstat);


### PR DESCRIPTION
This makes specifying a non-program with $ifcancall a compile error. I'm not sure this is the right thing to do instead of making it just consider the "can call" part false.

Fixing this fixes a segfault when trying to compile `$ifcancall me 0`.
