### PR TITLE
Fix a rare color issue in advancedb WHO

### DIFF
--- a/dbs/advancedb/muf/85.m
+++ b/dbs/advancedb/muf/85.m
@@ -11,9 +11,11 @@
     first when using name filter {eg "wd s"}.
   1.11, 27 March 2003: With #species, show species in normal color.
   1.2, 4 October 2003: Use $lib/wf to get watchfor list
+  1.3, 12 October 2018: Fix minor issue with rainbow color ending
+    up on some idle times. (Theo@HLM)
 )
 $author Natasha O'Brien <mufden@mufden.fuzzball.org>
-$version 1.2
+$version 1.3
 $note A tastefully colored WHO replacement for Fuzzball 6.
  
 $include $lib/strings
@@ -68,7 +70,7 @@ $endif
         dup case  ( intIdle intIdle )
             3600 >= when "\[[1;31m" end
              600 >= when "\[[1;33m" end
-              60 >= when ""         end
+              60 >= when "\[[0m"    end
             default pop  "\[[1;32m" end
         endcase  ( intIdle strColor )
 $iflib $lib/away


### PR DESCRIPTION
I noticed, on Here Lie Monsters, that when a player has been connected for over 100 days, and their idle time is over 60 seconds but under 600 seconds (usually uncolored!) that the rainbow text applied to their 'on for' time can get applied to their idle time.  This diff makes it so that the idle time is always uncolored for that time period, regardless of other factors.
Diff partially tested.  I didn't leave a MUCK running for 100 days, nor enabled the rainbow text at an earlier time.  Diff works correctly though.