### PR TITLE
don't let [abc] SMATCH end of string

### DIFF
--- a/src/fbstrings.c
+++ b/src/fbstrings.c
@@ -900,6 +900,9 @@ cmatch(char *s1, char c1)
 {
     int truthval = 0;
 
+    if (c1 == '\0')
+        return 1;
+
     c1 = tolower(c1);
     if (*s1 == '^') {
 	s1++;


### PR DESCRIPTION
This should fix an out-of-bounds read mentioned in #126.