### PR TITLE
CHECKREMOTE: tolerate HOME (#-3).

### DIFF
--- a/include/interp.h
+++ b/include/interp.h
@@ -264,7 +264,8 @@ do { \
     nargs = (N); \
 }
 
-#define CHECKREMOTE(x) if ((mlev < 2) && (LOCATION(x) != player) &&  \
+#define CHECKREMOTE(x) if ((mlev < 2) && ((x) != HOME) && \
+                           (LOCATION(x) != player) &&  \
                            (LOCATION(x) != LOCATION(player)) && \
                            ((x) != LOCATION(player)) && ((x) != player) \
 			   && !controls(ProgUID, x)) \


### PR DESCRIPTION
The program?/etc. primitives can pass #-3 to CHECKREMOTE.