### PR TITLE
fix a couple error messages

### DIFF
--- a/game/restart.in
+++ b/game/restart.in
@@ -118,14 +118,14 @@ if [ -r $DBOUT ]; then
 fi
 
 if [ ! -r $DBIN ]; then
-	echo "Hey\!  The "$DBIN" file has to exist and be readable to restart the server\!"
+	echo "Hey!  The $DBIN file has to exist and be readable to restart the server!"
 	echo "Restart attempt aborted."
 	exit
 fi
 
 end=`tail -1 $DBIN`
 if [ "x$end" != 'x***END OF DUMP***' ]; then
-	echo "WARNING\!  The "$DBIN" file is incomplete and therefore corrupt\!"
+	echo "WARNING!  The $DBIN file is incomplete and therefore corrupt!"
 	echo "Restart attempt aborted."
 	exit
 fi


### PR DESCRIPTION
The \ were unneeded and ended up in the error message itself.  The quotation marks were unneeded since variables expand within double quoted strings.