### PR TITLE
free auxillary CONTROL_STACK data on compile error

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -221,6 +221,8 @@ cleanup(COMPSTATE * cstat)
 
     for (struct CONTROL_STACK *eef = cstat->control_stack; eef; eef = tempif) {
 	tempif = eef->next;
+        if (eef->extra)
+            free(eef->extra);
 	free((void *) eef);
     }
     cstat->control_stack = 0;


### PR DESCRIPTION
This seems to fix the memory leak on compiling ': main FOR IF BREAK' mentioned in #126.