### PR TITLE
Replace bcopy and bzero with memmove and memset

### DIFF
--- a/include/db.h
+++ b/include/db.h
@@ -335,7 +335,7 @@ struct player_specific {
 #define THING_SET_HOME(x,y)	(PLAYER_SP(x)->home = y)
 
 #define PLAYER_SP(x)		(DBFETCH(x)->sp.player.sp)
-#define ALLOC_PLAYER_SP(x)      { PLAYER_SP(x) = (struct player_specific *)malloc(sizeof(struct player_specific)); bzero(PLAYER_SP(x),sizeof(struct player_specific));}
+#define ALLOC_PLAYER_SP(x)      { PLAYER_SP(x) = (struct player_specific *)malloc(sizeof(struct player_specific)); memset(PLAYER_SP(x),0,sizeof(struct player_specific));}
 #define FREE_PLAYER_SP(x)       { dbref foo = x; free(PLAYER_SP(foo)); PLAYER_SP(foo) = NULL; }
 
 #define PLAYER_HOME(x)		(PLAYER_SP(x)->home)

--- a/src/crt_malloc.c
+++ b/src/crt_malloc.c
@@ -890,7 +890,7 @@ CrT_alloc_prog_string(const char *s, const char *file, int line)
 
     ss->links = 1;
     ss->length = length;
-    bcopy(s, ss->data, ss->length + 1);
+    memmove(ss->data, s, ss->length + 1);
     return (ss);
 }
 

--- a/src/db.c
+++ b/src/db.c
@@ -99,7 +99,7 @@ db_clear_object(dbref i)
 {
     struct object *o = DBFETCH(i);
 
-    bzero(o, sizeof(struct object));
+    memset(o, 0, sizeof(struct object));
 
     NAME(i) = 0;
     ts_newobject(i);

--- a/src/fbmath.c
+++ b/src/fbmath.c
@@ -194,11 +194,11 @@ xMD5Update(struct xMD5Context *ctx, const byte * buf, size_t len)
 
     t = 64 - (t & 0x3f);	/* Space available in ctx->in (at least 1) */
     if ((unsigned) t > (unsigned) len) {
-	bcopy(buf, (byte *) ctx->in + 64 - (unsigned) t, len);
+	memmove((byte *) ctx->in + 64 - (unsigned) t, buf, len);
 	return;
     }
     /* First chunk is an odd size */
-    bcopy(buf, (byte *) ctx->in + 64 - (unsigned) t, (unsigned) t);
+    memmove((byte *) ctx->in + 64 - (unsigned) t, buf, (unsigned) t);
     byteSwap(ctx->in, 16);
     xMD5Transform(ctx->buf, ctx->in);
     buf += (unsigned) t;
@@ -206,7 +206,7 @@ xMD5Update(struct xMD5Context *ctx, const byte * buf, size_t len)
 
     /* Process data in 64-byte chunks */
     while (len >= 64) {
-	bcopy(buf, (byte *) ctx->in, 64);
+	memmove((byte *) ctx->in, buf, 64);
 	byteSwap(ctx->in, 16);
 	xMD5Transform(ctx->buf, ctx->in);
 	buf += 64;
@@ -214,7 +214,7 @@ xMD5Update(struct xMD5Context *ctx, const byte * buf, size_t len)
     }
 
     /* Handle any remaining bytes of data. */
-    bcopy(buf, (byte *) ctx->in, len);
+    memmove((byte *) ctx->in, buf, len);
 }
 
 /*
@@ -249,7 +249,7 @@ xMD5Final(byte digest[16], struct xMD5Context *ctx)
     xMD5Transform(ctx->buf, ctx->in);
 
     byteSwap(ctx->buf, 4);
-    bcopy((byte *) ctx->buf, digest, 16);
+    memmove(digest, (byte *) ctx->buf, 16);
     memset((byte *) ctx, 0, sizeof(ctx));
 }
 

--- a/src/fbmath.c
+++ b/src/fbmath.c
@@ -234,13 +234,13 @@ xMD5Final(byte digest[16], struct xMD5Context *ctx)
     count = 56 - 1 - count;
 
     if (count < 0) {		/* Padding forces an extra block */
-	bzero(p, count + 8);
+	memset(p, 0, count + 8);
 	byteSwap(ctx->in, 16);
 	xMD5Transform(ctx->buf, ctx->in);
 	p = (byte *) ctx->in;
 	count = 56;
     }
-    bzero(p, count + 8);
+    memset(p, 0, count + 8);
     byteSwap(ctx->in, 14);
 
     /* Append length in bits and transform */
@@ -250,7 +250,7 @@ xMD5Final(byte digest[16], struct xMD5Context *ctx)
 
     byteSwap(ctx->buf, 4);
     bcopy((byte *) ctx->buf, digest, 16);
-    bzero((byte *) ctx, sizeof(ctx));
+    memset((byte *) ctx, 0, sizeof(ctx));
 }
 
 /* dest buffer MUST be at least 16 bytes long. */

--- a/src/fbstrings.c
+++ b/src/fbstrings.c
@@ -387,7 +387,7 @@ alloc_prog_string(const char *s)
 
     ss->links = 1;
     ss->length = length;
-    bcopy(s, ss->data, ss->length + 1);
+    memmove(ss->data, s, ss->length + 1);
     return (ss);
 }
 #endif

--- a/src/interface.c
+++ b/src/interface.c
@@ -213,7 +213,7 @@ make_text_block(const char *s, size_t n)
     MALLOC(p, struct text_block, 1);
     MALLOC(p->buf, char, n);
 
-    bcopy(s, p->buf, n);
+    memmove(p->buf, s, n);
     p->nchars = n;
     p->start = p->buf;
     p->nxt = 0;

--- a/src/interface.c
+++ b/src/interface.c
@@ -1598,7 +1598,7 @@ addrout(int lport, long a, unsigned short prt)
     static char buf[128];
     struct in_addr addr;
 
-    bzero(&addr, sizeof(addr));
+    memset(&addr, 0, sizeof(addr));
     memcpy(&addr.s_addr, &a, sizeof(struct in_addr));
 
     prt = ntohs(prt);

--- a/src/p_math.c
+++ b/src/p_math.c
@@ -32,9 +32,8 @@ prim_add(PRIM_PROTOTYPE)
 	} else if (oper1->data.string->length + oper2->data.string->length > (BUFFER_LEN) - 1) {
 	    abort_interp("Operation would result in overflow.");
 	} else {
-	    bcopy(oper2->data.string->data, buf, oper2->data.string->length);
-	    bcopy(oper1->data.string->data, buf + oper2->data.string->length,
-	            oper1->data.string->length + 1);
+	    memmove(buf, oper2->data.string->data, oper2->data.string->length);
+	    memmove(buf + oper2->data.string->length, oper1->data.string->data, oper1->data.string->length + 1);
 	    string = alloc_prog_string(buf);
 	}
 	CLEAR(oper1);
@@ -134,7 +133,7 @@ prim_multiply(PRIM_PROTOTYPE)
             }
 
             for (size_t i = 0; i < (size_t)tmp; i++) {
-                bcopy(DoNullInd(string), buf + i * string->length, string->length);
+                memmove(buf + i * string->length, DoNullInd(string), string->length);
             }
             buf[(size_t)tmp * string->length] = 0;
         } else {

--- a/src/p_strings.c
+++ b/src/p_strings.c
@@ -1263,7 +1263,7 @@ prim_midstr(PRIM_PROTOTYPE)
 	    } else {
 		range = (size_t)oper1->data.number;
 	    }
-	    bcopy(oper3->data.string->data + start, buf, range);
+	    memmove(buf, oper3->data.string->data + start, range);
 	    buf[range] = '\0';
 	}
     }
@@ -1371,12 +1371,11 @@ prim_strcut(PRIM_PROTOTYPE)
 	    PushStrRaw(temp2.data.string);
 	    PushNullStr;
 	} else {
-	    bcopy(temp2.data.string->data, buf, temp1.data.number);
+	    memmove(buf, temp2.data.string->data, temp1.data.number);
 	    buf[temp1.data.number] = '\0';
 	    PushString(buf);
 	    if (temp2.data.string->length > (size_t)temp1.data.number) {
-		bcopy(temp2.data.string->data + temp1.data.number, buf,
-		      temp2.data.string->length - (size_t)temp1.data.number + 1);
+		memmove(buf, temp2.data.string->data + temp1.data.number, temp2.data.string->length - (size_t)temp1.data.number + 1);
 		PushString(buf);
 	    } else {
 		PushNullStr;
@@ -1423,9 +1422,8 @@ prim_strcat(PRIM_PROTOTYPE)
     } else if (oper1->data.string->length + oper2->data.string->length > (BUFFER_LEN) - 1) {
 	abort_interp("Operation would result in overflow.");
     } else {
-	bcopy(oper2->data.string->data, buf, oper2->data.string->length);
-	bcopy(oper1->data.string->data, buf + oper2->data.string->length,
-	      oper1->data.string->length + 1);
+	memmove(buf, oper2->data.string->data, oper2->data.string->length);
+	memmove(buf + oper2->data.string->length, oper1->data.string->data, oper1->data.string->length + 1);
 	string = alloc_prog_string(buf);
     }
     CLEAR(oper1);
@@ -1694,7 +1692,7 @@ prim_explode(PRIM_PROTOTYPE)
 	    return;
 	} else {
 	    result = 0;
-	    bcopy(temp2.data.string->data, buf, temp2.data.string->length + 1);
+	    memmove(buf, temp2.data.string->data, temp2.data.string->length + 1);
 	    for (int i = temp2.data.string->length - 1; i >= 0; i--) {
 		if (!strncmp(buf + i, delimit, temp1.data.string->length)) {
 		    buf[i] = '\0';
@@ -1795,7 +1793,7 @@ prim_subst(PRIM_PROTOTYPE)
 
 	buf[0] = '\0';
 	if (oper3->data.string) {
-	    bcopy(oper3->data.string->data, xbuf, oper3->data.string->length + 1);
+	    memmove(xbuf, oper3->data.string->data, oper3->data.string->length + 1);
 	    match = oper1->data.string->data;
 	    replacement = DoNullInd(oper2->data.string);
 	    k = *replacement ? oper2->data.string->length : 0;


### PR DESCRIPTION
Replace legacy function names with standard C function names.
future directions:
finally get rid of the string.h strings.h memory.h ifdef stuff in config.h :D  and just include both string.h and strings.h
figure out which memmove() can safely be replaced by the more efficient memcpy()