### PR TITLE
push forceing players/zombies on forcelist

### DIFF
--- a/src/mfuns2.c
+++ b/src/mfuns2.c
@@ -1553,12 +1553,14 @@ mfn_force(MFUNARGS)
 	if (lookup_player(objname) != NOTHING && Typeof(obj) != TYPE_PLAYER) {
 	    ABORT_MPI("FORCE", "Cannot force a thing named after a player. [2]");
 	}
+        objnode_push(&forcelist, player);
 	objnode_push(&forcelist, what);
 	force_level++;
 	if (*ptr)
 	    process_command(dbref_first_descr(obj), obj, ptr);
 	force_level--;
 	objnode_pop(&forcelist);
+        objnode_pop(&forcelist);
 	ptr = nxt;
     } while (ptr);
     *buf = '\0';

--- a/src/p_misc.c
+++ b/src/p_misc.c
@@ -266,11 +266,13 @@ prim_force(PRIM_PROTOTYPE)
     if (God(oper2->data.objref) && !God(OWNER(program)))
 	abort_interp("Cannot force god (1).");
 #endif
+    objnode_push(&forcelist, player);
     objnode_push(&forcelist, program);
     force_level++;
     process_command(dbref_first_descr(oper2->data.objref), oper2->data.objref,
 		    oper1->data.string->data);
     force_level--;
+    objnode_pop(&forcelist);
     objnode_pop(&forcelist);
 
     for (int i = 1; i <= fr->caller.top; i++) {


### PR DESCRIPTION
This allows recycle() to avoid recycling a thing currently running a program that is force'ing the recycle to happen.

This also changes what FORCEDBY_ARRAY returns.