### PR TITLE
Do not use CHECKOP() when oper* variables aren't being used.

### DIFF
--- a/src/p_stack.c
+++ b/src/p_stack.c
@@ -23,8 +23,7 @@ prim_pop(PRIM_PROTOTYPE)
 void
 prim_dup(PRIM_PROTOTYPE)
 {
-    CHECKOP_READONLY(1);
-    nargs = 0;
+    EXPECT_READ_STACK(1);
     CHECKOFLOW(1);
     copyinst(&arg[*top - 1], &arg[*top]);
     (*top)++;
@@ -33,7 +32,7 @@ prim_dup(PRIM_PROTOTYPE)
 void
 prim_pdup(PRIM_PROTOTYPE)
 {
-    CHECKOP_READONLY(1);
+    EXPECT_READ_STACK(1);
     if (!false_inst(&arg[*top - 1])) {
 	CHECKOFLOW(1);
 	copyinst(&arg[*top - 1], &arg[*top]);
@@ -83,7 +82,7 @@ prim_dupn(PRIM_PROTOTYPE)
 void
 prim_ldup(PRIM_PROTOTYPE)
 {
-    CHECKOP_READONLY(1);
+    EXPECT_READ_STACK(1);
     nargs = 0;
 
     if (arg[*top - 1].type != PROG_INTEGER)
@@ -226,7 +225,7 @@ prim_swap(PRIM_PROTOTYPE)
 void
 prim_over(PRIM_PROTOTYPE)
 {
-    CHECKOP_READONLY(2);
+    EXPECT_READ_STACK(2);
     CHECKOFLOW(1);
     copyinst(&arg[*top - 2], &arg[*top]);
     (*top)++;


### PR DESCRIPTION
CHECKOP() sets nargs(), so abort_interp() will try to erroneously CLEAR
the appropriate number of oper* variables.

This fixes the assertion failure from `: main pop "" 0 over main and and ;` mentioned in #126. (The program makes the OVER primitive overflow the stack, which causes CHECKOFLOW() to trigger an abort that tries to clear oper1, which is null.) 