### PR TITLE
fix memory leak when compiling ": main[" (premature end-of-file)

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -3271,9 +3271,11 @@ process_special(COMPSTATE * cstat, const char *token)
 
 	    do {
 		varspec = next_token(cstat);
-		if (!varspec)
+		if (!varspec) {
+                    free_intermediate_node(nu);
 		    abort_compile(cstat,
 				  "Unexpected end of file within procedure arguments declaration.");
+                }
 
 		if (!strcmp(varspec, "]")) {
 		    argsdone = 1;

--- a/src/compile.c
+++ b/src/compile.c
@@ -3291,6 +3291,7 @@ process_special(COMPSTATE * cstat, const char *token)
 		    if (*varname) {
 			if (add_scopedvar(cstat, varname, PROG_UNTYPED) < 0) {
                             free((void *) varspec);
+                            free_intermediate_node(nu);
 			    abort_compile(cstat, "Variable limit exceeded.");
                         }
 


### PR DESCRIPTION
Like `: main[` or something with too many arguments.