### PR TITLE
Handle MUCK_LOCALTIME() failing on huge time_ts.

### DIFF
--- a/src/mfuns.c
+++ b/src/mfuns.c
@@ -1523,7 +1523,12 @@ mfn_ftime(MFUNARGS)
 	lt -= get_tz_offset();
     }
 
-    strftime(buf, BUFFER_LEN - 1, argv[0], MUCK_LOCALTIME(lt));
+    struct tm *tm = MUCK_LOCALTIME(lt);
+    if (tm) {
+        strftime(buf, BUFFER_LEN - 1, argv[0], MUCK_LOCALTIME(lt));
+    } else {
+        ABORT_MPI("FTIME", "Out of range time argument.");
+    }
     return buf;
 }
 

--- a/src/p_misc.c
+++ b/src/p_misc.c
@@ -107,6 +107,9 @@ prim_timesplit(PRIM_PROTOTYPE)
 
     time_tm = MUCK_LOCALTIME(lt);
 
+    if (!time_tm)
+        abort_interp("Out of range time argument");
+
     CHECKOFLOW(8);
     CLEAR(oper1);
     result = time_tm->tm_sec;
@@ -143,6 +146,8 @@ prim_timefmt(PRIM_PROTOTYPE)
 	abort_interp("Invalid argument (2)");
     lt = (time_t) oper2->data.number;
     time_tm = MUCK_LOCALTIME(lt);
+    if (!time_tm)
+        abort_interp("Out of range time argument");
     if (!strftime(buf, BUFFER_LEN, oper1->data.string->data, time_tm))
 	abort_interp("Operation would result in overflow.");
     CHECKOFLOW(1);


### PR DESCRIPTION
Passing a huge time_t to localtime() can make it return NULL. This patch makes doing this from MUF or MPI result in an error instead of crashing the MUCK.