### PR TITLE
Remove a cygwin ifdef, update docs

### DIFF
--- a/game/data/man.txt
+++ b/game/data/man.txt
@@ -4980,7 +4980,9 @@ Also see: SYSTIME
 GMTOFFSET
 GMTOFFSET ( -- i)
 
-  Returns the machine's offset from Greenwich Mean Time in seconds.
+  Returns the server's offset from UTC in seconds.
+Result is negative for time zones west of the prime meridian.
+Result is positive for time zones east of the prime meridian.
 ~
 ~
 TIMESPLIT

--- a/game/data/mpihelp.html
+++ b/game/data/mpihelp.html
@@ -346,7 +346,9 @@ both considered false.  Any other value is considered true.
 <h3 id="tzoffset">{tzoffset}
 <br>
 </h3>
-    Returns local time zone offset from GMT in seconds.
+    Returns the server's offset from UTC in seconds.
+Result is negative for time zones west of the prime meridian.
+Result is positive for time zones east of the prime meridian.
 <!-- HTML_TOPICEND -->
 
 

--- a/game/data/mpihelp.raw
+++ b/game/data/mpihelp.raw
@@ -40,7 +40,9 @@ both considered false.  Any other value is considered true.
 ~~section Time Functions|TimeFuncs
 TZOFFSET
 {tzoffset}
-    Returns local time zone offset from GMT in seconds.
+    Returns the server's offset from UTC in seconds.
+Result is negative for time zones west of the prime meridian.
+Result is positive for time zones east of the prime meridian.
 ~
 ~
 TIME
@@ -1430,4 +1432,3 @@ arguments:
     }
     {names:{contents:here},1,1}
 ~~endcode
-

--- a/game/data/mpihelp.txt
+++ b/game/data/mpihelp.txt
@@ -178,7 +178,9 @@ secs       stimestr   time       timestr    tzoffset
 ~
 TZOFFSET
 {tzoffset}
-    Returns local time zone offset from GMT in seconds.
+    Returns the server's offset from UTC in seconds.
+Result is negative for time zones west of the prime meridian.
+Result is positive for time zones east of the prime meridian.
 ~
 ~
 TIME
@@ -1656,4 +1658,3 @@ arguments:
         }
     }
     {names:{contents:here},1,1}
-

--- a/game/data/mufman.html
+++ b/game/data/mufman.html
@@ -8128,7 +8128,9 @@ number, with microsecond accuracy.
 
 <br>
 </h3>
-  Returns the machine's offset from Greenwich Mean Time in seconds.
+  Returns the server's offset from UTC in seconds.
+Result is negative for time zones west of the prime meridian.
+Result is positive for time zones east of the prime meridian.
 <!-- HTML_TOPICEND -->
 
 

--- a/game/data/mufman.raw
+++ b/game/data/mufman.raw
@@ -4537,7 +4537,9 @@ number, with microsecond accuracy.
 GMTOFFSET
 GMTOFFSET ( -- i)
 
-  Returns the machine's offset from Greenwich Mean Time in seconds.
+  Returns the server's offset from UTC in seconds.
+Result is negative for time zones west of the prime meridian.
+Result is positive for time zones east of the prime meridian.
 ~
 ~
 TIMESPLIT

--- a/src/fbtime.c
+++ b/src/fbtime.c
@@ -46,14 +46,8 @@ ts_modifyobject(dbref thing)
 long
 get_tz_offset(void)
 {
-#ifdef HAVE_DECL__TIMEZONE
-	/* CygWin uses _timezone instead of timezone. */
-	return _timezone;
-#else
 	tzset();
-	/* extern long timezone; */
 	return timezone * -1;
-#endif
 }
 
 char *


### PR DESCRIPTION
I'll leave the BSD (tm_gmtoff-based) polarity of the result rather than the SysV (POSIX, SUS) polarity of the result, for backward compatibility with existing fuzzball installs.
And document it, too!