### PR TITLE
Eek: remove parentheses that shouldn't be there

### DIFF
--- a/dbs/advancedb/muf/85.m
+++ b/dbs/advancedb/muf/85.m
@@ -12,7 +12,7 @@
   1.11, 27 March 2003: With #species, show species in normal color.
   1.2, 4 October 2003: Use $lib/wf to get watchfor list
   1.3, 12 October 2018: Fix minor issue with rainbow color ending
-    up on some idle times. (Theo@HLM)
+    up on some idle times. {Theo@HLM}
 )
 $author Natasha O'Brien <mufden@mufden.fuzzball.org>
 $version 1.3


### PR DESCRIPTION
I was told to not use parentheses in MUF comments.  OOPS.  Fixed that.