### PR TITLE
checking CI output (don't merge)

### DIFF
--- a/configure
+++ b/configure
@@ -3820,7 +3820,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cflags___fwrapv" >&5
 $as_echo "$ax_cv_check_cflags___fwrapv" >&6; }
 if test "x$ax_cv_check_cflags___fwrapv" = xyes; then :
-  CFLAGS="$CFLAGS -fwrapv"
+  CFLAGS="-std=c99 -fwrapv"
 else
   :
 fi


### PR DESCRIPTION
testing std=c99 without xopen_source, will later test with both