### PR TITLE
fix link + question

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -16,7 +16,7 @@ GNU GENERAL PUBLIC LICENSE
 
 Version 3, 29 June 2007
 
-Copyright &copy; 2007 Free Software Foundation, Inc. &lt;<http://fsf.org/>&gt;
+Copyright &copy; 2007 Free Software Foundation, Inc. &lt;<https://www.fsf.org/>&gt;
 
 Everyone is permitted to copy and distribute verbatim copies of this license
 document, but changing it is not allowed.


### PR DESCRIPTION
GNU publishes their own markdown GPL3 here:
https://www.gnu.org/licenses/gpl.md
It has some differences in formatting.  Should the official gpl.md replace this current one? (of course with the openssl exception added back in)