### PR TITLE
Make fbtime.c more portable

### DIFF
--- a/src/fbtime.c
+++ b/src/fbtime.c
@@ -46,22 +46,13 @@ ts_modifyobject(dbref thing)
 long
 get_tz_offset(void)
 {
-/*
- * SunOS don't seem to have timezone as a "extern long", but as
- * a structure. This makes it very hard (at best) to check for,
- * therefor I'm checking for tm_gmtoff. --WF
- */
-#ifdef HAVE_STRUCT_TM_TM_GMTOFF
-    time_t now;
-
-    time(&now);
-    return localtime(&now)->tm_gmtoff;
-#elif defined(HAVE_DECL__TIMEZONE)
-    /* CygWin uses _timezone instead of timezone. */
-    return _timezone;
+#ifdef HAVE_DECL__TIMEZONE
+	/* CygWin uses _timezone instead of timezone. */
+	return _timezone;
 #else
-    /* extern long timezone; */
-    return timezone;
+	tzset();
+	/* extern long timezone; */
+	return timezone * -1;
 #endif
 }
 


### PR DESCRIPTION
This removes a BSD/GNU extension and instead uses a _XOPEN_SOURCE extension.

Please check this pull yourself before putting it anywhere, especially since I don't know the C preprocessor well.  the define/ifdef stuff.  I think it's right, though.  (And the C itself, I know is right)
But it turns out the solution was already there (albeit improperly there) in the code, hidden in the lower side of the ifdef.
I've confirmed this works on GNU/Linux GCC and OpenBSD Clang and GCC.
I can test it on FreeBSD Clang when I switch back from Ubuntu to FreeBSD, if you'd like me to test there too.

I thought the Windows builds build in Visual Studio now.  What's the fate of this cygwin stuff?  Is anyone still building it that way?  If we get rid of it, will Windows builds still work?
SunOS was discontinued in 1994, too, so it doesn't need to be worried about, I hope.
I had to do the multiplication by negative one to match current output from the function on GNU/Linux and OpenBSD.  In the Americas, people will continue to get a (identical) negative number from this function.

(you can easily test this by setting @succ here={tzoffset} and then looking at your current location)