### PR TITLE
Nonwiz bound and bound rooms

### DIFF
--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -37,7 +37,7 @@ git pull
 * See ```./configure --help```
  * Common options include ```--with-ssl```, ```--enable-ipv6```
  * If needed, specify SSL headers via ```--with-ssl=/path/to/dir```, or PCRE headers via ```--with-pcre=/path/to/dir```
-* When testing, use a different ```--prefix```, e.g. ```./configure --prefix="$HOME/fuzzball-test"``` (it may be helpful to use a shell variable like ```$PREFIX```)
+* When testing, use a different ```--prefix```, e.g. ```./configure --prefix="$HOME/fuzzball-test"```
 
 ### Build
 ```sh

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -37,7 +37,7 @@ git pull
 * See ```./configure --help```
  * Common options include ```--with-ssl```, ```--enable-ipv6```
  * If needed, specify SSL headers via ```--with-ssl=/path/to/dir```, or PCRE headers via ```--with-pcre=/path/to/dir```
-* When testing, use a different ```--prefix```, e.g. ```./configure --prefix="$HOME/fuzzball-test"```
+* When testing, use a different ```--prefix```, e.g. ```./configure --prefix="$HOME/fuzzball-test"``` (it may be helpful to use a shell variable like ```$PREFIX```)
 
 ### Build
 ```sh

--- a/game/data/help.txt
+++ b/game/data/help.txt
@@ -1348,6 +1348,10 @@ multitasking mode that the process had before calling this program.  When
 the execution exits this program, the multitasking mode returns to what
 it was before the function was called.  This lets libraries of atomic
 functions be written.
+
+  This flag is also called BOUND when it is set on rooms. An exit attached to
+a thing or player and linked to a player or room will not work when the object
+to which it is attached is in a room set BOUND.
 ~
 ~
 CHOWN_OK|COLOR

--- a/src/set.c
+++ b/src/set.c
@@ -451,17 +451,37 @@ restricted(dbref player, dbref thing, object_flag_type flag)
 	/* You cannot quell or unquell another wizard. */
 	return (TrueWizard(thing) && (thing != player) && (Typeof(thing) == TYPE_PLAYER));
 #endif
+	/* The following three cases aren't used, as far as I can tell, but
+	 * for consistency's sake let's make sure they reflect the documented
+	 * behaviors: */
     case MUCKER:
+	/* Setting a program M2 is limited to players of at least M2. */
+	if (Typeof(thing) == TYPE_PROGRAM)
+	    return (MLevel(OWNER(player)) < 2);
+	/* Setting anything else M2 takes a wizard. */
+	return (!Wizard(OWNER(player)));
     case SMUCKER:
+	/* Setting a program M1 is limited to players of at least M1. */
+	if (Typeof(thing) == TYPE_PROGRAM)
+	    return (MLevel(OWNER(player)) < 1);
+	/* Setting anything else M1 takes a wizard. */
+	return (!Wizard(OWNER(player)));
     case (SMUCKER | MUCKER):
+	/* Setting a program M3 is limited to players of at least M3. */
+	if (Typeof(thing) == TYPE_PROGRAM)
+	    return (MLevel(OWNER(player)) < 3);
+	/* Setting anything else M3 takes a wizard. */
+	return (!Wizard(OWNER(player)));
     case BUILDER:
-	/* Would someone tell me why setting a program SMUCKER|MUCKER doesn't
-	 * go through here? -winged */
 	/* Setting a program Bound causes any function called therein to be
 	 * put in preempt mode, regardless of the mode it had before.
 	 * Since this is just a convenience for atomic-functionwriters,
 	 * why is it limited to only a Wizard? -winged */
-	/* Setting a player Builder is limited to a Wizard. */
+	/* That's a very good question! Let's limit it to players of at
+	 * least M2 instead. -aidanPB */
+	if (Typeof(thing) == TYPE_PROGRAM)
+	    return (MLevel(OWNER(player)) < 2);
+	/* Setting a player Builder or a room Bound is limited to a Wizard. */
 	return (!Wizard(OWNER(player)));
     case WIZARD:
 	/* To do anything with a Wizard flag requires a Wizard. */


### PR DESCRIPTION
This PR introduces three changes:
1. Players of at least M2 may now set programs ```BOUND```;
2. The use of ```BOUND``` on rooms is now mentioned in user-visible documentation; and,
3. Even though the ```int restricted(dbref player, dbref thing, object_flag_type flag)``` function in set.c isn't called for M1, M2, or M3, their cases in that function now return appropriate values.