### PR TITLE
ci: Fix Windows conan install flags for v1.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,8 +29,8 @@ init:
 
 build_script:
     - ps: |
-        # Install Conan dependencies for 32-bit (x86)
-        conan install -s arch=x86
+        # Install Conan dependencies for 32-bit (x86) using the local directory's conanfile
+        conan install . --settings arch=x86
         # > For statically-linked OpenSSL, specify: -s compiler="Visual Studio" -s compiler.runtime=MT
         #   Then modify makefile.win to reference ..MT.lib instead.  Dynamic linking is preferred.
 


### PR DESCRIPTION
## In short
* Specify the path to `conanfile.txt` when calling `conan install` on Windows
  * Fixes the build failure due to invalid command line arguments
  * Changes resulted from the [upgrade to Conan v1.0, as per the documentation](http://docs.conan.io/en/latest/conan1.0.html#command-line-changes )

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Fixes automated builds, important to see if other things break
Risk | ★☆☆ *1/3* | Potential incompatability with older Conan versions, easily revertable
Intrusiveness | ★☆☆ *1/3* | Build system changes, shouldn't interfere with other pull requests

## Examples
### Before
```
ERROR: Exiting with code: 2
conan : usage: conan install [-h] [-g GENERATOR] [-if INSTALL_FOLDER] [-m [MANIFESTS]]
At line:2 char:1
+ conan install -s arch=x86
+ ~~~~~~~~~~~~~~~~~~~~~~~~~
[...]
conan install: error: too few arguments
```

### After
```
PROJECT: Installing C:\projects\fuzzball\conanfile.txt
Requirements
    OpenSSL/1.0.2n@conan/stable from conan-center
    zlib/1.2.11@conan/stable from conan-center
[...]
PROJECT imports(): Copied 87 '.h' files
PROJECT imports(): Copied 2 '.dll' files: libeay32.dll, ssleay32.dll
PROJECT imports(): Copied 3 '.lib' files: libeay32.lib, ssleay32.lib, zlib.lib
...
Build success
```