### PR TITLE
ci: Use AppVeyor's default build numbers

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,13 +15,16 @@ init:
     # Thanks to @jakoch and @ronaldbarendse
     # Modified to also include the build number, distinguishes rebuilds of the same commit
     # See comments on https://github.com/appveyor/ci/issues/691
+    #
+    # While it's possible to use 'Update-AppveyorBuild -Version' to change the build number, that
+    # breaks Github's "Details" link until the build completes.  Just change the build output.
     - ps: |
         if ($env:APPVEYOR_REPO_TAG -eq "true")
         {
             # Trim any starting 'v' from tags
-            Update-AppveyorBuild -Version "$($env:APPVEYOR_REPO_TAG_NAME.TrimStart("v"))-$env:APPVEYOR_BUILD_NUMBER"
+            $env:DEPLOY_IMAGE_NAME = "$($env:APPVEYOR_REPO_TAG_NAME.TrimStart("v"))-$env:APPVEYOR_BUILD_NUMBER"
         } else {
-            Update-AppveyorBuild -Version "dev-$($env:APPVEYOR_REPO_COMMIT.Substring(0, 8))-$env:APPVEYOR_BUILD_NUMBER"
+            $env:DEPLOY_IMAGE_NAME = "dev-$($env:APPVEYOR_REPO_COMMIT.Substring(0, 8))-$env:APPVEYOR_BUILD_NUMBER"
         }
 
 build_script:
@@ -44,7 +47,7 @@ build_script:
 
         # Package and store the build results
         # > File name of compressed output
-        $artifact_name = "fuzzball-win32-$env:APPVEYOR_BUILD_VERSION"
+        $artifact_name = "fuzzball-win32-$env:DEPLOY_IMAGE_NAME"
         # > Folder name stored inside compressed output
         #   Don't include "...-$env:APPVEYOR_BUILD_VERSION" as that's now part of the artifact name
         $artifact_root = "$env:APPVEYOR_BUILD_FOLDER/$artifact_name"


### PR DESCRIPTION
## In short
* Use branch/commit info only for packaging; don't change AppVeyor build numbers
  * Builds from before this commit won't be changed
  * Fixes Github's `Details` link for in-progress builds giving a `404`
  * Partially reverts 233f40c76f1b38e8556f407379703dbff330aea8

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Fixes Github links for unfinished builds, dev. quality of life
Risk | ★☆☆ *1/3* | Changes build URLs for future AppVeyor builds, easily revertable
Intrusiveness | ★☆☆ *1/3* | Build system changes, shouldn't interfere with other pull requests

## Rationale
Unfortunately, Github only updates the build link when AppVeyor finishes building.  If one tries viewing a build before it's done, the `Details` link returns a `404` as it points to the old build version.  Having the `Details` link work when a build hangs seems more important than having fancy links to point to.

## Examples
### Before
**Link**
https://ci.appveyor.com/project/digitalcircuit/fuzzball/build/dev-1d00e7b0-218
*Github does* ***not*** *point to this link until build is finished*

**File name**
```
fuzzball-win32-dev-1d00e7b0-218.zip
```

### After
**Link**
https://ci.appveyor.com/project/digitalcircuit/fuzzball/build/219
*Github always points to this link, during and after build*

**File name**
```
fuzzball-win32-dev-df828458-219.zip
```