### PR TITLE
reset nargs during CHECKOP stack depth check to avoid re-CLEAR() oper[1234]

### DIFF
--- a/include/interp.h
+++ b/include/interp.h
@@ -252,12 +252,14 @@ do { \
 
 #define CHECKOP_READONLY(N) \
 { \
+    nargs = (0); \
     EXPECT_READ_STACK(N); \
     nargs = (N); \
 }
 
 #define CHECKOP(N) \
 { \
+    nargs = (0); \
     EXPECT_POP_STACK(N); \
     nargs = (N); \
 }


### PR DESCRIPTION
EXPECT_POP/READ_STACK can call abort_interp() which uses nargs.