### PR TITLE
Let server start when logs directory doesn't exist

### DIFF
--- a/game/restart.in
+++ b/game/restart.in
@@ -146,6 +146,12 @@ if [ "x$*" != "x" ]; then
     PORTS=$*
 fi
 
+if
+test ! -d "$GAMEDIR/logs"
+then
+mkdir logs
+fi
+
 touch $RESTARTS_LOGFILE
 echo "`date +%Y-%m-%dT%H:%M:%S`: `who am i`" >> $RESTARTS_LOGFILE
 


### PR DESCRIPTION
There are only a couple reasons why the logs directory wouldn't exist: a user not copying the game directory post-install as detailed in README_LINUX.md, or the log directory being moved or deleted at some later date.
https://github.com/fuzzball-muck/fuzzball/issues/235
Nonetheless, this diff fixes the above issue by creating the logs directory if it doesn't already exist.