### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 addons:
   apt:
@@ -33,6 +34,8 @@ script:
   - make clean
   # Make Fuzzball and all related code
   - make all
+  # Make helpfiles, see if prochelp runs or whether it segmentation faults
+  - make install
 
 # Currently, --enable-memprof and --enable-debug are ignored for that generates
 # 32 builds instead of 8.  If those need tested in the future, use the


### PR DESCRIPTION
I've seen some bugs more obviously show up during make install.  I remember in some of my builds, seeing prochelp segmentation fault during make install (which includes make help) let me know something was wrong with a diff I wrote.
Including the very quick make install lets such a chance be possible, to see prochelp segfault or run OK.
Also, switch to the newest version of Ubuntu that Travis has available.
btw is there a difference between make and make all for fuzzball?