### PR TITLE
Improve timefmt and ftime's docs

### DIFF
--- a/game/data/man.txt
+++ b/game/data/man.txt
@@ -4997,41 +4997,46 @@ TIMEFMT
 TIMEFMT (s i -- s)
 
   Takes a format string and a SYSTIME integer and returns a string formatted
-with the time.  The format string is ascii text with formatting commands:
+with the time.  The format string is ASCII text with formatting commands:
 
-  %% -- "%"
-  %+ -- The date and time in server date format.
-  %a -- abbreviated weekday name.
-  %A -- full weekday name.
-  %b -- abbreviated month name.
-  %B -- full month name.
-  %C -- "%x %X"
-  %c -- century number.
-  %D -- "%m/%d/%y"
-  %d -- month day, "01" - "31"
-  %e -- month day, " 1" - "31"
-  %h -- "%b"
-  %H -- hour, "00" - "23"
-  %I -- hour, "01" - "12"
-  %j -- year day, "001" - "366"
-  %k -- hour, " 0" - "23"
-  %l -- hour, " 1" - "12"
-  %M -- minute, "00" - "59"
-  %m -- month, "01" - "12"
-  %p -- "AM" or "PM"
-  %R -- "%H:%M"
-  %r -- "%I:%M:%S %p"
-  %S -- seconds, "00" - "59"
-  %T -- "%H:%M:%S"
-  %U -- week number of the year. "00" - "52"
-  %w -- week day number, "0" - "6"
-  %W -- week# of year, starting on a monday, "00" - "52"
-  %X -- preferred date representation for the current locale.
-  %x -- preferred time representation for the current locale.
-  %y -- year, "00" - "99"
-  %Y -- year, "1900" - "2155"
-  %z -- numeric time zone. (+hhmm)
-  %Z -- string time zone.  "GMT", "EDT", "PST", etc.
+  %a -- abbreviated weekday name
+  %A -- full weekday name
+  %b -- abbreviated month name
+  %B -- full month name
+  %c -- date and time (default: %a %b %e %T %Y)
+  %C -- year divided by 100 and truncated to an integer, as a decimal number (00-99)
+  %d -- day of the month as a decimal number (01-31)
+  %D -- %m/%d/%y
+  %e -- day of the month as a decimal number (1-31); a single digit is preceded by a space
+  %F -- %Y-%m-%d (ISO 8601 date)
+  %g -- last 2 digits of the ISO 8601 week-based year as a decimal number (00-99)
+  %G -- ISO 8601 week-based year as a decimal number
+  %h -- %b
+  %H -- hour (24-hour clock) as a decimal number (00-23)
+  %I -- hour (12-hour clock) as a decimal number (01-12)
+  %j -- day of the year as a decimal number (001-366)
+  %m -- month as a decimal number (01-12)
+  %M -- minute as a decimal number (00-59)
+  %n -- new-line character
+  %p -- AM or PM
+  %r -- 12-hour clock time (default: %I:%M:%S %p)
+  %R -- %H:%M
+  %S -- second as a decimal number (00-60)
+  %t -- horizontal-tab character
+  %T -- %H:%M:%S (ISO 8601 time)
+  %u -- ISO 8601 weekday as a decimal number (1-7), where Monday is 1
+  %U -- week number of the year (the first Sunday as the first day of week 1) as a decimal number (00-53)
+  %V -- ISO 8601 week number as a decimal number (01-53)
+  %w -- weekday as a decimal number (0-6), where Sunday is 0
+  %W -- week number of the year (the first Monday as the first day of week 1) as a decimal number (00-53)
+  %x -- date (default: %m/%d/%y)
+  %X -- time (default: %T)
+  %y -- last 2 digits of the year as a decimal number (00-99)
+  %Y -- year as a decimal number
+  %z -- offset from UTC in the ISO 8601 format, or by no characters if no time zone is determinable (example: -0500 for EST)
+  %Z -- time zone name or abbreviation, or by no characters if no time zone is determinable (examples: UTC, EDT, PST)
+  %% -- % (percent sign)
+  TIMEFMT processes format strings with the C function strftime().  The above list of conversion specifiers (formatting commands) is from the C (draft C17/C18) standard: some MUCKs may have more conversion specifiers available.
 Also see: FMTSTRING
 ~
 ~

--- a/game/data/mpihelp.html
+++ b/game/data/mpihelp.html
@@ -383,9 +383,10 @@ of seconds.
 </h3>
     Returns a time string in the format you specify.  See 'man timefmt' for
 the %subs that you can use in the format string.  If specified, tz is the
-number of seconds offset from GMT.  If specified, secs is the systime to
-use, instead of the current time.  {ftime:%x %X %Y,{tzoffset},0} will return
+number of seconds offset from UTC.  If specified, secs is the systime to
+use, instead of the current time.  {ftime:%x %X,{tzoffset},0} will return
 the date and time for systime 0, for the local time zone of the server.
+ftime processes format strings with the C function strftime().
 <!-- HTML_TOPICEND -->
 
 

--- a/game/data/mpihelp.raw
+++ b/game/data/mpihelp.raw
@@ -67,9 +67,10 @@ FTIME
 {ftime:format,tz,secs}
     Returns a time string in the format you specify.  See 'man timefmt' for
 the %subs that you can use in the format string.  If specified, tz is the
-number of seconds offset from GMT.  If specified, secs is the systime to
-use, instead of the current time.  {ftime:%x %X %Y,{tzoffset},0} will return
+number of seconds offset from UTC.  If specified, secs is the systime to
+use, instead of the current time.  {ftime:%x %X,{tzoffset},0} will return
 the date and time for systime 0, for the local time zone of the server.
+ftime processes format strings with the C function strftime().
 ~
 ~
 TIMESTR

--- a/game/data/mpihelp.txt
+++ b/game/data/mpihelp.txt
@@ -205,9 +205,10 @@ FTIME
 {ftime:format,tz,secs}
     Returns a time string in the format you specify.  See 'man timefmt' for
 the %subs that you can use in the format string.  If specified, tz is the
-number of seconds offset from GMT.  If specified, secs is the systime to
-use, instead of the current time.  {ftime:%x %X %Y,{tzoffset},0} will return
+number of seconds offset from UTC.  If specified, secs is the systime to
+use, instead of the current time.  {ftime:%x %X,{tzoffset},0} will return
 the date and time for systime 0, for the local time zone of the server.
+ftime processes format strings with the C function strftime().
 ~
 ~
 TIMESTR

--- a/game/data/mufman.html
+++ b/game/data/mufman.html
@@ -8151,43 +8151,49 @@ with sunday as 1, and yearday is the day of the year (1-366).
 <br>
 </h3>
   Takes a format string and a SYSTIME integer and returns a string formatted
-with the time.  The format string is ascii text with formatting commands:
+with the time.  The format string is ASCII text with formatting commands:
 
 <pre>
-  %% -- &quot;%&quot;
-  %+ -- The date and time in server date format.
-  %a -- abbreviated weekday name.
-  %A -- full weekday name.
-  %b -- abbreviated month name.
-  %B -- full month name.
-  %C -- &quot;%x %X&quot;
-  %c -- century number.
-  %D -- &quot;%m/%d/%y&quot;
-  %d -- month day, &quot;01&quot; - &quot;31&quot;
-  %e -- month day, &quot; 1&quot; - &quot;31&quot;
-  %h -- &quot;%b&quot;
-  %H -- hour, &quot;00&quot; - &quot;23&quot;
-  %I -- hour, &quot;01&quot; - &quot;12&quot;
-  %j -- year day, &quot;001&quot; - &quot;366&quot;
-  %k -- hour, &quot; 0&quot; - &quot;23&quot;
-  %l -- hour, &quot; 1&quot; - &quot;12&quot;
-  %M -- minute, &quot;00&quot; - &quot;59&quot;
-  %m -- month, &quot;01&quot; - &quot;12&quot;
-  %p -- &quot;AM&quot; or &quot;PM&quot;
-  %R -- &quot;%H:%M&quot;
-  %r -- &quot;%I:%M:%S %p&quot;
-  %S -- seconds, &quot;00&quot; - &quot;59&quot;
-  %T -- &quot;%H:%M:%S&quot;
-  %U -- week number of the year. &quot;00&quot; - &quot;52&quot;
-  %w -- week day number, &quot;0&quot; - &quot;6&quot;
-  %W -- week# of year, starting on a monday, &quot;00&quot; - &quot;52&quot;
-  %X -- preferred date representation for the current locale.
-  %x -- preferred time representation for the current locale.
-  %y -- year, &quot;00&quot; - &quot;99&quot;
-  %Y -- year, &quot;1900&quot; - &quot;2155&quot;
-  %z -- numeric time zone. (+hhmm)
-  %Z -- string time zone.  &quot;GMT&quot;, &quot;EDT&quot;, &quot;PST&quot;, etc.
+  %a -- abbreviated weekday name
+  %A -- full weekday name
+  %b -- abbreviated month name
+  %B -- full month name
+  %c -- date and time (default: %a %b %e %T %Y)
+  %C -- year divided by 100 and truncated to an integer, as a decimal number (00-99)
+  %d -- day of the month as a decimal number (01-31)
+  %D -- %m/%d/%y
+  %e -- day of the month as a decimal number (1-31); a single digit is preceded by a space
+  %F -- %Y-%m-%d (ISO 8601 date)
+  %g -- last 2 digits of the ISO 8601 week-based year as a decimal number (00-99)
+  %G -- ISO 8601 week-based year as a decimal number
+  %h -- %b
+  %H -- hour (24-hour clock) as a decimal number (00-23)
+  %I -- hour (12-hour clock) as a decimal number (01-12)
+  %j -- day of the year as a decimal number (001-366)
+  %m -- month as a decimal number (01-12)
+  %M -- minute as a decimal number (00-59)
+  %n -- new-line character
+  %p -- AM or PM
+  %r -- 12-hour clock time (default: %I:%M:%S %p)
+  %R -- %H:%M
+  %S -- second as a decimal number (00-60)
+  %t -- horizontal-tab character
+  %T -- %H:%M:%S (ISO 8601 time)
+  %u -- ISO 8601 weekday as a decimal number (1-7), where Monday is 1
+  %U -- week number of the year (the first Sunday as the first day of week 1) as a decimal number (00-53)
+  %V -- ISO 8601 week number as a decimal number (01-53)
+  %w -- weekday as a decimal number (0-6), where Sunday is 0
+  %W -- week number of the year (the first Monday as the first day of week 1) as a decimal number (00-53)
+  %x -- date (default: %m/%d/%y)
+  %X -- time (default: %T)
+  %y -- last 2 digits of the year as a decimal number (00-99)
+  %Y -- year as a decimal number
+  %z -- offset from UTC in the ISO 8601 format, or by no characters if no time zone is determinable (example: -0500 for EST)
+  %Z -- time zone name or abbreviation, or by no characters if no time zone is determinable (examples: UTC, EDT, PST)
+  %% -- % (percent sign)
 </pre>
+<p>
+  TIMEFMT processes format strings with the C function strftime().  The above list of conversion specifiers (formatting commands) is from the C (draft C17/C18) standard: some MUCKs may have more conversion specifiers available.
 <p>Also see:
     <a href="#fmtstring">FMTSTRING</a>
 </p>

--- a/game/data/mufman.raw
+++ b/game/data/mufman.raw
@@ -4554,43 +4554,48 @@ TIMEFMT
 TIMEFMT (s i -- s)
 
   Takes a format string and a SYSTIME integer and returns a string formatted
-with the time.  The format string is ascii text with formatting commands:
+with the time.  The format string is ASCII text with formatting commands:
 
 ~~code
-  %% -- "%"
-  %+ -- The date and time in server date format.
-  %a -- abbreviated weekday name.
-  %A -- full weekday name.
-  %b -- abbreviated month name.
-  %B -- full month name.
-  %C -- "%x %X"
-  %c -- century number.
-  %D -- "%m/%d/%y"
-  %d -- month day, "01" - "31"
-  %e -- month day, " 1" - "31"
-  %h -- "%b"
-  %H -- hour, "00" - "23"
-  %I -- hour, "01" - "12"
-  %j -- year day, "001" - "366"
-  %k -- hour, " 0" - "23"
-  %l -- hour, " 1" - "12"
-  %M -- minute, "00" - "59"
-  %m -- month, "01" - "12"
-  %p -- "AM" or "PM"
-  %R -- "%H:%M"
-  %r -- "%I:%M:%S %p"
-  %S -- seconds, "00" - "59"
-  %T -- "%H:%M:%S"
-  %U -- week number of the year. "00" - "52"
-  %w -- week day number, "0" - "6"
-  %W -- week# of year, starting on a monday, "00" - "52"
-  %X -- preferred date representation for the current locale.
-  %x -- preferred time representation for the current locale.
-  %y -- year, "00" - "99"
-  %Y -- year, "1900" - "2155"
-  %z -- numeric time zone. (+hhmm)
-  %Z -- string time zone.  "GMT", "EDT", "PST", etc.
+  %a -- abbreviated weekday name
+  %A -- full weekday name
+  %b -- abbreviated month name
+  %B -- full month name
+  %c -- date and time (default: %a %b %e %T %Y)
+  %C -- year divided by 100 and truncated to an integer, as a decimal number (00-99)
+  %d -- day of the month as a decimal number (01-31)
+  %D -- %m/%d/%y
+  %e -- day of the month as a decimal number (1-31); a single digit is preceded by a space
+  %F -- %Y-%m-%d (ISO 8601 date)
+  %g -- last 2 digits of the ISO 8601 week-based year as a decimal number (00-99)
+  %G -- ISO 8601 week-based year as a decimal number
+  %h -- %b
+  %H -- hour (24-hour clock) as a decimal number (00-23)
+  %I -- hour (12-hour clock) as a decimal number (01-12)
+  %j -- day of the year as a decimal number (001-366)
+  %m -- month as a decimal number (01-12)
+  %M -- minute as a decimal number (00-59)
+  %n -- new-line character
+  %p -- AM or PM
+  %r -- 12-hour clock time (default: %I:%M:%S %p)
+  %R -- %H:%M
+  %S -- second as a decimal number (00-60)
+  %t -- horizontal-tab character
+  %T -- %H:%M:%S (ISO 8601 time)
+  %u -- ISO 8601 weekday as a decimal number (1-7), where Monday is 1
+  %U -- week number of the year (the first Sunday as the first day of week 1) as a decimal number (00-53)
+  %V -- ISO 8601 week number as a decimal number (01-53)
+  %w -- weekday as a decimal number (0-6), where Sunday is 0
+  %W -- week number of the year (the first Monday as the first day of week 1) as a decimal number (00-53)
+  %x -- date (default: %m/%d/%y)
+  %X -- time (default: %T)
+  %y -- last 2 digits of the year as a decimal number (00-99)
+  %Y -- year as a decimal number
+  %z -- offset from UTC in the ISO 8601 format, or by no characters if no time zone is determinable (example: -0500 for EST)
+  %Z -- time zone name or abbreviation, or by no characters if no time zone is determinable (examples: UTC, EDT, PST)
+  %% -- % (percent sign)
 ~~endcode
+  TIMEFMT processes format strings with the C function strftime().  The above list of conversion specifiers (formatting commands) is from the C (draft C17/C18) standard: some MUCKs may have more conversion specifiers available.
 ~~alsosee FMTSTRING
 ~
 ~


### PR DESCRIPTION
The list of conversion specifiers had many errors, in timefmt's documentation.  I documented that timefmt and ftime use strftime(), and replaced the list of conversion specifiers with one more similar to the one in the C standard. (the C17/C18 standard's list of specifiers is compatible with the C99 one, btw)