### PR TITLE
include errno.h

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -144,6 +144,7 @@
  * Include all the good standard headers here.
  */
 #include <ctype.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
 #include <signal.h>
@@ -187,16 +188,6 @@ typedef int dbref;
 #ifdef MALLOC_PROFILING
 # include "crt_malloc.h"
 #endif	
-
-#if defined (HAVE_ERRNO_H)
-# include <errno.h>
-#else
-# if defined (HAVE_SYS_ERRNO_H)
-#  include <sys/errno.h>
-# else
-extern int errno;
-# endif
-#endif
 
 /******************************************************************/
 /* System configuration stuff... Figure out who and what we are.  */


### PR DESCRIPTION
errno.h is what the C standard and the POSIX standard use.  sys/errno.h isn't something I see mentioned anywhere.  (in fact, on FreeBSD they're identical files, and on OpenBSD, errno.h includes sys/errno.h and then adds more functionality)
resolver.c already specifically includes errno.h, so if this was going to break anything, resolver would already be broken.

TODO: get rid of the checks in autoconf for this
long-term TODO: fix this in fb5's final/bonus release since it causes fb5's build to fail on OpenBSD :P