### PR TITLE
do not assert pop depth if err is set

### DIFF
--- a/src/interp.c
+++ b/src/interp.c
@@ -1684,7 +1684,7 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
 		tmp = atop;
 		prim_func[pc->data.number - 1] (player, program, mlev, pc, arg, &tmp, fr);
 #ifdef DEBUG
-                assert(expect_pop == actual_pop);
+                assert(expect_pop == actual_pop || err);
                 assert(expect_push_to == -1 || expect_push_to == tmp || err);
                 assert(expect_push_to != -1 || tmp <= atop);
 #endif


### PR DESCRIPTION
There are some times when we check argument-by-argument for correct types after checking for the number of arguments, for example, in array_n_diff.