### PR TITLE
Change matrix order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ compiler:
 env:
   global:
   matrix:
+    - FLAG_SSL=""            FLAG_MEMPROF=""                   FLAG_DEBUG=""
     - FLAG_SSL="--with-ssl"  FLAG_MEMPROF="--enable-memprof"   FLAG_DEBUG="--enable-debug"
     - FLAG_SSL=""            FLAG_MEMPROF="--enable-memprof"   FLAG_DEBUG="--enable-debug"
     - FLAG_SSL="--with-ssl"  FLAG_MEMPROF="--enable-memprof"   FLAG_DEBUG=""
@@ -21,7 +22,6 @@ env:
     - FLAG_SSL="--with-ssl"  FLAG_MEMPROF=""                   FLAG_DEBUG="--enable-debug"
     - FLAG_SSL=""            FLAG_MEMPROF=""                   FLAG_DEBUG="--enable-debug"
     - FLAG_SSL="--with-ssl"  FLAG_MEMPROF=""                   FLAG_DEBUG=""
-    - FLAG_SSL=""            FLAG_MEMPROF=""                   FLAG_DEBUG=""
 
 script:
   # Set up configure flags


### PR DESCRIPTION
This way, the first things that get built are both the nothing and all settings of the matrix, thus providing the most different builds first, with all the other variations after.
Waiting for the nothing/empty option, last, sometimes took a few minutes. :3