### PR TITLE
track array allocations with their responsible program to cleanup circular references

### DIFF
--- a/include/array.h
+++ b/include/array.h
@@ -1,6 +1,7 @@
 #ifndef _ARRAY_H
 #define _ARRAY_H
 
+#include <stddef.h>  /* for offsetof() */
 #include "inst.h"
 
 #define ARRAY_UNDEFINED		0
@@ -18,6 +19,23 @@ typedef struct array_tree_t {
     short height;
 } array_tree;
 
+/* Linked list node structure for stk_arrays. This is used to track what stk_arrays are allocated
+   to a MUF program and cleanup any extras due to circular references.
+   
+   The linked list is circular --- a designated stk_array_list of these represents the head/tail of
+   the list (next = head pointer, prev = tail pointer), and is not associated with any stk_array.
+
+   The others elements on the list (iterated by following the next pointers until one reaches the 
+   head/tail again) are members of stk_array, and offsetof() is used to access the overall stk_array.
+ */
+typedef struct stk_array_list_t {
+    struct stk_array_list_t *next, *prev;
+} stk_array_list;
+
+/* The currently active stk_array_list to which to assign allocations.
+   If we were multithreaded, this would be thread-local */
+extern stk_array_list *stk_array_active_list;
+
 typedef struct stk_array_t {
     int links;			/* number of pointers  to array */
     int items;			/* number of items in array */
@@ -27,7 +45,11 @@ typedef struct stk_array_t {
 	array_data *packed;	/* pointer to packed array */
 	array_tree *dict;	/* pointer to dictionary AVL tree */
     } data;
+    stk_array_list list_node;   /* list array is on, typically of all allocated to a MUF program */
 } stk_array;
+
+#define STK_ARRAY_FROM_LIST_NODE(x) \
+    ((stk_array*) ((unsigned char*) (x) - offsetof(stk_array, list_node)))
 
 int array_appenditem(stk_array **arr, array_data *item);
 int array_count(stk_array *arr);
@@ -61,5 +83,15 @@ int array_setitem(stk_array **arr, array_iter *idx, array_data *item);
 int array_setrange(stk_array **arr, array_iter *start, stk_array *inarr);
 stk_array *new_array_dictionary(int pin);
 stk_array *new_array_packed(int size, int pin);
+
+/* place the array on a list of arrays of tracking allocations
+   unless it is already on one */
+void array_maybe_place_on_list(stk_array_list *list, stk_array *array);
+/* remove the array from any lists trackings its allocations */
+void array_remove_from_list(stk_array *array);
+
+void array_init_active_list(stk_array_list *list);
+
+void array_free_all_on_list(stk_array_list *list);
 
 #endif				/* _ARRAY_H */

--- a/include/array.h
+++ b/include/array.h
@@ -21,11 +21,11 @@ typedef struct array_tree_t {
 
 /* Linked list node structure for stk_arrays. This is used to track what stk_arrays are allocated
    to a MUF program and cleanup any extras due to circular references.
-   
+
    The linked list is circular --- a designated stk_array_list of these represents the head/tail of
    the list (next = head pointer, prev = tail pointer), and is not associated with any stk_array.
 
-   The others elements on the list (iterated by following the next pointers until one reaches the 
+   The others elements on the list (iterated by following the next pointers until one reaches the
    head/tail again) are members of stk_array, and offsetof() is used to access the overall stk_array.
  */
 typedef struct stk_array_list_t {

--- a/include/interp.h
+++ b/include/interp.h
@@ -1,6 +1,7 @@
 #ifndef _INTERP_H
 #define _INTERP_H
 
+#include "array.h"
 #include "fbstrings.h"
 #include "inst.h"
 
@@ -180,6 +181,8 @@ struct frame {
     int actual_pop;
     int expect_push_to;
 #endif
+    stk_array_list array_active_list;
+    stk_array_list *prev_array_active_list;
 };
 
 struct publics {

--- a/src/array.c
+++ b/src/array.c
@@ -1742,7 +1742,7 @@ array_init_active_list(stk_array_list *list) {
 void
 array_free_all_on_list(stk_array_list *list) {
     stk_array_list *cur_node;
-    
+
     cur_node = list->next;
     while (cur_node != list) {
         stk_array *arr = STK_ARRAY_FROM_LIST_NODE(cur_node);

--- a/src/array.c
+++ b/src/array.c
@@ -8,6 +8,8 @@
 #include "inst.h"
 #include "interp.h"
 
+stk_array_list *stk_array_active_list;
+
 static int array_tree_compare(array_iter * a, array_iter * b, int case_sens);
 
 /*
@@ -534,6 +536,10 @@ new_array(int pin)
     nu->items = 0;
     nu->pinned = pin;
     nu->data.packed = NULL;
+    nu->list_node.prev = nu->list_node.next = NULL;
+    if (stk_array_active_list) {
+        array_maybe_place_on_list(stk_array_active_list, nu);
+    }
 
     return nu;
 }
@@ -663,6 +669,7 @@ array_free(stk_array * arr)
     arr->items = 0;
     arr->data.packed = NULL;
     arr->type = ARRAY_UNDEFINED;
+    array_remove_from_list(arr);
     free(arr);
 }
 
@@ -1708,3 +1715,62 @@ array_get_intkey_strval(stk_array * arr, int key)
     }
 }
 
+void
+array_maybe_place_on_list(stk_array_list *list, stk_array *arr) {
+    if (list && !arr->list_node.prev) {
+        arr->list_node.next = list->next;
+        arr->list_node.prev = list;
+        list->next->prev = &arr->list_node;
+        list->next = &arr->list_node;
+    }
+}
+
+void
+array_remove_from_list(stk_array *arr) {
+    if (arr->list_node.prev) {
+        arr->list_node.prev->next = arr->list_node.next;
+        arr->list_node.next->prev = arr->list_node.prev;
+        arr->list_node.prev = arr->list_node.next = 0;
+    }
+}
+
+void
+array_init_active_list(stk_array_list *list) {
+    list->next = list->prev = list;
+}
+
+void
+array_free_all_on_list(stk_array_list *list) {
+    stk_array_list *cur_node;
+    
+    cur_node = list->next;
+    while (cur_node != list) {
+        stk_array *arr = STK_ARRAY_FROM_LIST_NODE(cur_node);
+        /* CLEARing the contents of this array might cause it to be free'd
+           if it has a circular reference. We want to prevent this from
+           happening until we have used the next pointer, so we increment
+           the link count here. */
+        arr->links++;
+        switch (arr->type) {
+        case ARRAY_PACKED:
+	    for (int i = arr->items; i-- > 0;) {
+		CLEAR(&arr->data.packed[i]);
+	    }
+            arr->items = 1;
+            arr->data.packed[0].type = PROG_INTEGER;
+            arr->data.packed[0].line = 0;
+            arr->data.packed[0].data.number = 0;
+            break;
+        case ARRAY_DICTIONARY:
+            array_tree_delete_all(arr->data.dict);
+            arr->data.dict = NULL;
+            break;
+        default:
+            assert(0 /* unknown array type */);
+        }
+        cur_node = cur_node->next;
+        /* Call array_free() to decrement the link count and free this array
+           if it has no more links. */
+        array_free(arr);
+    }
+}

--- a/src/interp.c
+++ b/src/interp.c
@@ -897,7 +897,7 @@ deep_copyinst(struct inst *in, struct inst *out, int pinned)
 	    if (array_first(arr, &idx)) {
 		do {
 		    val = array_getitem(arr, &idx);
-		    deep_copyinst(&temp1, val, pinned);
+		    deep_copyinst(val, &temp1, pinned);
 		    array_setitem(&nu, &idx, &temp1);
 		} while (array_next(arr, &idx));
 	    }

--- a/src/p_misc.c
+++ b/src/p_misc.c
@@ -327,13 +327,16 @@ prim_fork(PRIM_PROTOTYPE)
     tmpfr = (struct frame *) calloc(1, sizeof(struct frame));
     tmpfr->next = NULL;
 
+    array_init_active_list(&tmpfr->array_active_list);
+    stk_array_active_list = &tmpfr->array_active_list;
+
     tmpfr->system.top = fr->system.top;
     for (int i = 0; i < fr->system.top; i++)
 	tmpfr->system.st[i] = fr->system.st[i];
 
     tmpfr->argument.top = fr->argument.top;
     for (int i = 0; i < fr->argument.top; i++)
-	copyinst(&fr->argument.st[i], &tmpfr->argument.st[i]);
+	deep_copyinst(&fr->argument.st[i], &tmpfr->argument.st[i], -1);
 
     tmpfr->caller.top = fr->caller.top;
     for (int i = 0; i <= fr->caller.top; i++) {
@@ -349,7 +352,7 @@ prim_fork(PRIM_PROTOTYPE)
     tmpfr->fors.st = copy_fors(fr->fors.st);
 
     for (int i = 0; i < MAX_VAR; i++)
-	copyinst(&fr->variables[i], &tmpfr->variables[i]);
+	deep_copyinst(&fr->variables[i], &tmpfr->variables[i], -1);
 
     localvar_dupall(tmpfr, fr);
     scopedvar_dupall(tmpfr, fr);
@@ -421,6 +424,8 @@ prim_fork(PRIM_PROTOTYPE)
 
     result = add_muf_delay_event(0, fr->descr, player, NOTHING, NOTHING, program,
 				 tmpfr, "BACKGROUND");
+    
+    stk_array_active_list = &fr->array_active_list;
 
     /* parent process gets the child's pid returned on the stack */
     if (!result)
@@ -846,8 +851,11 @@ prim_event_send(PRIM_PROTOTYPE)
 	destfr = timequeue_pid_frame(oper1->data.number);
 
     if (destfr) {
-	arr = new_array_dictionary(fr->pinning);
-	array_set_strkey(&arr, "data", oper3);
+        stk_array_active_list = &destfr->array_active_list;
+        struct inst data_copy;
+        deep_copyinst(oper3, &data_copy, destfr->pinning);
+	arr = new_array_dictionary(destfr->pinning);
+	array_set_strkey(&arr, "data", &data_copy);
 	array_set_strkey_intval(&arr, "caller_pid", fr->pid);
 	array_set_strkey_intval(&arr, "descr", fr->descr);
 	array_set_strkey_refval(&arr, "caller_prog", program);
@@ -861,7 +869,10 @@ prim_event_send(PRIM_PROTOTYPE)
 	snprintf(buf, sizeof(buf), "USER.%.32s", DoNullInd(oper2->data.string));
 	muf_event_add(destfr, buf, &temp1, 0);
 
+        stk_array_active_list = &fr->array_active_list;
+
 	CLEAR(&temp1);
+        CLEAR(&data_copy);
     }
 
     CLEAR(oper1);

--- a/src/p_misc.c
+++ b/src/p_misc.c
@@ -424,7 +424,7 @@ prim_fork(PRIM_PROTOTYPE)
 
     result = add_muf_delay_event(0, fr->descr, player, NOTHING, NOTHING, program,
 				 tmpfr, "BACKGROUND");
-    
+
     stk_array_active_list = &fr->array_active_list;
 
     /* parent process gets the child's pid returned on the stack */


### PR DESCRIPTION
This partially addresses issue #199.

This creates a linked list of all array allocations for each program. When the program is freed, all arrays on this list are cleared, to clean up circular references that weren't dealt with by reference counting.

To minimize modifications to existing code, a global variable indicates what list new arrays should go on. This is set by the MUF interpreter before and after running MUF primitives and reset on interpreter exit/abort.

To deal with cases where arrays are shared between MUF processes, FORK and EVENT_SEND are changed to do deep copies of any passed array.

I suspect I may have missed some cases where arrays can be passed between or into MUF programs.
