### PR TITLE
Fix size_t to int comparison in prochelp

### DIFF
--- a/src/prochelp.c
+++ b/src/prochelp.c
@@ -87,7 +87,7 @@ static const char *doccmd = "";
 static char *
 strcpyn(char *buf, size_t bufsize, const char *src)
 {
-    int pos = 0;
+    size_t pos = 0;
     char *dest = buf;
 
     while (++pos < bufsize && *src) {


### PR DESCRIPTION
bufsize is always a size_t, and pos is only ever compared with bufsize.  Up pos from int to size_t (which CI checks say is an unsigned long)
I still think strcpyn could be replaced with some usage of strncpy...  But this is just a small easy fix for this comparison warning for now.