### PR TITLE
Get rid of double negation where return value is already usable in boolean expression

### DIFF
--- a/src/help.c
+++ b/src/help.c
@@ -83,7 +83,7 @@ index_file(dbref player, const char *onwhat, const char *file)
 void
 do_helpfile(dbref player, const char *dir, const char *file, char *topic, char *segment)
 {
-    if ((!*topic || !*segment) && !!strchr(match_args, ARG_DELIMITER))
+    if ((!*topic || !*segment) && strchr(match_args, ARG_DELIMITER))
         topic = match_args;
 
     if (show_subfile(player, dir, topic, segment, 0))

--- a/src/tune.c
+++ b/src/tune.c
@@ -803,7 +803,7 @@ do_tune(dbref player, char *parmname, char *parmval)
 
     /* If parmname exists, and either has parmvalue or the reset to default flag, try to set the
        value.  Otherwise, fall back to displaying it. */
-    if (*parmname && (!!strchr(match_args, ARG_DELIMITER) || TP_HAS_FLAG_DEFAULT(parmname))) {
+    if (*parmname && (strchr(match_args, ARG_DELIMITER) || TP_HAS_FLAG_DEFAULT(parmname))) {
 	if (force_level) {
 	    notify(player, "You cannot force setting a @tune.");
 	    return;


### PR DESCRIPTION
There's also double negation in property.c but it belongs there since it's saved into an int.