### PR TITLE
avoid compiling program from within program primitive (e.g. FORCE)

### DIFF
--- a/include/db.h
+++ b/include/db.h
@@ -271,6 +271,7 @@ typedef long object_flag_type;
 
 struct program_specific {
     unsigned short instances;	/* number of instances of this prog running */
+    unsigned short instances_in_primitive; /* number instances running a primitive */
     short curr_line;		/* current-line */
     int siz;			/* size of code */
     struct inst *code;		/* byte-compiled code */
@@ -290,6 +291,7 @@ struct program_specific {
 #define FREE_PROGRAM_SP(x)      { dbref foo = x; if(PROGRAM_SP(foo)) free(PROGRAM_SP(foo)); PROGRAM_SP(foo) = (struct program_specific *)NULL; }
 
 #define PROGRAM_INSTANCES(x)		(PROGRAM_SP(x)!=NULL?PROGRAM_SP(x)->instances:0)
+#define PROGRAM_INSTANCES_IN_PRIMITIVE(x)   (PROGRAM_SP(x)!=NULL?PROGRAM_SP(x)->instances_in_primitive:0)
 #define PROGRAM_CURR_LINE(x)		(PROGRAM_SP(x)->curr_line)
 #define PROGRAM_SIZ(x)			(PROGRAM_SP(x)->siz)
 #define PROGRAM_CODE(x)			(PROGRAM_SP(x)->code)
@@ -302,9 +304,12 @@ struct program_specific {
 
 #define PROGRAM_INC_INSTANCES(x)	(PROGRAM_SP(x)->instances++)
 #define PROGRAM_DEC_INSTANCES(x)	(PROGRAM_SP(x)->instances--)
+#define PROGRAM_INC_INSTANCES_IN_PRIMITIVE(x)	(PROGRAM_SP(x)->instances_in_primitive++)
+#define PROGRAM_DEC_INSTANCES_IN_PRIMITIVE(x)	(PROGRAM_SP(x)->instances_in_primitive--)
 #define PROGRAM_INC_PROF_USES(x)	(PROGRAM_SP(x)->profuses++)
 
 #define PROGRAM_SET_INSTANCES(x,y)	(PROGRAM_SP(x)->instances = y)
+#define PROGRAM_SET_INSTANCES_IN_PRIMITIVE(x,y)	(PROGRAM_SP(x)->instances_in_primitive = y)
 #define PROGRAM_SET_CURR_LINE(x,y)	(PROGRAM_SP(x)->curr_line = y)
 #define PROGRAM_SET_SIZ(x,y)		(PROGRAM_SP(x)->siz = y)
 #define PROGRAM_SET_CODE(x,y)		(PROGRAM_SP(x)->code = y)

--- a/src/compile.c
+++ b/src/compile.c
@@ -597,6 +597,9 @@ init_defs(COMPSTATE * cstat)
 void
 uncompile_program(dbref i)
 {
+    if (PROGRAM_INSTANCES_IN_PRIMITIVE(i) > 0) {
+        return;
+    }
     /* free program */
     (void) dequeue_prog(i, 1);
     free_prog(i);
@@ -1925,6 +1928,14 @@ do_compile(int descr, dbref player_in, dbref program_in, int force_err_display)
     const char *token;
     struct INTERMEDIATE *new_word;
     COMPSTATE cstat;
+
+    if (PROGRAM_INSTANCES_IN_PRIMITIVE(program_in) > 0) {
+        if (force_err_display ||
+            ((FLAGS(player_in) & INTERACTIVE) && !(FLAGS(player_in) & READMODE))) {
+            notify_nolisten(player_in, "Error: Cannot compile program from primitive it is running.", 1);
+        }
+        return;
+    }
 
     /* set all compile state variables */
     cstat.force_err_display = force_err_display;

--- a/src/db.c
+++ b/src/db.c
@@ -206,6 +206,7 @@ create_program(dbref player, const char *name)
     PROGRAM_SET_PROFSTART(newprog, 0);
     PROGRAM_SET_PROF_USES(newprog, 0);
     PROGRAM_SET_INSTANCES(newprog, 0);
+    PROGRAM_SET_INSTANCES_IN_PRIMITIVE(newprog, 0);
 
     PUSH(newprog, CONTENTS(player));
     DBDIRTY(newprog);
@@ -691,6 +692,7 @@ db_read_object(FILE * f, dbref objno, int dtype)
 	PROGRAM_SET_PROFSTART(objno, 0);
 	PROGRAM_SET_PROF_USES(objno, 0);
 	PROGRAM_SET_INSTANCES(objno, 0);
+        PROGRAM_SET_INSTANCES_IN_PRIMITIVE(objno, 0);
 	break;
     case TYPE_GARBAGE:
 	break;

--- a/src/interp.c
+++ b/src/interp.c
@@ -1676,13 +1676,16 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
 
 	    default:
 		nargs = 0;
+                fprintf(stderr, "about to run %s\n", base_inst[pc->data.number - 1]);
 #ifdef DEBUG
                 expect_pop = actual_pop = 0;
                 expect_push_to = -1;
 #endif
 		reload(fr, atop, stop);
 		tmp = atop;
+                PROGRAM_INC_INSTANCES_IN_PRIMITIVE(program);
 		prim_func[pc->data.number - 1] (player, program, mlev, pc, arg, &tmp, fr);
+                PROGRAM_DEC_INSTANCES_IN_PRIMITIVE(program);
 #ifdef DEBUG
                 assert(expect_pop == actual_pop || err);
                 assert(expect_push_to == -1 || expect_push_to == tmp || err);


### PR DESCRIPTION
This should address #156.

This patch adds to the program_specific struct to track when we are currently running a primitive for a program. This avoids breaking any programs that might rely on editing or uncompiling other programs in this way, though I'm not sure that's actually a concern.