### PR TITLE
Improve page's wording for recipient

### DIFF
--- a/dbs/advancedb/muf/59.m
+++ b/dbs/advancedb/muf/59.m
@@ -1877,7 +1877,7 @@ $endif
         dup 1 + rotate
         dup remember-pager
         "You sense that " me @ name strcat
-        " is looking for you in " strcat
+        " is paging you from " strcat
         me @ location name strcat
         over me @ location owner dbcmp if
           me @ location intostr

--- a/dbs/basedb/muf/16.m
+++ b/dbs/basedb/muf/16.m
@@ -1564,7 +1564,7 @@ Gazer's Sort routines
     dup 1 + rotate
     dup remember-pager
     "You sense that " me @ name strcat
-    " is looking for you in " strcat
+    " is paging you from " strcat
     me @ location name strcat
     over me @ location owner dbcmp if
       me @ location intostr

--- a/game/data/help.txt
+++ b/game/data/help.txt
@@ -189,12 +189,11 @@ PAGE
 PAGE <player>
 PAGE <player>=<message>
 
-  In the first form, this tells a player that you are looking for them, like
-'You sense <pager> is looking for you in <location>.'
+  In the first form, this tells a player your location, like
+'You sense that <pager> is paging you from <location>.'
 
   In the second form, with the <message>, the user receives a message like:
-'<pager> pages, "<message>" to you.'  Your location is not revealed in
-message pages.
+'<pager> pages from <location>: "<message>"'
 
   If a player is set HAVEN, you cannot page them.  You will instead be told,
 'That player does not wish to be disturbed.'
@@ -2436,4 +2435,3 @@ Costs:
 Wizards don't need money to do anything.
 ~
 ~
-

--- a/game/data/muckhelp.html
+++ b/game/data/muckhelp.html
@@ -412,13 +412,12 @@ PAGE &lt;player&gt;=&lt;message&gt;
 
 <br>
 </h3>
-  In the first form, this tells a player that you are looking for them, like
-'You sense &lt;pager&gt; is looking for you in &lt;location&gt;.'
+  In the first form, this tells a player your location, like
+'You sense that &lt;pager&gt; is paging you from &lt;location&gt;.'
 
 <p>
   In the second form, with the &lt;message&gt;, the user receives a message like:
-'&lt;pager&gt; pages, &quot;&lt;message&gt;&quot; to you.'  Your location is not revealed in
-message pages.
+'&lt;pager&gt; pages from &lt;location&gt;: &quot;&lt;message&gt;&quot;'
 
 <p>
   If a player is set HAVEN, you cannot page them.  You will instead be told,

--- a/game/data/muckhelp.raw
+++ b/game/data/muckhelp.raw
@@ -44,12 +44,11 @@ PAGE
 PAGE <player>
 PAGE <player>=<message>
 
-  In the first form, this tells a player that you are looking for them, like
-'You sense <pager> is looking for you in <location>.'
+  In the first form, this tells a player your location, like
+'You sense that <pager> is paging you from <location>.'
 
   In the second form, with the <message>, the user receives a message like:
-'<pager> pages, "<message>" to you.'  Your location is not revealed in
-message pages.
+'<pager> pages from <location>: "<message>"'
 
   If a player is set HAVEN, you cannot page them.  You will instead be told,
 'That player does not wish to be disturbed.'

--- a/src/speech.c
+++ b/src/speech.c
@@ -116,7 +116,7 @@ do_page(dbref player, const char *arg1, const char *arg2)
 	return;
     }
     if (blank(arg2))
-	snprintf(buf, sizeof(buf), "You sense that %s is looking for you in %s.",
+	snprintf(buf, sizeof(buf), "You sense that %s is paging you from %s.",
 		 NAME(player), NAME(LOCATION(player)));
     else
 	snprintf(buf, sizeof(buf), "%s pages from %s: \"%s\"", NAME(player),


### PR DESCRIPTION
This wording for sending a location reduces potential confusion with the 'whereis' command available on many MUCKs, and clarifies what page is doing.
In this pull request is also some corrections to the documentation, which incorrectly documented the behavior of basedb/advancedb page instead of fuzzball's page, for sending messages.