### PR TITLE
Added MCP package org-fuzzball-languages.

### DIFF
--- a/include/mcppkg.h
+++ b/include/mcppkg.h
@@ -5,6 +5,7 @@
 #define _MCPPKG_H
 
 void mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context);
+void mcppkg_languages(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context);
 void mcppkg_help_request(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context);
 void show_mcp_error(McpFrame * mfr, char *topic, char *text);
 

--- a/src/mcp.c
+++ b/src/mcp.c
@@ -619,10 +619,9 @@ mcp_initialize(void)
     mcp_package_register(MCP_NEGOTIATE_PKG, oneoh, twooh, mcp_negotiate_handler, NULL, NULL);
     mcp_package_register("org-fuzzball-help", oneoh, oneoh, mcppkg_help_request, NULL, NULL);
     mcp_package_register("org-fuzzball-notify", oneoh, oneoh, mcppkg_simpleedit, NULL, NULL);
-    mcp_package_register("org-fuzzball-simpleedit", oneoh, oneoh, mcppkg_simpleedit, NULL,
-			 NULL);
-    mcp_package_register("dns-org-mud-moo-simpleedit", oneoh, oneoh, mcppkg_simpleedit, NULL,
-			 NULL);
+    mcp_package_register("org-fuzzball-simpleedit", oneoh, oneoh, mcppkg_simpleedit, NULL, NULL);
+    mcp_package_register("org-fuzzball-languages", oneoh, oneoh, mcppkg_languages, NULL, NULL);
+    mcp_package_register("dns-org-mud-moo-simpleedit", oneoh, oneoh, mcppkg_simpleedit, NULL, NULL);
 }
 
 /*****************************************************************

--- a/src/mcppkgs.c
+++ b/src/mcppkgs.c
@@ -278,6 +278,28 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
 }
 
 void
+mcppkg_languages(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
+{
+    McpMesg omsg;
+    McpVer supp = mcp_frame_package_supported(mfr, "org-fuzzball-languages");
+
+    if (supp.verminor == 0 && supp.vermajor == 0) {
+	notify(mcpframe_to_user(mfr), "MCP: org-fuzzball-languages not supported.");
+	return;
+    }
+
+    if (!strcasecmp(msg->mesgname, "request")) {
+	mcp_mesg_init(&omsg, "org-fuzzball-languages", "supported");
+	mcp_mesg_arg_append(&omsg, "languages", "muf:7.0");
+	/* mcp_mesg_arg_append(&omsg, "languages", "muv:2.0"); */
+	mcp_frame_output_mesg(mfr, &omsg);
+	mcp_mesg_clear(&omsg);
+	return;
+    }
+}
+
+
+void
 mcppkg_help_request(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
 {
     FILE *f;


### PR DESCRIPTION
The MCP org-fuzzball-languages package allows clients to query what extension languages the server supports.

The client sends the org-fuzzball-languages-request message with no args, and the server will send back an org-fuzzball-languages-supported message with a languages list argument, where each line is a language name and a version number separated by a colon.  Currently, the only response is "muf:7.0".
