### PR TITLE
Replace index() with strchr()

### DIFF
--- a/src/boolexp.c
+++ b/src/boolexp.c
@@ -195,7 +195,7 @@ parse_boolexp_F(int descr, const char **parsebuf, dbref player, int dbloadp)
 	remove_ending_whitespace(&p);
 
 	/* check to see if this is a property expression */
-	if (index(buf, PROP_DELIMITER)) {
+	if (strchr(buf, PROP_DELIMITER)) {
 	    if (!dbloadp) {
 		if (Prop_System(buf) || (!Wizard(OWNER(player)) && Prop_Hidden(buf))) {
 		    notify(player,
@@ -313,7 +313,7 @@ static struct boolexp *
 parse_boolprop(char *buf)
 {
     const char *type = alloc_string(buf);
-    char *strval = index(type, PROP_DELIMITER);
+    char *strval = strchr(type, PROP_DELIMITER);
     const char *x;
     struct boolexp *b;
     PropPtr p;

--- a/src/compile.c
+++ b/src/compile.c
@@ -2475,8 +2475,8 @@ do_directive(COMPSTATE * cstat, char *direct)
 	    v_abort_compile(cstat, "Unexpected end of file looking for $pubdef name.");
 
 	if (strcasecmp(tmpname, (char[]){PROP_DELIMITER,0}) &&
-	    (index(tmpname, PROPDIR_DELIMITER) ||
-	     index(tmpname, PROP_DELIMITER) ||
+	    (strchr(tmpname, PROPDIR_DELIMITER) ||
+	     strchr(tmpname, PROP_DELIMITER) ||
 	     Prop_SeeOnly(tmpname) || Prop_Hidden(tmpname) || Prop_System(tmpname))) {
 	    char buf[BUFFER_LEN];
 	    free(tmpname);
@@ -2530,8 +2530,8 @@ do_directive(COMPSTATE * cstat, char *direct)
 	if (!tmpname)
 	    v_abort_compile(cstat, "Unexpected end of file looking for $libdef name.");
 
-	if (index(tmpname, PROPDIR_DELIMITER) ||
-	    index(tmpname, PROP_DELIMITER) ||
+	if (strchr(tmpname, PROPDIR_DELIMITER) ||
+	    strchr(tmpname, PROP_DELIMITER) ||
 	    Prop_SeeOnly(tmpname) || Prop_Hidden(tmpname) || Prop_System(tmpname)) {
 	    char buf[BUFFER_LEN];
 	    free(tmpname);
@@ -3378,7 +3378,7 @@ process_special(COMPSTATE * cstat, const char *token)
 		} else if (!strcmp(varspec, "--")) {
 		    outflag = 1;
 		} else if (!outflag) {
-		    varname = index(varspec, ':');
+		    varname = strchr(varspec, ':');
 		    if (varname) {
 			varname++;
 		    } else {

--- a/src/create.c
+++ b/src/create.c
@@ -114,7 +114,7 @@ do_link(int descr, dbref player, const char *thing_name, const char *dest_name)
     if ((thing = noisy_match_result(&md)) == NOTHING)
 	return;
 
-    if (Typeof(thing) != TYPE_EXIT && index(dest_name, EXIT_DELIMITER)) {
+    if (Typeof(thing) != TYPE_EXIT && strchr(dest_name, EXIT_DELIMITER)) {
         notify(player, "Only actions and exits can be linked to multiple destinations.");
         return;
     }

--- a/src/db.c
+++ b/src/db.c
@@ -488,7 +488,7 @@ getproperties(FILE * f, dbref obj, const char *pdir)
 	    /* fgets reads in \n too! */
 	    if (!strcmp(buf, "*End*\n"))
 		break;
-	    p = index(buf, PROP_DELIMITER);
+	    p = strchr(buf, PROP_DELIMITER);
 	    *(p++) = '\0';	/* Purrrrrrrrrr... */
 	    datalen = strlen(p);
 	    p[datalen - 1] = '\0';
@@ -1033,11 +1033,11 @@ ok_name(const char *name)
             && *name != LOOKUP_TOKEN
             && *name != REGISTERED_TOKEN
             && *name != NUMBER_TOKEN
-            && !index(name, ARG_DELIMITER)
-            && !index(name, AND_TOKEN)
-            && !index(name, OR_TOKEN)
-            && !index(name, '\r')
-            && !index(name, ESCAPE_CHAR)
+            && !strchr(name, ARG_DELIMITER)
+            && !strchr(name, AND_TOKEN)
+            && !strchr(name, OR_TOKEN)
+            && !strchr(name, '\r')
+            && !strchr(name, ESCAPE_CHAR)
             && strcasecmp(name, "me")
             && strcasecmp(name, "here")
             && strcasecmp(name, "home")

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -811,7 +811,7 @@ muf_debugger(int descr, dbref player, dbref program, const char *text, struct fr
 	int startline, endline;
 
 	add_muf_read_event(descr, player, program, fr);
-	if ((ptr2 = (char *) index(arg, ','))) {
+	if ((ptr2 = (char *) strchr(arg, ','))) {
 	    *ptr2++ = '\0';
 	} else {
 	    ptr2 = "";

--- a/src/interface.c
+++ b/src/interface.c
@@ -581,7 +581,7 @@ welcome_user(struct descriptor_data *d)
             perror("spit_file: welcome.txt");
         } else {
             while (fgets(buf, sizeof(buf) - 3, f)) {
-                ptr = index(buf, '\n');
+                ptr = strchr(buf, '\n');
                 if (ptr && ptr > buf && *(ptr - 1) != '\r') {
                     *ptr++ = '\r';
                     *ptr++ = '\n';
@@ -1419,10 +1419,10 @@ initializesock(int s, const char *hostname, int is_ssl)
 #endif
 
     strcpyn(buf, sizeof(buf), hostname);
-    ptr = index(buf, ')');
+    ptr = strchr(buf, ')');
     if (ptr)
 	*ptr = '\0';
-    ptr = index(buf, '(');
+    ptr = strchr(buf, '(');
     *ptr++ = '\0';
     d->hostname = alloc_string(buf);
     d->username = alloc_string(ptr);
@@ -2240,22 +2240,22 @@ resolve_hostnames()
 	    dc++;
 	}
 	if (*ptr2) {
-	    ptr3 = index(ptr2, '|');
+	    ptr3 = strchr(ptr2, '|');
 	    if (!ptr3)
 		return;
 	    hostip = ptr2;
-	    port = index(ptr2, '(');
+	    port = strchr(ptr2, '(');
 	    if (!port)
 		return;
-	    tempptr = index(port, ')');
+	    tempptr = strchr(port, ')');
 	    if (!tempptr)
 		return;
 	    *tempptr = '\0';
 	    hostname = ptr3;
-	    username = index(ptr3, '(');
+	    username = strchr(ptr3, '(');
 	    if (!username)
 		return;
-	    tempptr = index(username, ')');
+	    tempptr = strchr(username, ')');
 	    if (!tempptr)
 		return;
 	    *tempptr = '\0';
@@ -4002,7 +4002,7 @@ show_subfile(dbref player, const char *dir, const char *topic, const char *seg, 
     if (!topic || !*topic)
 	return 0;
 
-    if ((*topic == '.') || (*topic == '~') || (index(topic, '/'))) {
+    if ((*topic == '.') || (*topic == '~') || (strchr(topic, '/'))) {
 	return 0;
     }
     if (strlen(topic) > 63)

--- a/src/mfuns.c
+++ b/src/mfuns.c
@@ -1783,7 +1783,7 @@ mfn_tell(MFUNARGS)
     *buf = '\0';
     strcpyn(buf2, sizeof(buf2), argv[0]);
     for (char *ptr = buf2; (ptr != NULL) && *ptr != '\0'; ptr = ptr2) {
-	ptr2 = index(ptr, '\r');
+	ptr2 = strchr(ptr, '\r');
 	if (ptr2 != NULL) {
 	    *ptr2++ = '\0';
 	} else {
@@ -1834,7 +1834,7 @@ mfn_otell(MFUNARGS)
 	eobj = mesg_dbref_raw(descr, player, what, argv[2]);
     strcpyn(buf2, sizeof(buf2), argv[0]);
     for (char *ptr = buf2; *ptr; ptr = ptr2) {
-	ptr2 = index(ptr, '\r');
+	ptr2 = strchr(ptr, '\r');
 	if (ptr2) {
 	    *ptr2 = '\0';
 	} else {

--- a/src/mfuns.c
+++ b/src/mfuns.c
@@ -418,7 +418,7 @@ mfn_listprops(MFUNARGS)
 	    if ((flag != 0) && (pattern != NULL)) {
 		char *nptr;
 
-		nptr = rindex(ptr, PROPDIR_DELIMITER);
+		nptr = strrchr(ptr, PROPDIR_DELIMITER);
 		if (nptr && *nptr) {
 		    strcpyn(patbuf, sizeof(patbuf), ++nptr);
 		    if (!equalstr(pattern, patbuf)) {

--- a/src/mfuns2.c
+++ b/src/mfuns2.c
@@ -345,7 +345,7 @@ mfn_name(MFUNARGS)
     }
     strcpyn(buf, buflen, NAME(obj));
     if (Typeof(obj) == TYPE_EXIT) {
-	ptr = index(buf, EXIT_DELIMITER);
+	ptr = strchr(buf, EXIT_DELIMITER);
 	if (ptr)
 	    *ptr = '\0';
     }
@@ -1545,7 +1545,7 @@ mfn_force(MFUNARGS)
 	const char *ptr2 = NAME(obj);
 	char objname[BUFFER_LEN], *ptr3;
 
-	nxt = index(ptr, '\r');
+	nxt = strchr(ptr, '\r');
 	if (nxt)
 	    *nxt++ = '\0';
 

--- a/src/p_misc.c
+++ b/src/p_misc.c
@@ -260,7 +260,7 @@ prim_force(PRIM_PROTOTYPE)
 	abort_interp("Object to force not a thing or player. (1)");
     if (0 == strcmp(DoNullInd(oper1->data.string), ""))
 	abort_interp("Empty command argument (2).");
-    if (index(oper1->data.string->data, '\r'))
+    if (strchr(oper1->data.string->data, '\r'))
 	abort_interp("Carriage returns not allowed in command string. (2).");
 #ifdef GOD_PRIV
     if (God(oper2->data.objref) && !God(OWNER(program)))

--- a/src/p_strings.c
+++ b/src/p_strings.c
@@ -2323,7 +2323,7 @@ prim_tokensplit(PRIM_PROTOTYPE)
     } else {
 	esc = '\0';
     }
-    escisdel = index(oper2->data.string->data, esc) != 0;
+    escisdel = strchr(oper2->data.string->data, esc) != 0;
     strcpyn(buf, sizeof(buf), DoNullInd(oper1->data.string));
     ptr = buf;
     out = outbuf;

--- a/src/prochelp.c
+++ b/src/prochelp.c
@@ -230,7 +230,7 @@ print_section_topics(FILE * f, FILE * hf, const char *whichsect)
 	    currsect = sptr->section;
 	    for (struct topiclist *ptr = topichead; ptr; ptr = ptr->next) {
 		if (!strcasecmp(currsect, ptr->section)) {
-		    divpos = index(ptr->topic, '|');
+		    divpos = strchr(ptr->topic, '|');
 		    if (!divpos) {
 			cnt = strlen(ptr->topic);
 		    } else {
@@ -255,7 +255,7 @@ print_section_topics(FILE * f, FILE * hf, const char *whichsect)
 	    hcol = 0;
 	    buf[0] = '\0';
 	    strcpyn(sectname, sizeof(sectname), currsect);
-	    sectptr = index(sectname, '|');
+	    sectptr = strchr(sectname, '|');
 	    if (sectptr) {
 		*sectptr++ = '\0';
 		osectptr = sectptr;
@@ -330,7 +330,7 @@ print_sections(FILE * f, FILE * hf)
 	currsect = sptr->section;
 	buf[0] = '\0';
 	strcpyn(sectname, sizeof(sectname), currsect);
-	sectptr = index(sectname, '|');
+	sectptr = strchr(sectname, '|');
 	if (sectptr) {
 	    *sectptr++ = '\0';
 	    osectptr = sectptr;
@@ -384,7 +384,7 @@ print_topics(FILE * f, FILE * hf)
 	    firstletter = toupper(ptr->topic[0]);
 	    if (firstletter == alph || (!isalpha(alph) && !isalpha(firstletter))) {
 		cnt++;
-		divpos = index(ptr->topic, '|');
+		divpos = strchr(ptr->topic, '|');
 		if (!divpos) {
 		    len = strlen(ptr->topic);
 		} else {
@@ -567,7 +567,7 @@ process_lines(FILE * infile, FILE * outfile, FILE * htmlfile)
 			    "", author);
 		} else if (!strncmp(buf, "~~section ", 10)) {
 		    buf[strlen(buf) - 1] = '\0';
-		    sectptr = index(buf + 10, '|');
+		    sectptr = strchr(buf + 10, '|');
 		    if (sectptr) {
 			*sectptr = '\0';
 		    }
@@ -585,7 +585,7 @@ process_lines(FILE * infile, FILE * outfile, FILE * htmlfile)
 		    skip_whitespace((const char **)&ptr);
 		    while (ptr && *ptr) {
 			ptr2 = ptr;
-			ptr = index(ptr, ',');
+			ptr = strchr(ptr, ',');
 			if (ptr) {
 			    *ptr++ = '\0';
 			    skip_whitespace((const char **)&ptr);

--- a/src/prochelp.c
+++ b/src/prochelp.c
@@ -259,7 +259,7 @@ print_section_topics(FILE * f, FILE * hf, const char *whichsect)
 	    if (sectptr) {
 		*sectptr++ = '\0';
 		osectptr = sectptr;
-		sectptr = rindex(sectptr, '|');
+		sectptr = strrchr(sectptr, '|');
 		if (sectptr) {
 		    sectptr++;
 		}
@@ -334,7 +334,7 @@ print_sections(FILE * f, FILE * hf)
 	if (sectptr) {
 	    *sectptr++ = '\0';
 	    osectptr = sectptr;
-	    sectptr = rindex(sectptr, '|');
+	    sectptr = strrchr(sectptr, '|');
 	    if (sectptr) {
 		sectptr++;
 	    }

--- a/src/propdirs.c
+++ b/src/propdirs.c
@@ -21,7 +21,7 @@ propdir_new_elem(PropPtr * root, char *path)
 	path++;
     if (!*path)
 	return (NULL);
-    n = index(path, PROPDIR_DELIMITER);
+    n = strchr(path, PROPDIR_DELIMITER);
     while (n && *n == PROPDIR_DELIMITER)
 	*(n++) = '\0';
     if (n && *n) {
@@ -50,7 +50,7 @@ propdir_delete_elem(PropPtr root, char *path)
 	path++;
     if (!*path)
 	return (root);
-    n = index(path, PROPDIR_DELIMITER);
+    n = strchr(path, PROPDIR_DELIMITER);
     while (n && *n == PROPDIR_DELIMITER)
 	*(n++) = '\0';
     if (n && *n) {
@@ -91,7 +91,7 @@ propdir_get_elem(PropPtr root, char *path)
 	path++;
     if (!*path)
 	return (NULL);
-    n = index(path, PROPDIR_DELIMITER);
+    n = strchr(path, PROPDIR_DELIMITER);
     while (n && *n == PROPDIR_DELIMITER)
 	*(n++) = '\0';
     if (n && *n) {
@@ -148,7 +148,7 @@ propdir_next_elem(PropPtr root, char *path)
 	path++;
     if (!*path)
 	return (NULL);
-    n = index(path, PROPDIR_DELIMITER);
+    n = strchr(path, PROPDIR_DELIMITER);
     while (n && *n == PROPDIR_DELIMITER)
 	*(n++) = '\0';
     if (n && *n) {

--- a/src/property.c
+++ b/src/property.c
@@ -659,7 +659,7 @@ next_prop_name(dbref player, char *outbuf, size_t outbuflen, char *name)
 	    return NULL;
 	}
 	strcpyn(outbuf, outbuflen, name);
-	ptr = rindex(outbuf, PROPDIR_DELIMITER);
+	ptr = strrchr(outbuf, PROPDIR_DELIMITER);
 	if (!ptr)
 	    ptr = outbuf;
 	*(ptr++) = PROPDIR_DELIMITER;

--- a/src/property.c
+++ b/src/property.c
@@ -39,7 +39,7 @@ set_property_nofetch(dbref player, const char *pname, PData * dat, int sync)
     w = strcpyn(buf, sizeof(buf), pname);
 
     /* truncate propnames with a ':' in them at the ':' */
-    n = index(buf, PROP_DELIMITER);
+    n = strchr(buf, PROP_DELIMITER);
     if (n)
 	*n = '\0';
     if (!*buf)
@@ -831,7 +831,7 @@ db_get_single_prop(FILE * f, dbref obj, long pos, PropPtr pnode, const char *pdi
 	}
     }
 
-    flags = index(name, PROP_DELIMITER);
+    flags = strchr(name, PROP_DELIMITER);
     if (!flags) {
 	wall_wizards
 		("## WARNING! A corrupt property was found while trying to read it from disk.");
@@ -845,7 +845,7 @@ db_get_single_prop(FILE * f, dbref obj, long pos, PropPtr pnode, const char *pdi
     }
     *flags++ = '\0';
 
-    value = index(flags, PROP_DELIMITER);
+    value = strchr(flags, PROP_DELIMITER);
     if (!value) {
 	wall_wizards
 		("## WARNING! A corrupt property was found while trying to read it from disk.");
@@ -859,7 +859,7 @@ db_get_single_prop(FILE * f, dbref obj, long pos, PropPtr pnode, const char *pdi
     }
     *value++ = '\0';
 
-    p = index(value, '\n');
+    p = strchr(value, '\n');
     if (p) {
 	*p = '\0';
     }

--- a/src/props.c
+++ b/src/props.c
@@ -417,7 +417,7 @@ Prop_Check(const char *name, const char what)
 {
     if (*name == what)
 	return (1);
-    while ((name = index(name, PROPDIR_DELIMITER))) {
+    while ((name = strchr(name, PROPDIR_DELIMITER))) {
 	if (name[1] == what)
 	    return (1);
 	name++;

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -229,7 +229,7 @@ static const char * get_username_v6(struct in6_addr *a, int prt, int myprt) {
     if (result < 0)
 	goto bad2;
 
-    ptr = index(buf, ':');
+    ptr = strchr(buf, ':');
     if (!ptr)
 	goto bad2;
     ptr++;
@@ -238,10 +238,10 @@ static const char * get_username_v6(struct in6_addr *a, int prt, int myprt) {
     if (strncmp(ptr, "USERID", 6))
 	goto bad2;
 
-    ptr = index(ptr, ':');
+    ptr = strchr(ptr, ':');
     if (!ptr)
 	goto bad2;
-    ptr = index(ptr + 1, ':');
+    ptr = strchr(ptr + 1, ':');
     if (!ptr)
 	goto bad2;
     ptr++;
@@ -249,7 +249,7 @@ static const char * get_username_v6(struct in6_addr *a, int prt, int myprt) {
 
     shutdown(fd, 2);
     close(fd);
-    if ((ptr2 = index(ptr, '\r')))
+    if ((ptr2 = strchr(ptr, '\r')))
 	*ptr2 = '\0';
     if (!*ptr)
 	return (0);
@@ -484,7 +484,7 @@ static const char * get_username(long a, int prt, int myprt) {
     if (result < 0)
 	goto bad2;
 
-    ptr = index(buf, ':');
+    ptr = strchr(buf, ':');
     if (!ptr)
 	goto bad2;
     ptr++;
@@ -493,10 +493,10 @@ static const char * get_username(long a, int prt, int myprt) {
     if (strncmp(ptr, "USERID", 6))
 	goto bad2;
 
-    ptr = index(ptr, ':');
+    ptr = strchr(ptr, ':');
     if (!ptr)
 	goto bad2;
-    ptr = index(ptr + 1, ':');
+    ptr = strchr(ptr + 1, ':');
     if (!ptr)
 	goto bad2;
     ptr++;
@@ -504,7 +504,7 @@ static const char * get_username(long a, int prt, int myprt) {
 
     shutdown(fd, 2);
     close(fd);
-    if ((ptr2 = index(ptr, '\r')))
+    if ((ptr2 = strchr(ptr, '\r')))
 	*ptr2 = '\0';
     if (!*ptr)
 	return (0);

--- a/src/set.c
+++ b/src/set.c
@@ -183,7 +183,7 @@ do_relink(int descr, dbref player, const char *thing_name, const char *dest_name
     if ((thing = noisy_match_result(&md)) == NOTHING)
 	return;
 
-    if (Typeof(thing) != TYPE_EXIT && index(dest_name, EXIT_DELIMITER)) {
+    if (Typeof(thing) != TYPE_EXIT && strchr(dest_name, EXIT_DELIMITER)) {
 	notify(player, "Only actions and exits can be linked to multiple destinations.");
 	return;
     }
@@ -505,10 +505,10 @@ do_set(int descr, dbref player, const char *name, const char *flag)
 
     /* Now we check to see if it's a property reference */
     /* if this gets changed, please also modify boolexp.c */
-    if (index(flag, PROP_DELIMITER)) {
+    if (strchr(flag, PROP_DELIMITER)) {
 	/* copy the string so we can muck with it */
 	const char *type = alloc_string(flag);	/* type */
-	char *pname = (char *) index(type, PROP_DELIMITER);	/* propname */
+	char *pname = (char *) strchr(type, PROP_DELIMITER);	/* propname */
 	const char *x;		/* to preserve string location so we can free it */
 	char *temp;
 	int ival = 0;

--- a/src/tune.c
+++ b/src/tune.c
@@ -737,7 +737,7 @@ tune_load_parms_from_file(FILE * f, dbref player, int cnt)
     while (!feof(f) && (cnt < 0 || cnt--)) {
 	fgets(buf, sizeof(buf), f);
 	if (*buf != '#') {
-	    c = index(buf, ARG_DELIMITER);
+	    c = strchr(buf, ARG_DELIMITER);
 	    if (c) {
 		*c++ = '\0';
 		p = buf;
@@ -849,7 +849,7 @@ do_tune(dbref player, char *parmname, char *parmval)
     } else if (*parmname && string_prefix(parmname, TP_INFO_CMD)) {
 	/* Space-separated parameters are all in parmname.  Trim out the 'info' command and
 	   any extra spaces */
-	const char *p_trim = index(parmname, ' ');
+	const char *p_trim = strchr(parmname, ' ');
 	if (p_trim != NULL) {
 	    skip_whitespace(&p_trim);
 	    if (*p_trim) {


### PR DESCRIPTION
Also rindex() with strrchr().  Each function is replaced with an entirely identical function, the only difference is the name.  Before, this was done using some #define in config.h.  Now, we're one step closer to getting rid of the string.h/strings.h mess in config.h.
(moving from BSD/strings.h functions to standard/string.h functions, in this case)