### PR TITLE
Adjusted timestr_long to properly concatenate strings.

### DIFF
--- a/src/fbtime.c
+++ b/src/fbtime.c
@@ -149,19 +149,19 @@ timestr_full(long dtime)
 const char *
 timestr_long(long dtime)
 {
-    static char buf[100];
+    static char buf[100], value[100];
     const char *str[7] = { "year", "month", "week", "day", "hour", "minute", "second" };
     int div[7] = { 31556736, 2621376, 604800, 86400, 3600, 60, 1 };
 
-    *buf = 0;
+    *buf = *value = 0;
 
     for (int i = 0; i < 7; i++) {
-	if (dtime >= div[i]) {
-	    if (*buf) snprintf(buf, sizeof(buf), "%s, ", buf);
-	    long temp = dtime / div[i];
-	    snprintf(buf, sizeof(buf), "%s%ld %s%s", buf, temp, str[i], temp != 1 ? "s" : "");
-	    dtime %= div[i];
-	}
+        if (dtime >= div[i]) {
+            long temp = dtime / div[i];
+            snprintf(value, sizeof(value), "%s%s%ld %s%s", buf, (*buf ? ", " : ""), temp, str[i], temp != 1 ? "s" : "");
+            strncpy(buf, value, sizeof(buf));
+            dtime %= div[i];
+        }
     }
 
     return buf;


### PR DESCRIPTION
`timestr_long` had a bug in it that would only print out the last value from the time array. You could see this by using `@mpi {ltimestr:61}`. This should have produced `1 minute, 1 second` but it instead produces `1 second`. This is because snprintf can't be used to print into the same buffer from which it's reading. As per the man page for snprintf:
> Some programs imprudently rely on code such as the following
> 
>     sprintf(buf, "%s some further text", buf);
> 
> to append text to buf. However, the standards explicitly note that the results are undefined if source and destination buffers overlap when calling sprintf(), snprintf(), vsprintf(), and vsnprintf(). Depending on the version of gcc(1) used, and the compiler options employed, calls such as the above will not produce the expected results.
> 
> The glibc implementation of the functions snprintf() and vsnprintf() conforms to the C99 standard, that is, behaves as described above, since glibc version 2.1. Until glibc 2.0.6, they would return -1 when the output was truncated.

This patch fixes this particular call by printing the calculated value into its own buffer plus the previous result and then copying it back to the result buffer.

It may be worthwhile to look through the code for anything else that may be using the same (or overlapping) buffers in string writing.