### PR TITLE
clear old propnode values in copy_proplist

### DIFF
--- a/src/props.c
+++ b/src/props.c
@@ -354,6 +354,7 @@ copy_proplist(dbref obj, PropPtr * nu, PropPtr old)
 	propfetch(obj, old);
 #endif
 	p = new_prop(nu, PropName(old));
+        clear_propnode(p);
 	SetPFlagsRaw(p, PropFlagsRaw(old));
 	switch (PropType(old)) {
 	case PROP_STRTYP:


### PR DESCRIPTION
copy_proplist() can overwrite property values without freeing old values. This can be triggered by calling COPYPLAYER, where the pname history property will be generated, then may be immediately overwritten by the copy, causing a memory leak of the original string.