### PR TITLE
do_get: don't try to find Typeof(NOTHING) if someone does 'get #0'.

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -569,7 +569,7 @@ do_get(int descr, dbref player, const char *what, const char *obj)
 	    }
 	}
 	if (Typeof(player) != TYPE_PLAYER) {
-	    if (Typeof(LOCATION(thing)) != TYPE_ROOM) {
+	    if (LOCATION(thing) != NOTHING && Typeof(LOCATION(thing)) != TYPE_ROOM) {
 		if (OWNER(player) != OWNER(thing)) {
 		    notify(player, "Zombies aren't allowed to be thieves!");
 		    return;


### PR DESCRIPTION
This fixes an out-of-bounds heap access from running:
```
@create Zombie
@force Zombie=get #0
```
