### PR TITLE
Fixed NULL_COMMAND resetting idle timer

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -1844,10 +1844,6 @@ process_input(struct descriptor_data *d)
 		|| strncasecmp(d->raw_input, NULL_COMMAND, got)
 		&& !(got-2 == strlen(NULL_COMMAND))) {
 		d->last_time = time(NULL);
-		log_status("COMMAND: %s", d->raw_input);
-		log_status("GOT BYTES: %i", got);
-		log_status("NULL LEN: %i", strlen(NULL_COMMAND));
-		log_status("MATCHES? %i", strncasecmp(d->raw_input, NULL_COMMAND, got-2));
 	    }
 	    *p = '\0';
 	    if (p >= d->raw_input)

--- a/src/interface.c
+++ b/src/interface.c
@@ -1841,7 +1841,7 @@ process_input(struct descriptor_data *d)
     for (q = buf, qend = buf + got; q < qend; q++) {
 	if (*q == '\n') {
 	    if (!tp_recognize_null_command
-		|| strcasecmp(d->raw_input, NULL_COMMAND)) {
+		|| strncasecmp(d->raw_input, NULL_COMMAND, strlen(NULL_COMMAND))) {
 		d->last_time = time(NULL);
 	    }
 	    *p = '\0';

--- a/src/interface.c
+++ b/src/interface.c
@@ -1841,8 +1841,8 @@ process_input(struct descriptor_data *d)
     for (q = buf, qend = buf + got; q < qend; q++) {
 	if (*q == '\n') {
 	    if (!tp_recognize_null_command
-		|| strncasecmp(d->raw_input, NULL_COMMAND, got-2)
-		&& !(got-2 == strlen(NULL_COMMAND))) {
+		|| !(!strncasecmp(d->raw_input, NULL_COMMAND, got-2)
+		&& strlen(NULL_COMMAND) == got-2)) {
 		d->last_time = time(NULL);
 	    }
 	    *p = '\0';

--- a/src/interface.c
+++ b/src/interface.c
@@ -1841,7 +1841,7 @@ process_input(struct descriptor_data *d)
     for (q = buf, qend = buf + got; q < qend; q++) {
 	if (*q == '\n') {
 	    if (!tp_recognize_null_command
-		|| strcasecmp(d->raw_input, NULL_COMMAND)) {
+		|| strncasecmp(d->raw_input, NULL_COMMAND, got-2)) {
 		d->last_time = time(NULL);
 	    }
 	    *p = '\0';

--- a/src/interface.c
+++ b/src/interface.c
@@ -1841,7 +1841,7 @@ process_input(struct descriptor_data *d)
     for (q = buf, qend = buf + got; q < qend; q++) {
 	if (*q == '\n') {
 	    if (!tp_recognize_null_command
-		|| strncasecmp(d->raw_input, NULL_COMMAND, got)
+		|| strncasecmp(d->raw_input, NULL_COMMAND, got-2)
 		&& !(got-2 == strlen(NULL_COMMAND))) {
 		d->last_time = time(NULL);
 	    }

--- a/src/interface.c
+++ b/src/interface.c
@@ -1841,8 +1841,13 @@ process_input(struct descriptor_data *d)
     for (q = buf, qend = buf + got; q < qend; q++) {
 	if (*q == '\n') {
 	    if (!tp_recognize_null_command
-		|| strncasecmp(d->raw_input, NULL_COMMAND, got-2)) {
+		|| strncasecmp(d->raw_input, NULL_COMMAND, got)
+		&& !(got-2 == strlen(NULL_COMMAND))) {
 		d->last_time = time(NULL);
+		log_status("COMMAND: %s", d->raw_input);
+		log_status("GOT BYTES: %i", got);
+		log_status("NULL LEN: %i", strlen(NULL_COMMAND));
+		log_status("MATCHES? %i", strncasecmp(d->raw_input, NULL_COMMAND, got-2));
 	    }
 	    *p = '\0';
 	    if (p >= d->raw_input)


### PR DESCRIPTION
This should address  #206.

The idle timer should no longer reset if the input command is the same as NULL_COMMAND, regardless of what NULL_COMMAND is set to.