### PR TITLE
Don't set flags on out-of-bounds instructions in OptimizeInermediate

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -922,7 +922,10 @@ OptimizeIntermediate(COMPSTATE * cstat, int force_err_display)
 	case PROG_EXEC:
 	    i = cstat->addrlist[curr->in.data.number]->no +
 		    cstat->addroffsets[curr->in.data.number];
-	    Flags[i] |= IMMFLAG_REFERENCED;
+            /* unreachable code (outside of any word, like ': x ; if then' can have
+               references one-past-the-end of a file */
+            if (i < count)
+                Flags[i] |= IMMFLAG_REFERENCED;
 	    break;
 	}
     }


### PR DESCRIPTION
This patch prevents compiling a (bizarre) MUF program like `: x ; if then` from causing an out-of-bounds write.