### PR TITLE
Add compile option for free'ing memory on exit

### DIFF
--- a/configure
+++ b/configure
@@ -685,6 +685,7 @@ enable_option_checking
 with_pcre
 with_ssl
 with_lint
+enable_memcleanup
 enable_memprof
 enable_debug
 enable_ipv6
@@ -1307,6 +1308,7 @@ Optional Features:
   --disable-option-checking  ignore unrecognized --enable/--with options
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
+  --enable-memcleanup        free all memory on exit (for memory debugging tools)
   --enable-memprof           enable memory leak detection and profiling (slow)
   --enable-debug             enable developer assertions
   --enable-ipv6             enable IPv6-support
@@ -3907,11 +3909,25 @@ $as_echo "#define WITH_LINT /**/" >>confdefs.h
 fi
 
 
+# Check whether --enable-memcleanup was given.
+if test "${enable_memcleanup+set}" = set; then :
+  enableval=$enable_memcleanup;
+if test "$enableval" = yes; then
+
+$as_echo "#define MEMORY_CLEANUP /**/" >>confdefs.h
+
+fi
+
+fi
+
+
 # Check whether --enable-memprof was given.
 if test "${enable_memprof+set}" = set; then :
   enableval=$enable_memprof;
 if test "$enableval" = yes; then
 	$as_echo "#define MALLOC_PROFILING 1" >>confdefs.h
+
+        $as_echo "#define MEMORY_CLEANUP 1" >>confdefs.h
 
 else
 	if test "$enableval" = debug; then

--- a/configure
+++ b/configure
@@ -685,7 +685,7 @@ enable_option_checking
 with_pcre
 with_ssl
 with_lint
-enable_memcleanup
+enable_memory_cleanup
 enable_memprof
 enable_debug
 enable_ipv6
@@ -1308,7 +1308,7 @@ Optional Features:
   --disable-option-checking  ignore unrecognized --enable/--with options
   --disable-FEATURE       do not include FEATURE (same as --enable-FEATURE=no)
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
-  --enable-memcleanup        free all memory on exit (for memory debugging tools)
+  --enable-memory-cleanup        free all memory on exit (for memory debugging tools)
   --enable-memprof           enable memory leak detection and profiling (slow)
   --enable-debug             enable developer assertions
   --enable-ipv6             enable IPv6-support
@@ -3909,9 +3909,9 @@ $as_echo "#define WITH_LINT /**/" >>confdefs.h
 fi
 
 
-# Check whether --enable-memcleanup was given.
-if test "${enable_memcleanup+set}" = set; then :
-  enableval=$enable_memcleanup;
+# Check whether --enable-memory-cleanup was given.
+if test "${enable_memory_cleanup+set}" = set; then :
+  enableval=$enable_memory_cleanup;
 if test "$enableval" = yes; then
 
 $as_echo "#define MEMORY_CLEANUP /**/" >>confdefs.h

--- a/configure.ac
+++ b/configure.ac
@@ -179,7 +179,7 @@ AC_ARG_ENABLE(memcleanup,
 [  --enable-memcleanup        free all memory on exit (for memory debugging tools)],
 [
 if test "$enableval" = yes; then
-	AC_DEFINE(MEMORY_CLEANUP, [], [Enable memory usage profiling.])
+	AC_DEFINE(MEMORY_CLEANUP, [], [Enable freeing memory on exit.])
 fi
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -175,8 +175,8 @@ AC_DEFINE(WITH_LINT, [], [Makefile is configured to run lint on sources.])
 AC_SUBST(LINT)
 ])
 
-AC_ARG_ENABLE(memcleanup,
-[  --enable-memcleanup        free all memory on exit (for memory debugging tools)],
+AC_ARG_ENABLE(memory-cleanup,
+[  --enable-memory-cleanup        free all memory on exit (for memory debugging tools)],
 [
 if test "$enableval" = yes; then
 	AC_DEFINE(MEMORY_CLEANUP, [], [Enable freeing memory on exit.])

--- a/configure.ac
+++ b/configure.ac
@@ -175,11 +175,20 @@ AC_DEFINE(WITH_LINT, [], [Makefile is configured to run lint on sources.])
 AC_SUBST(LINT)
 ])
 
+AC_ARG_ENABLE(memcleanup,
+[  --enable-memcleanup        free all memory on exit (for memory debugging tools)],
+[
+if test "$enableval" = yes; then
+	AC_DEFINE(MEMORY_CLEANUP, [], [Enable memory usage profiling.])
+fi
+])
+
 AC_ARG_ENABLE(memprof,
 [  --enable-memprof           enable memory leak detection and profiling (slow)],
 [
 if test "$enableval" = yes; then
 	AC_DEFINE(MALLOC_PROFILING)
+        AC_DEFINE(MEMORY_CLEANUP)
 else
 	if test "$enableval" = debug; then
 		AC_DEFINE(MALLOC_PROFILING, [], [Enables memory usage profiling.])

--- a/include/autoconf.h.in
+++ b/include/autoconf.h.in
@@ -149,6 +149,9 @@
 /* With MALLOC_PROFILING, can detect double-frees, buffer overruns, etc. */
 #undef MALLOC_PROFILING_EXTRA
 
+/* Enable freeing memory on exit. */
+#undef MEMORY_CLEANUP
+
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT
 

--- a/src/edit.c
+++ b/src/edit.c
@@ -225,7 +225,7 @@ kill_macro(const char *macroname, dbref player, struct macrotable **mtop)
 	return (0);
 }
 
-#ifdef MALLOC_PROFILING
+#ifdef MEMORY_CLEANUP
 void
 free_old_macros(void)
 {

--- a/src/game.c
+++ b/src/game.c
@@ -48,6 +48,9 @@ const char *compile_options =
 #ifdef MALLOC_PROFILING
 	"MEMPROF "
 #endif
+#ifdef MEMORY_CLEANUP
+        "MEMCLEANUP "
+#endif
 #ifdef MCP_SUPPORT
 	"MCP "
 #endif
@@ -410,7 +413,7 @@ init_game(const char *infile, const char *outfile)
     return 0;
 }
 
-#ifdef MALLOC_PROFILING
+#ifdef MEMORY_CLEANUP
 void
 cleanup_game()
 {

--- a/src/interface.c
+++ b/src/interface.c
@@ -4602,7 +4602,7 @@ main(int argc, char **argv)
         }
 #endif
 
-#ifdef MALLOC_PROFILING
+#ifdef MEMORY_CLEANUP
 	db_free();
 	free_old_macros();
 	purge_all_free_frames();

--- a/src/interp.c
+++ b/src/interp.c
@@ -339,7 +339,7 @@ purge_free_frames(void)
     }
 }
 
-#ifdef MALLOC_PROFILING
+#ifdef MEMORY_CLEANUP
 void
 purge_all_free_frames(void)
 {

--- a/src/mcp.c
+++ b/src/mcp.c
@@ -12,10 +12,6 @@
 #include "mcp.h"
 #include "mcppkg.h"
 
-#ifdef HAVE_MALLOC_H
-#include <malloc.h>
-#endif				/* HAVE_MALLOC_H */
-
 #define EMCP_SUCCESS             0      /* successful result */
 #define EMCP_NOMCP                      -1      /* MCP isn't supported on this connection. */
 #define EMCP_NOPACKAGE          -2      /* Package isn't supported for this connection. */

--- a/src/mcpgui.c
+++ b/src/mcpgui.c
@@ -7,10 +7,6 @@
 #include "mcpgui.h"
 #include "mcppkg.h"
 
-#ifdef HAVE_MALLOC_H
-#include <malloc.h>
-#endif				/* HAVE_MALLOC_H */
-
 static DlogData *dialog_list = NULL;
 static DlogData *dialog_last_accessed = NULL;
 

--- a/src/timequeue.c
+++ b/src/timequeue.c
@@ -147,7 +147,7 @@ free_timenode(timequeue ptr)
     }
 }
 
-#ifdef MALLOC_PROFILING
+#ifdef MEMORY_CLEANUP
 void
 purge_timenode_free_pool(void)
 {

--- a/src/tune.c
+++ b/src/tune.c
@@ -481,7 +481,7 @@ tune_get_parmstring(const char *name, int mlev)
     return (buf);
 }
 
-#ifdef MALLOC_PROFILING
+#ifdef MEMORY_CLEANUP
 void
 tune_freeparms()
 {


### PR DESCRIPTION
When running leak detection tools like AddressSanitizer, its useful if the MUCK frees memory on exit. Currently this is done when malloc profiling is turned on, but not otherwise. This patch should make this a separate option which is also enabled by enabling malloc profiling.