### PR TITLE
Docfix: MUF primitives MD5HASH and SHA1HASH

### DIFF
--- a/game/data/man.txt
+++ b/game/data/man.txt
@@ -2800,14 +2800,14 @@ Also see: STRENCRYPT
 ~
 ~
 MD5HASH
-MD5HASH ( s -- )
+MD5HASH ( s -- s' )
 
   Calculates the MD5 hash of the given string.
 Also see: SHA1HASH
 ~
 ~
 SHA1HASH
-SHA1HASH ( s -- )
+SHA1HASH ( s -- s' )
 
   Calculates the SHA1 hash of the given string.
 Also see: MD5HASH

--- a/game/data/mufman.raw
+++ b/game/data/mufman.raw
@@ -2548,14 +2548,14 @@ the plaintext string s3.
 ~
 ~
 MD5HASH
-MD5HASH ( s -- )
+MD5HASH ( s -- s' )
 
   Calculates the MD5 hash of the given string.
 ~~alsosee SHA1HASH
 ~
 ~
 SHA1HASH
-SHA1HASH ( s -- )
+SHA1HASH ( s -- s' )
 
   Calculates the SHA1 hash of the given string.
 ~~alsosee MD5HASH


### PR DESCRIPTION
The stack-effect comments in the documentation for the MUF primitives `MD5HASH` and `SHA1HASH` were `( s -- )`, as though the hash string was being stored in a system variable or something. This PR corrects them to `( s -- s' )` in both mufman.raw and man.txt.