### PR TITLE
docs: Update README Markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Fuzzball also offers a built-in help system.  Connect, then type ```help``` for 
 
 ## Downloads
 * **Stable**
- * *Tested and supported, recommended for everyday usage*
- * **Linux**: download from [the Fuzzball homepage][web-home], follow the steps in [the Linux README][docs-buildsrc-lin], skipping *Get Source*
- * **Windows**: download from [the Fuzzball homepage][web-home], follow the steps under *Running* in [the Windows README](README_WINDOWS.md#running)
+  * *Tested and supported, recommended for everyday usage*
+  * **Linux**: download from [the Fuzzball homepage][web-home], follow the steps in [the Linux README][docs-buildsrc-lin], skipping *Get Source*
+  * **Windows**: download from [the Fuzzball homepage][web-home], follow the steps under *Running* in [the Windows README](README_WINDOWS.md#running)
 * **Development**
- * *Try out the latest features and help find issues, but if it breaks you get to keep all the pieces*
- * **Linux**: follow the steps in [the Linux README][docs-buildsrc-lin].
- * **Windows**: download a pre-built package from [the Appveyor build artifacts page](https://ci.appveyor.com/project/fuzzball-muck/fuzzball/branch/master/artifacts), follow the steps under *Running* in [the Windows README](README_WINDOWS.md#running).
+  * *Try out the latest features and help find issues, but if it breaks you get to keep all the pieces*
+  * **Linux**: follow the steps in [the Linux README][docs-buildsrc-lin].
+  * **Windows**: download a pre-built package from [the Appveyor build artifacts page](https://ci.appveyor.com/project/fuzzball-muck/fuzzball/branch/master/artifacts), follow the steps under *Running* in [the Windows README](README_WINDOWS.md#running).
 
 ### Building and Running from Source
 * [Linux README][docs-buildsrc-lin]

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -35,8 +35,8 @@ git pull
 ./configure --with-ssl --enable-ipv6 # Or choose your own options
 ```
 * See ```./configure --help```
- * Common options include ```--with-ssl```, ```--enable-ipv6```
- * If needed, specify SSL headers via ```--with-ssl=/path/to/dir```, or PCRE headers via ```--with-pcre=/path/to/dir```
+  * Common options include ```--with-ssl```, ```--enable-ipv6```
+  * If needed, specify SSL headers via ```--with-ssl=/path/to/dir```, or PCRE headers via ```--with-pcre=/path/to/dir```
 * When testing, use a different ```--prefix```, e.g. ```./configure --prefix="$HOME/fuzzball-test"```
 
 ### Build

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -10,14 +10,14 @@ Tools needed:
 
 ### Get source
 * First time
- * Open a Git Bash shell in the desired folder (*if Windows Explorer integration is active, right-click, ```Git Bash```*)
+  * Open a Git Bash shell in the desired folder (*if Windows Explorer integration is active, right-click, ```Git Bash```*)
 ```sh
 cd ~          # Or any other desired directory
 git clone     https://github.com/fuzzball-muck/fuzzball.git
 cd fuzzball
 ```
 * To update
- * Open a Git Bash shell
+  * Open a Git Bash shell
 ```sh
 cd ~/fuzzball  # Same path as above, plus the 'fuzzball' directory
 git pull
@@ -27,8 +27,8 @@ git pull
 ### Configure
 *Use the Windows command prompt instead of Git Bash*
 * Set up Visual Studio environment variables
- * Use ```Program Files``` instead of ```Program Files (x86)``` if on a 32-bit machine
- * Fuzzball does not currently support compiling as 64-bit
+  * Use ```Program Files``` instead of ```Program Files (x86)``` if on a 32-bit machine
+  * Fuzzball does not currently support compiling as 64-bit
 ```bat
 "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 ```


### PR DESCRIPTION
## In short
* Update README Markdown formatting to be consistent

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Fixes appearance of developer docs, first impressions
Risk | ★☆☆ *1/3* | No functional changes, trivial to revert
Intrusiveness | ★☆☆ *1/3* | Only touches README, shouldn't interfere with other pull requests

## Rationale
A while back Github changed required indentation for their Github-flavored Markdown, among other steps to unify with CommonMark.  This fixes the formatting to show as it should.

See: [Github Engineering blog: A formal spec for GitHub Flavored Markdown](https://githubengineering.com/a-formal-spec-for-github-markdown/ )

## Examples
### Before
[README.md as of 73676ce5b29e5d638512c3a03884994e05b9d1c5](https://github.com/fuzzball-muck/fuzzball/blob/73676ce5b29e5d638512c3a03884994e05b9d1c5/README.md#downloads )

### After
[README.md from this pull request](https://github.com/digitalcircuit/fuzzball/blob/fix-readme-mkdn/README.md#downloads )