### PR TITLE
diff3: CLEAR() correct number of items on abort_interp().

### DIFF
--- a/src/p_float.c
+++ b/src/p_float.c
@@ -289,7 +289,9 @@ prim_diff3(PRIM_PROTOTYPE)
     double x, y, z;
     double x2, y2, z2;
 
-    CHECKOP(6);
+    EXPECT_POP_STACK(6);
+    // three things to CLEAR on abort_interp()
+    nargs = 3;
     oper3 = POP();
     oper2 = POP();
     oper1 = POP();


### PR DESCRIPTION
Setting nargs = 6 keeps do_abort_interp() from clearing any of the oper1/2/3/4 variables, which can leak memory.