### PR TITLE
Don't include sys/file.h

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -277,7 +277,6 @@ extern int errno;
 # include <netdb.h>
 # include <netinet/in.h>
 # include <netinet/tcp.h>
-# include <sys/file.h>
 # include <sys/ioctl.h>
 # include <sys/resource.h>
 # include <sys/socket.h>


### PR DESCRIPTION
I believe this is safe because we already include fcntl.h, sys/types.h, and unistd.h, and I've even seen on some systems (through googling) that sys/file.h is often blank and empty, other than including those things.
On systems where it has stuff, I don't think fuzzball uses anything from it.
future directions: remove the ifdef around stdlib.h and unistd.h, if possible.  (this should definitely be possible for stdlib.h, maybe not for unistd.h)