### PR TITLE
add italic+overstrike to mpihelp.txt

### DIFF
--- a/game/data/mpihelp.txt
+++ b/game/data/mpihelp.txt
@@ -847,9 +847,10 @@ ATTR
     This will surround the given string with the neccesary ANSI escape codes
 to cause the text to display with the given attributes.  You may specify up
 to eight attributes, though this shouldn't ever be neccesary.  The supported
-attributes are: null, reset, bold, dim, flash, underline, reverse, black,
-red, yellow, green, cyan, blue, magenta, white, bg_black, bg_red, bg_yellow, 
-bg_green, bg_cyan, bg_blue, bg_magenta, and bg_white.
+attributes are:
+null, reset, bold, dim, italic, underline, flash, reverse, overstrike,
+black, red, green, yellow, blue, magenta, cyan, white,
+bg_black, bg_red, bg_green, bg_yellow, bg_blue, bg_magenta, bg_cyan, and bg_white.
     Not all clients will display all these attributes, and those that do 
 won't always show them the same way.  Players who do not have their Color 
 flag set will not see the ANSI codes or colors at all.  Nesting {attr}


### PR DESCRIPTION
Also reorganize the attributes as before, to match the sensible order in color.h