### PR TITLE
Speed up CI builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,5 +12,7 @@ task:
   install_script: pkg install -y pcre
   script:
     - ./configure --prefix="$PWD/fuzzpre" $FLAG_SSL $FLAG_MEMPROF $FLAG_DEBUG
+    # Speed up CI builds
+    - printf '/CFLAGS=/s/-g//\ns/-O2//\nw\nq\n' | ed -s src/Makefile
     - make
     - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ env:
 script:
   # Set up configure flags
   - ./configure --prefix="$PWD/fuzzpre" $FLAG_SSL $FLAG_MEMPROF $FLAG_DEBUG
+  # Speed up CI builds
+  - printf '/CFLAGS=/s/-g//\ns/-O2//\nw\nq\n' | ed -s src/Makefile
   # Clean up build directory
   - make clean
   # Make Fuzzball and all related code


### PR DESCRIPTION
When building on a CI, remove -g and -O2 flags from src/Makefile after configure is run.