### PR TITLE
Change matrix order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ compiler:
 env:
   global:
   matrix:
+    - FLAG_SSL=""            FLAG_MEMPROF=""                   FLAG_DEBUG=""
     - FLAG_SSL="--with-ssl"  FLAG_MEMPROF="--enable-memprof"   FLAG_DEBUG="--enable-debug"
     - FLAG_SSL=""            FLAG_MEMPROF="--enable-memprof"   FLAG_DEBUG="--enable-debug"
     - FLAG_SSL="--with-ssl"  FLAG_MEMPROF="--enable-memprof"   FLAG_DEBUG=""
@@ -21,7 +22,6 @@ env:
     - FLAG_SSL="--with-ssl"  FLAG_MEMPROF=""                   FLAG_DEBUG="--enable-debug"
     - FLAG_SSL=""            FLAG_MEMPROF=""                   FLAG_DEBUG="--enable-debug"
     - FLAG_SSL="--with-ssl"  FLAG_MEMPROF=""                   FLAG_DEBUG=""
-    - FLAG_SSL=""            FLAG_MEMPROF=""                   FLAG_DEBUG=""
 
 script:
   # Set up configure flags


### PR DESCRIPTION
Attempt 2.  What did does is make Travis build the no-options and all-options builds first.
In the past, the no-option build was always last.  This provides more variety to the immediate results.