### PR TITLE
ci: Use Conan OpenSSL, use semantic versioning

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,8 @@
 [requires]
-# Update version whenever a new release of OpenSSL comes out
-OpenSSL/1.0.2k@lasote/stable
+# Use compatible versions of OpenSSL accoding to semantic versioning.
+# See: http://docs.conan.io/en/latest/mastering/version_ranges.html
+OpenSSL/[~=1.0.2m]@conan/stable
+
 
 [options]
 # Use shared .dll libraries (MD instead of MT)

--- a/makefile.win
+++ b/makefile.win
@@ -27,15 +27,27 @@ PACKAGE_DIR=.\win32
 OPENSSLDIR=e:\sandbox\openssl
 !ENDIF
 
+# Conan.io's packaging of OpenSSL removed the "...MD" suffix.  Try to detect that.
+# > Check the OPENSSLDIR first
+!IF EXIST("$(OPENSSLDIR)\lib\vc\libeay32MD.lib")
+LIB_SUFFIX="MD"
+# > Then check the PACKAGE_DIR
+!ELSEIF EXIST("$(PACKAGE_DIR)\lib\vc\libeay32MD.lib")
+LIB_SUFFIX="MD"
+!ELSE
+# Assume there's no "MD" suffix
+LIB_SUFFIX=""
+!ENDIF
+
 # Specify PACKAGE_DIR first so it takes priority, allowing easier overriding of any built-in binaries/libs
 CPP=cl.exe
 CPP_OPS=/nologo /EHsc /MT /W3 /O2 /c /D "WIN32" /D "FD_SETSIZE=4096" /D "_WINSOCK_DEPRECATED_NO_WARNINGS" /D "_CRT_SECURE_NO_DEPRECATE" /I"$(PACKAGE_DIR)\include" /I"$(WINDIR)" /I"$(INCDIR)" /I"$(OPENSSLDIR)\include" /Fd"$(INTDIR)\\"
 LINK32=link.exe
-LINK32_OPS=/NODEFAULTLIB:libc /LIBPATH:"$(PACKAGE_DIR)\lib\vc" /LIBPATH:".\win32" /LIBPATH:"$(OPENSSLDIR)\lib\vc" pcre.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib ws2_32.lib libeay32MD.lib ssleay32MD.lib winmm.lib /nologo /subsystem:console /incremental:no /machine:I386
+LINK32_OPS=/NODEFAULTLIB:libc /LIBPATH:"$(PACKAGE_DIR)\lib\vc" /LIBPATH:".\win32" /LIBPATH:"$(OPENSSLDIR)\lib\vc" pcre.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib ws2_32.lib libeay32$(LIB_SUFFIX).lib ssleay32$(LIB_SUFFIX).lib winmm.lib /nologo /subsystem:console /incremental:no /machine:I386
 
 # Enable These for debugging
 #CPP_OPS=/c /Od /D "_DEBUG" /Zi /EHsc /nologo /MTd /W3 /D "WIN32" /D "FD_SETSIZE=4096" /D "_WINSOCK_DEPRECATED_NO_WARNINGS" /D "_CRT_SECURE_NO_DEPRECATE" /I"$(PACKAGE_DIR)\include" /I"$(WINDIR)" /I"$(INCDIR)" /I"$(OPENSSLDIR)\include" /Fd"$(INTDIR)\\"
-#LINK32_OPS=/DEBUG /NODEFAULTLIB:libc /LIBPATH:"$(PACKAGE_DIR)\lib\vc" /LIBPATH:".\win32" /LIBPATH:"$(OPENSSLDIR)\lib\vc" pcre.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib ws2_32.lib libeay32MD.lib ssleay32MD.lib winmm.lib /nologo /subsystem:console /incremental:no /machine:I386
+#LINK32_OPS=/DEBUG /NODEFAULTLIB:libc /LIBPATH:"$(PACKAGE_DIR)\lib\vc" /LIBPATH:".\win32" /LIBPATH:"$(OPENSSLDIR)\lib\vc" pcre.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib ws2_32.lib libeay32$(LIB_SUFFIX).lib ssleay32$(LIB_SUFFIX).lib winmm.lib /nologo /subsystem:console /incremental:no /machine:I386
 
 
 ALL : "$(OUTDIR)\fbmuck.exe" "$(OUTDIR)\restart.exe"


### PR DESCRIPTION
## In short
* Switch to Conan's new, maintained [OpenSSL package](https://bintray.com/conan-community/conan/OpenSSL%3Aconan )
  * Replaces the legacy OpenSSL package from before [the Bintray move](http://docs.conan.io/en/latest/packaging/using_bintray.html )
  * This was planned in the past, but Conan's package didn't have 32-bit builds for a while
* Detect if OpenSSL packaging specifies a `MD` suffix
  * Some OpenSSL packages specify it as `libeay32MD.lib`, `ssleay32MD.lib`
  * Conan switched to specifying it as `libeay32.lib`, `ssleay32.lib`

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Fixes automated builds, important to see if other things break
Risk | ★☆☆ *1/3* | Potential incompatability with newer OpenSSL version, easily revertable
Intrusiveness | ★☆☆ *1/3* | Build system changes, shouldn't interfere with other pull requests

## Rationale
By [using semantic versioning](http://docs.conan.io/en/latest/mastering/version_ranges.html ) to pick the latest compatible OpenSSL version, newer Fuzzball builds will automatically get the most recent OpenSSL release, ensuring security patches get included without manually updating the version number.

Fixing the Windows CI build allows for checking if other commits break matters and makes testing of commits easier for those without a Windows build environment.

*NOTE:  It seems the semantic versioning currently picks `1.0.2` over anything `1.0.2X`, where `X` is some letter.  I suspect the non-suffixed OpenSSL `1.0.2` version upload was a mistake, and if Conan doesn't rename/remove it, we may have to go back to specifying exact version numbers.*

## Examples
### Before
```
OpenSSL/1.0.2k@lasote/stable: Not found in local cache, looking in remotes...
...
link.exe @C:\Users\appveyor\AppData\Local\Temp\1\nm48C4.tmp
LINK : fatal error LNK1181: cannot open input file 'libeay32MD.lib'
```

### After
```
Version range '~=1.0.2m' required by 'None' resolved to 'OpenSSL/1.0.2@conan/stable'
OpenSSL/1.0.2@conan/stable: Not found in local cache, looking in remotes...
...
Build success
```