### PR TITLE
Typo patrol: Correctly report what CHECKARGS expects.

### DIFF
--- a/src/p_stack.c
+++ b/src/p_stack.c
@@ -624,7 +624,7 @@ prim_checkargs(PRIM_PROTOTYPE)
 		    if ((ref >= 0) && (Typeof(ref) != TYPE_THING))
 			ABORT_CHECKARGS("Expected thing dbref.");
 		    if (ref == HOME)
-			ABORT_CHECKARGS("Expected player dbref.");
+			ABORT_CHECKARGS("Expected thing dbref.");
 		    break;
 
 		case 'E':
@@ -634,7 +634,7 @@ prim_checkargs(PRIM_PROTOTYPE)
 		    if ((ref >= 0) && (Typeof(ref) != TYPE_EXIT))
 			ABORT_CHECKARGS("Expected exit dbref.");
 		    if (ref == HOME)
-			ABORT_CHECKARGS("Expected player dbref.");
+			ABORT_CHECKARGS("Expected exit dbref.");
 		    break;
 
 		case 'F':
@@ -644,7 +644,7 @@ prim_checkargs(PRIM_PROTOTYPE)
 		    if ((ref >= 0) && (Typeof(ref) != TYPE_PROGRAM))
 			ABORT_CHECKARGS("Expected program dbref.");
 		    if (ref == HOME)
-			ABORT_CHECKARGS("Expected player dbref.");
+			ABORT_CHECKARGS("Expected program dbref.");
 		    break;
 		}
 		break;


### PR DESCRIPTION
Since this is such a simple and easy thing to fix, I figured I'd just do it rather than open an issue pointing the problem out.

This changes `CHECKARGS` to correctly report what it expects when it encounters HOME (#-3) at argument specifiers "t", "e", or "f".