### PR TITLE
Use standard spellings for definition of pi

### DIFF
--- a/include/fbmath.h
+++ b/include/fbmath.h
@@ -12,25 +12,13 @@
 # define NINF (-9.9E999)
 #endif
 
-#ifdef M_PI
-# define F_PI M_PI
-#else
-# define F_PI 3.141592653589793239
+#ifndef M_PI
+# define M_PI 3.14159265358979323846
 #endif
 
-#ifdef M_PI_2
-# define H_PI M_PI_2
-#else
-# define H_PI 1.5707963267949
+#ifndef M_PI_2
+# define M_PI_2 1.57079632679489661923
 #endif
-
-/*
-#ifdef M_PI_4
-# define Q_PI M_PI_4
-#else
-# define Q_PI 0.7853981633974
-#endif
-*/
 
 #define MIN(p,q) ((p >= q) ? q : p)
 #define MAX(p,q) ((p >= q) ? p : q)

--- a/src/p_float.c
+++ b/src/p_float.c
@@ -79,7 +79,7 @@ void
 prim_pi(PRIM_PROTOTYPE)
 {
     CHECKOP(0);
-    fresult = F_PI;
+    fresult = M_PI;
     CHECKOFLOW(1);
     PushFloat(fresult);
 }
@@ -172,8 +172,8 @@ prim_tan(PRIM_PROTOTYPE)
     if (oper1->type != PROG_FLOAT)
 	abort_interp("Non-float argument. (1)");
     if (!no_good(oper1->data.fnumber)) {
-	fresult = fmod((oper1->data.fnumber - H_PI), F_PI);
-	if (fabs(fresult) > DBL_EPSILON && fabs(fresult - F_PI) > DBL_EPSILON) {
+	fresult = fmod((oper1->data.fnumber - M_PI_2), M_PI);
+	if (fabs(fresult) > DBL_EPSILON && fabs(fresult - M_PI) > DBL_EPSILON) {
 	    fresult = tan(oper1->data.fnumber);
 	} else {
 	    fresult = 0.0;
@@ -232,7 +232,7 @@ prim_atan(PRIM_PROTOTYPE)
     if (!no_good(oper1->data.fnumber)) {
 	fresult = atan(oper1->data.fnumber);
     } else {
-	fresult = H_PI;
+	fresult = M_PI_2;
     }
     CLEAR(oper1);
     PushFloat(fresult);


### PR DESCRIPTION
Many systems have M_PI available, which is mentioned as an optional part of math.h:
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/math.h.html
Instead of defining a unique name for pi all the time, instead, use the standard M_PI.  If it's defined, we use the one defined by math.h.  If not, we define it ourselves.
I also used a slightly longer definition of pi, the same one available in the math.h of GNU, OpenBSD, and FreeBSD.
Interestingly, in a test MUF program just outputting the value of pi with ftostr, we don't get a value of pi as precise as the one we define:
```
Debug> Pid 5: #2 1 ("") INIT FUNC: main (0 args)
Debug> Pid 5: #2 2 ("") PI
Debug> Pid 5: #2 2 ("", 3.141592653589793) FTOSTR
Debug> Pid 5: #2 2 ("", "3.14159265358979") TELL
3.14159265358979
Debug> Pid 5: #2 3 ("") EXIT
```
Program source:
```
: main
pi ftostr tell
;
```
It's still pretty precise, but it makes me wonder if MUF floats and C floats/doubles are different sizes.  For more context, the standard linked above says M_PI is a double in C.