### PR TITLE
Update .travis.yml attempt 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 sudo: false
 addons:
   apt:
@@ -28,11 +29,13 @@ env:
 
 script:
   # Set up configure flags
-  - ./configure $FLAG_LINT $FLAG_IPV6 $FLAG_SSL
+  - ./configure --prefix="$PWD/fuzzpre" $FLAG_LINT $FLAG_IPV6 $FLAG_SSL
   # Clean up build directory
   - make clean
   # Make Fuzzball and all related code
   - make all
+  # Check whether install works
+  - make install
 
 # Currently, --enable-memprof and --enable-debug are ignored for that generates
 # 32 builds instead of 8.  If those need tested in the future, use the


### PR DESCRIPTION
I've seen some bugs more obviously show up during make install.  I remember in some of my builds, seeing prochelp segmentation fault during make install (which includes make help) let me know something was wrong with a diff I wrote.
Including the very quick make install lets such a chance be possible, to see prochelp segfault or run OK.
Also, switch to the newest version of Ubuntu that Travis has available.
btw is there a difference between make and make all for fuzzball?