### PR TITLE
Get rid of an unused variable tmpe in p_props.c

### DIFF
--- a/src/p_props.c
+++ b/src/p_props.c
@@ -573,7 +573,6 @@ prim_setprop(PRIM_PROTOTYPE)
 	abort_interp("Permission denied.");
 
     {
-	char *tmpe;
 	char tname[BUFFER_LEN];
 	PData propdat;
 	int len = oper2->data.string->length;


### PR DESCRIPTION
This fixes ".\src\p_props.c(576): warning C4101: 'tmpe': unreferenced local variable" in https://ci.appveyor.com/project/fuzzball-muck/fuzzball/branch/master
Indeed, tmpe was not used in this function prim_setprop anymore.

Also, what are these spare curly braces (now at line 575 and 613) doing?  They introduce a new scope, for naming variables.  But I don't see variables with the same names (tname, propdat, len) being used elsewhere in prim_setprop outside of that scope.  And fuzzball compiles fine when the two brackets are removed.
Looking at github blame, they've been around since the original move to github from cvs.  (there are also similar cases of extra braces in this file, too)
Note I'm a big newb to C so I might be missing something.
OH WAIT, I SEE THE ANSWER: according to https://stackoverflow.com/a/1677801 in C89 you could only create new variables at the beginning of a scope.  (I had previously thought in C89 it was only at the beginning of a function... but apparently I was wrong!)  But that makes me wonder why these same variables weren't just defined at the beginning of the function then.
Since it works either way, it's not important, but, there's that.