### PR TITLE
Add setting to limit total number of interp_loop calls in any interp_loop

### DIFF
--- a/include/defaults.h
+++ b/include/defaults.h
@@ -136,6 +136,12 @@
 /* Max # of instrs in uninterruptable muf programs before timeout at ML4. */
 #define MAX_ML4_PREEMPT_COUNT 0
 
+/* Max # of recursive interpreter calls at ML4. */
+#define MAX_ML4_NESTED_INTERP_LOOP_COUNT 0
+
+/* Max # of recursive interpreter calls other than at ML4. */
+#define MAX_NESTED_INTERP_LOOP_COUNT 16
+
 /* INSTR_SLICE is the number of instructions to run before forcing a
  * context switch to the next waiting muf program.  This is for the
  * multitasking interpreter.

--- a/include/tune.h
+++ b/include/tune.h
@@ -125,6 +125,8 @@ extern int tp_max_force_level;
 extern int tp_max_instr_count;
 extern int tp_max_loaded_objs;
 extern int tp_max_ml4_preempt_count;
+extern int tp_max_ml4_nested_interp_loop_count;
+extern int tp_max_nested_interp_loop_count;
 extern int tp_max_plyr_processes;
 extern int tp_max_process_limit;
 extern int tp_max_object_endowment;

--- a/include/tunelist.h
+++ b/include/tunelist.h
@@ -206,6 +206,8 @@ int tp_max_force_level;
 int tp_max_instr_count;
 int tp_max_loaded_objs;
 int tp_max_ml4_preempt_count;
+int tp_max_ml4_nested_interp_loop_count;
+int tp_max_nested_interp_loop_count;
 int tp_max_object_endowment;
 int tp_max_output;
 int tp_max_pennies;
@@ -269,6 +271,12 @@ struct tune_val_entry tune_val_list[] = {
     {"MUF", "max_ml4_preempt_count", &tp_max_ml4_preempt_count, 0, MLEV_WIZARD,
      "Max. MUF preempt instruction run length for ML4, (0 = no limit)", "", 1,
      MAX_ML4_PREEMPT_COUNT},
+    {"MUF", "max_ml4_nested_interp_loop_count", &tp_max_ml4_nested_interp_loop_count, 0, MLEV_WIZARD,
+     "Max. MUF preempt interp loop nesting level for ML4 (0 = no limit)", "", 1,
+     MAX_ML4_NESTED_INTERP_LOOP_COUNT},
+    {"MUF", "max_nested_interp_loop_count", &tp_max_nested_interp_loop_count, 0, MLEV_WIZARD,
+     "Max. MUF preempt interp loop nesting level", "", 1,
+     MAX_NESTED_INTERP_LOOP_COUNT},
     {"MUF", "max_plyr_processes", &tp_max_plyr_processes, 0, MLEV_WIZARD,
      "Concurrent processes allowed per player", "", 1, MAX_PLYR_PROCESSES},
     {"MUF", "max_process_limit", &tp_max_process_limit, 0, MLEV_WIZARD,

--- a/src/interp.c
+++ b/src/interp.c
@@ -1085,14 +1085,14 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
 		    instr_count = 0;
                 if (tp_max_ml4_nested_interp_loop_count)
                     if (nested_interp_loop_count >= tp_max_ml4_nested_interp_loop_count)
-                        abort_loop_hard("Maximum interp loop nested depth exceeded in preempt mode",
+                        abort_loop_hard("Maximum interp loop nested call count exceeded in preempt mode",
                                         NULL, NULL);
 	    } else {
 		/* else make sure that the program doesn't run too long */
 		if (instr_count >= tp_max_instr_count)
 		    abort_loop_hard("Maximum preempt instruction count exceeded", NULL, NULL);
                 if (nested_interp_loop_count >= tp_max_nested_interp_loop_count)
-                    abort_loop_hard("Maximum interp loop nested depth exceeded in preempt mode",
+                    abort_loop_hard("Maximum interp loop nested call count exceeded in preempt mode",
                                     NULL, NULL);
 	    }
 	} else {


### PR DESCRIPTION
This limits the total number of interp calls before returning control
to the event queue (not just the nesting depth). This ensures that there is
a limit on how long MUF code can run before commands are read even
in the case of massive recursive program uninterruptible program
executions.

This adds two `@tune`s, one for the setting for mucker level 4 programs, one otherwise.

When programs are not in preempt mode, hitting the limit causes them to enqueue themselves on the timequeue. Otherwise, they are aborted.

This addresses #162, though perhaps default limits should be lower.