### PR TITLE
compiler warning test (CI check, don't merge)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,6 +13,6 @@ task:
   script:
     - ./configure --prefix="$PWD/fuzzpre" $FLAG_SSL $FLAG_MEMPROF $FLAG_DEBUG
     # Speed up CI builds
-    - printf '/CFLAGS=/s/-g//\ns/-O2//\nw\nq\n' | ed -s src/Makefile
+    - printf '/CFLAGS=/s/-g/-pedantic/\ns/-O2/-Weverything/\nw\nq\n' | ed -s src/Makefile
     - make
     - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
   # Set up configure flags
   - ./configure --prefix="$PWD/fuzzpre" $FLAG_SSL $FLAG_MEMPROF $FLAG_DEBUG
   # Speed up CI builds
-  - printf '/CFLAGS=/s/-g//\ns/-O2//\nw\nq\n' | ed -s src/Makefile
+  - printf '/CFLAGS=/s/-g/-pedantic/\ns/-O2/-Wall -Wextra/\nw\nq\n' | ed -s src/Makefile
   # Clean up build directory
   - make clean
   # Make Fuzzball and all related code


### PR DESCRIPTION
Curious to see what warnings we get when we enable them all on Clang, and many (but absolutely not all) on GCC.  Don't merge this.