### PR TITLE
check bounds when stripping trailing spaces in parse_boolexp_F

### DIFF
--- a/src/boolexp.c
+++ b/src/boolexp.c
@@ -190,7 +190,7 @@ parse_boolexp_F(int descr, const char **parsebuf, dbref player, int dbloadp)
 	}
 	/* strip trailing whitespace */
 	*p-- = '\0';
-	while (isspace(*p))
+	while (p >= buf && isspace(*p))
 	    *p-- = '\0';
 
 	/* check to see if this is a property expression */


### PR DESCRIPTION
This seems to fix one of the bugs mentioned in #126.
