### PR TITLE
Fix non-TLS builds, attempt 2

### DIFF
--- a/src/fbsignal.c
+++ b/src/fbsignal.c
@@ -224,15 +224,16 @@ wall_status(char *s)
 void
 sig_reconfigure(int i)
 {
-    wall_status("Configuration reload requested remotely.");
-#ifdef USE_SSL
-    if (!reconfigure_ssl()) {
-        wall_status("Certificate reload failed!");
-    } else {
-        wall_status("Certificate reload was successful.");
-    }
-#endif
-    wall_status("Configuration reload complete.");
+	wall_status("Configuration reload requested remotely.");
+	#ifdef USE_SSL
+	if (reconfigure_ssl()) {
+		wall_status("Certificate reload was successful.");
+	} else {
+		wall_status("Certificate reload failed!");
+	}
+	#else
+	wall_status("This MUCK wasn't compiled to use TLS, so no certificate reload was attempted.");
+	#endif
 }
 
 /*


### PR DESCRIPTION
Attempt 2: attempts to be more generic in wording.

This diff fixes a build problem, and also provides an informative message to wizards when SIGHUP is received by a MUCK not compiled to use TLS.
Also change order of true and false results for easier readability.  Also changed first wall_status message to specify certificate rather than configuration.  Not intentionally, formatting is changed because the github editor decided to use tabs instead of spaces.  Fine with me.

Relevant previous commits:
https://github.com/fuzzball-muck/fuzzball/commit/55c2bebd65c537551e48a6f2fa40b9131314edf4
https://github.com/fuzzball-muck/fuzzball/commit/3531244046b2e81e5117cfffc01911f6f2dccc09

Results that show Fuzzball building only when compiled with TLS:
https://travis-ci.org/fuzzball-muck/fuzzball/builds/493378579

Compiler error:
https://travis-ci.org/fuzzball-muck/fuzzball/jobs/493378580#L365
https://travis-ci.org/fuzzball-muck/fuzzball/jobs/493378581#L365
https://cirrus-ci.com/task/6399888666394624