### PR TITLE
Fix crash when non-SSL descriptor logs in

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -867,7 +867,9 @@ check_connect(struct descriptor_data *d, const char *msg)
 		log_status("CONNECTED: %s(%d) on descriptor %d",
 			   NAME(player), player, d->descriptor);
 #ifdef USE_SSL
-		log_status("Connected via %s", SSL_get_cipher_name(d->ssl_session));
+		if (d->ssl_session) {
+		    log_status("Connected via %s", SSL_get_cipher_name(d->ssl_session));
+		}
 #endif
 		d->connected = 1;
 		d->connected_at = time(NULL);


### PR DESCRIPTION
`d->ssl_session` isn't set for non-SSL connections, so SSL_get_cipher_name() gets passed a NULL and chokes.