### PR TITLE
Better adhere to Unix hier

### DIFF
--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -61,8 +61,8 @@ mv "$PREFIX/game/data/basedb.db" "$PREFIX/game/data/std-db.db" # Rename database
 ```
 * Start Fuzzball
 ```sh
-/usr/local/sbin/fbmuck/fb-restart
-# If using a custom prefix, $PREFIX/sbin/fbmuck/fb-restart
+/usr/local/sbin/fb-restart
+# If using a custom prefix, $PREFIX/sbin/fb-restart
 ```
 
 [help-mink]: http://www.rdwarf.com/users/mink/muckman/

--- a/README_LINUX.md
+++ b/README_LINUX.md
@@ -61,8 +61,8 @@ mv "$PREFIX/game/data/basedb.db" "$PREFIX/game/data/std-db.db" # Rename database
 ```
 * Start Fuzzball
 ```sh
-/usr/share/fbmuck/restart-script
-# If using a custom prefix, $PREFIX/share/fbmuck/restart-script
+/usr/local/sbin/fbmuck/fb-restart
+# If using a custom prefix, $PREFIX/sbin/fbmuck/fb-restart
 ```
 
 [help-mink]: http://www.rdwarf.com/users/mink/muckman/

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -26,7 +26,7 @@ exec_prefix=@exec_prefix@
 INSTALL_BINDIR=@bindir@
 INSTALL_SBINDIR=@sbindir@
 # Destination for helpfiles
-INSTALL_HELPDIR=@datadir@/fbmuck
+INSTALL_HELPDIR=@datadir@/doc/fbmuck
 
 # #######################################################################
 # 		Variables set by the configure script.

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -86,6 +86,7 @@ all: $(INCLUDE)/defines.h ${TARGETS}
 
 install: all
 	${INSTALL} -d ${INSTALL_BINDIR}
+	${INSTALL} -d ${INSTALL_SBINDIR}
 	${INSTALL_PROGRAM} ${TARGETS} ${INSTALL_BINDIR}
 	${INSTALL} -d ${INSTALL_HELPDIR}
 	${MAKE} help

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -89,7 +89,7 @@ install: all
 	${INSTALL_PROGRAM} ${TARGETS} ${INSTALL_BINDIR}
 	${INSTALL} -d ${INSTALL_HELPDIR}
 	${MAKE} help
-	${INSTALL_SCRIPT} ../game/restart ${INSTALL_HELPDIR}/restart-script
+	${INSTALL_SCRIPT} ../game/restart ${INSTALL_SBINDIR}/fb-restart
 	@echo " "
 	@echo "You may run '${MAKE} install-sysv-inits' to install SysV style init scripts."
 	@echo " "


### PR DESCRIPTION
Move restart command to sbin.  Renamed it so it won't conflict with other programs on a Unix system that might have restart scripts.  Move documentation files to share/doc/fbmuck rather than share/fbmuck
FUTURE DIRECTIONS:
move fbmuck and fb-resolver to sbin
have help files not originate from game/data/, but maybe from docs/
figure out why GNU autostuff uses "install -c" instead of "install", even for other uses...