### PR TITLE
Limit depth of MUF interpreter nesting for locks

### DIFF
--- a/include/defaults.h
+++ b/include/defaults.h
@@ -133,6 +133,11 @@
 /* Max # of instrs in uninterruptable muf programs before timeout. */
 #define MAX_INSTR_COUNT 20000
 
+/* Maximum number of nested interp calls (via the INTERP muf primitive,
+   MPI called via MUF, locks called via MUF, etc.) 
+ */
+#define MAX_INTERP_DEPTH 8
+
 /* Max # of instrs in uninterruptable muf programs before timeout at ML4. */
 #define MAX_ML4_PREEMPT_COUNT 0
 

--- a/include/interp.h
+++ b/include/interp.h
@@ -327,6 +327,7 @@ extern int expect_push_to;
 #endif
 extern int prim_count;
 extern const char *base_inst[];
+int interp_depth;
 
 struct forvars *copy_fors(struct forvars *);
 struct tryvars *copy_trys(struct tryvars *);

--- a/include/tune.h
+++ b/include/tune.h
@@ -123,6 +123,7 @@ extern int tp_listen_mlev;
 extern int tp_lookup_cost;
 extern int tp_max_force_level;
 extern int tp_max_instr_count;
+extern int tp_max_interp_depth;
 extern int tp_max_loaded_objs;
 extern int tp_max_ml4_preempt_count;
 extern int tp_max_plyr_processes;

--- a/include/tunelist.h
+++ b/include/tunelist.h
@@ -204,6 +204,7 @@ int tp_listen_mlev;
 int tp_lookup_cost;
 int tp_max_force_level;
 int tp_max_instr_count;
+int tp_max_interp_depth;
 int tp_max_loaded_objs;
 int tp_max_ml4_preempt_count;
 int tp_max_object_endowment;
@@ -266,6 +267,8 @@ struct tune_val_entry tune_val_list[] = {
      "Max. uninterrupted instructions per timeslice", "", 1, INSTR_SLICE},
     {"MUF", "max_instr_count", &tp_max_instr_count, 0, MLEV_WIZARD,
      "Max. MUF instruction run length for ML1", "", 1, MAX_INSTR_COUNT},
+    {"MUF", "max_interp_depth", &tp_max_interp_depth, 0, MLEV_WIZARD,
+     "Max. level of nested MUF interpreter calls", "", 1, MAX_INTERP_DEPTH},
     {"MUF", "max_ml4_preempt_count", &tp_max_ml4_preempt_count, 0, MLEV_WIZARD,
      "Max. MUF preempt instruction run length for ML4, (0 = no limit)", "", 1,
      MAX_ML4_PREEMPT_COUNT},

--- a/src/boolexp.c
+++ b/src/boolexp.c
@@ -8,6 +8,7 @@
 #include "interp.h"
 #include "match.h"
 #include "props.h"
+#include "tune.h"
 
 static struct boolexp *
 alloc_boolnode(void)
@@ -92,6 +93,9 @@ eval_boolexp_rec(int descr, dbref player, struct boolexp *b, dbref thing)
 		struct inst *rv;
 		struct frame *tmpfr;
 		dbref real_player;
+
+                if (interp_depth > tp_max_interp_depth)
+                    return 0;
 
 		if (Typeof(player) == TYPE_PLAYER || Typeof(player) == TYPE_THING)
 		    real_player = player;

--- a/src/interp.c
+++ b/src/interp.c
@@ -906,7 +906,7 @@ calc_profile_timing(dbref prog, struct frame *fr)
     }
 }
 
-static int interp_depth = 0;
+int interp_depth = 0;
 
 static void
 interp_err(dbref player, dbref program, struct inst *pc,

--- a/src/p_stack.c
+++ b/src/p_stack.c
@@ -6,6 +6,7 @@
 #include "fbstrings.h"
 #include "inst.h"
 #include "interp.h"
+#include "tune.h"
 
 #include <limits.h>
 
@@ -806,7 +807,7 @@ prim_interp(PRIM_PROTOTYPE)
 	abort_interp("Bad object. (2)");
     if ((mlev < 3) && !permissions(ProgUID, oper2->data.objref))
 	abort_interp("Permission denied.");
-    if (fr->level > 8)
+    if (fr->level > tp_max_interp_depth)
 	abort_interp("Interp call loops not allowed.");
     CHECKREMOTE(oper2->data.objref);
 


### PR DESCRIPTION
Also turns max interpreter nesting limit into an `@tune`.