### PR TITLE
Don't crash when the struct tm* passed to format_time is null.

### DIFF
--- a/src/fbtime.c
+++ b/src/fbtime.c
@@ -46,6 +46,10 @@ ts_modifyobject(dbref thing)
 int
 format_time(char *buf, int max_len, const char *fmt, struct tm *tmval)
 {
+    if (!tmval) {
+        *buf = '\0';
+        return 0;
+    }
 
 #ifdef USE_STRFTIME
     return (strftime(buf, max_len, fmt, tmval));


### PR DESCRIPTION
At least glibc's localtime() can return a NULL struct tm when given a very large time_t (e.g. 100000000000000000), which otherwise triggers a NULL pointer dereference something like the MPI
"{ftime:%a,,100000000000000000}".