### PR TITLE
Ip forward

### DIFF
--- a/include/interface.h
+++ b/include/interface.h
@@ -66,6 +66,7 @@ typedef enum {
 #define TELNET_SE	240
 
 #define TELOPT_STARTTLS	46
+#define TELOPT_FORWARDED  113 /* non-standard; for gateways */
 
 struct text_block {
     size_t nchars;
@@ -104,6 +105,12 @@ struct descriptor_data {
     telnet_states_t telnet_state;
     int telnet_sb_opt;
     int short_reads;
+
+    /* Fields related to ip-forwarding, to support websocket gateways  */
+    int forwarding_enabled;
+    char *forwarded_buffer;
+    int forwarded_size;
+
     time_t last_time;
     time_t connected_at;
     time_t last_pinged_at;

--- a/include/interface.h
+++ b/include/interface.h
@@ -45,7 +45,8 @@ typedef enum {
     TELNET_STATE_DO,
     TELNET_STATE_WONT,
     TELNET_STATE_DONT,
-    TELNET_STATE_SB
+    TELNET_STATE_SB,
+    TELNET_STATE_FORWARDING  // Non-standard telnet extension for gateway support.
 } telnet_states_t;
 
 #define TELNET_IAC	255

--- a/src/interface.c
+++ b/src/interface.c
@@ -307,13 +307,13 @@ queue_ansi(struct descriptor_data *d, const char *msg)
 
 static int
 is_local_connection(struct descriptor_data *d) {
-  /* Treat anything coming from 127.0.0.1 or localhost as local */
-  /* n.b. that this is potentially broken for ipv6 */
-  if (!strcmp(d->hostname, "127.0.0.1") ||
-      !strcmp(d->hostname, "localhost"))
-    return 1;
-  else
-    return 0;
+    /* Treat anything coming from 127.0.0.1 or localhost as local */
+    /* n.b. that this is potentially broken for ipv6 */
+    if (!strcmp(d->hostname, "127.0.0.1") ||
+        !strcmp(d->hostname, "localhost"))
+        return 1;
+    else
+        return 0;
 }
 
 static void
@@ -336,8 +336,8 @@ dump_users(struct descriptor_data *e, char *user)
 
     if (wizard) {
         char *log_name = whowhere(e->player);
-	/* S/he is connected and not quelled. Okay; log it. */
-	log_command("%s: %s", log_name, WHO_COMMAND);
+        /* S/he is connected and not quelled. Okay; log it. */
+        log_command("%s: %s", log_name, WHO_COMMAND);
         free(log_name);
     }
 
@@ -354,20 +354,20 @@ dump_users(struct descriptor_data *e, char *user)
     d = descriptor_list;
     players = 0;
     while (d) {
-	if (d->connected &&
-	    (!tp_who_hides_dark ||
-	     (wizard || !(FLAGS(d->player) & DARK))) &&
-	    ++players && (!user || string_prefix(NAME(d->player), user))
-		) {
+    if (d->connected &&
+        (!tp_who_hides_dark ||
+         (wizard || !(FLAGS(d->player) & DARK))) &&
+        ++players && (!user || string_prefix(NAME(d->player), user))
+        ) {
 
 #ifdef USE_SSL
-	    /* Secure means using SSL or coming from localhost or being forwarded. */
+        /* Secure means using SSL or coming from localhost or being forwarded. */
         if (d->ssl_session || d->forwarding_enabled || is_local_connection(d))
-        	secchar = '@';
-      	else
-        	secchar = ' ';
+            secchar = '@';
+        else
+            secchar = ' ';
 #else
-	    secchar = ' ';
+        secchar = ' ';
 #endif
 
 	    if (wizard) {
@@ -1423,12 +1423,12 @@ initializesock(int s, const char *hostname, int is_ssl)
     d->telnet_sb_opt = 0;
     d->short_reads = 0;
     
-	// Gateway logic
-	d->forwarding_enabled = 0;
-	MALLOC(d->forwarded_buffer, char, 128);
-	d->forwarded_size = 0;
+    // Gateway logic
+    d->forwarding_enabled = 0;
+    MALLOC(d->forwarded_buffer, char, 128);
+    d->forwarded_size = 0;
 
-	d->quota = tp_command_burst_size;
+    d->quota = tp_command_burst_size;
     d->last_time = d->connected_at;
     d->last_pinged_at = d->connected_at;
 
@@ -1921,20 +1921,20 @@ process_input(struct descriptor_data *d)
 		}
 #endif
 
-		// Gateway support.
-		// Copy over the new hostname.
-		if (d->telnet_sb_opt == TELOPT_FORWARDED) {
-			if (d->forwarded_size && d->forwarding_enabled) {
-				d->forwarded_buffer[d->forwarded_size++] = '\0';
-				free((void *) d->hostname);
-				d->hostname = alloc_string(d->forwarded_buffer);
-			}
-			d->forwarded_size = 0;
-		}
-		d->telnet_sb_opt = 0;
+        // Gateway support.
+        // Copy over the new hostname.
+        if (d->telnet_sb_opt == TELOPT_FORWARDED) {
+            if (d->forwarded_size && d->forwarding_enabled) {
+                d->forwarded_buffer[d->forwarded_size++] = '\0';
+                free((void *) d->hostname);
+                d->hostname = alloc_string(d->forwarded_buffer);
+            }
+            d->forwarded_size = 0;
+        }
+        d->telnet_sb_opt = 0;
 
-		d->telnet_state = TELNET_STATE_NORMAL;
-		break;
+        d->telnet_state = TELNET_STATE_NORMAL;
+        break;
 	    case TELNET_IAC:	/* IAC a second time */
 #if 0
 		/* If we were 8 bit clean, we'd pass this along */
@@ -1966,19 +1966,19 @@ process_input(struct descriptor_data *d)
                 process_output(d);
 	    } else
 #endif
-		// If we get a request to do IP forwarding agree to it, 
-		// but only for the localhost.
-		if (*q == TELOPT_FORWARDED) {
-			/* We support TELOPT_FORWARDED */
-			sendbuf[0] = TELNET_IAC;
-			sendbuf[1] = TELNET_DO;
-			sendbuf[2] = *q;
-			sendbuf[3] = '\0';
-			socket_write(d, sendbuf, 3);
-			/* Only support forwarding from the localhost */
-        	if (is_local_connection(d))
-				d->forwarding_enabled = 1;
-		} else
+        // If we get a request to do IP forwarding agree to it, 
+        // but only for the localhost.
+        if (*q == TELOPT_FORWARDED) {
+            /* We support TELOPT_FORWARDED */
+            sendbuf[0] = TELNET_IAC;
+            sendbuf[1] = TELNET_DO;
+            sendbuf[2] = *q;
+            sendbuf[3] = '\0';
+            socket_write(d, sendbuf, 3);
+            /* Only support forwarding from the localhost */
+            if (is_local_connection(d))
+                d->forwarding_enabled = 1;
+        } else
 
 		/* Otherwise, we don't negotiate: send back DONT option */
 	    {
@@ -2015,21 +2015,21 @@ process_input(struct descriptor_data *d)
 	    d->telnet_state = TELNET_STATE_NORMAL;
 	    d->telnet_enabled = 1;
 	} else if (d->telnet_state == TELNET_STATE_SB) {
-	    d->telnet_sb_opt = *((unsigned char *) q);
-		/* Check if this is a forwarded hostname from a gateway */
-		if (d->telnet_sb_opt == TELOPT_FORWARDED && d->forwarding_enabled) {
-			d->telnet_state = TELNET_STATE_FORWARDING;
-		} else {
-			/* TODO: Start remembering other subnegotiation data. */
-			d->telnet_state = TELNET_STATE_NORMAL;
-		}
-	} else if (d->telnet_state == TELNET_STATE_FORWARDING) {
-		if (*((unsigned char *)q) == TELNET_IAC) {
-			d->telnet_state = TELNET_STATE_IAC;
-		} else {
-			if (d->forwarded_size < 127)
-				d->forwarded_buffer[d->forwarded_size++] = *q;
-		}
+        d->telnet_sb_opt = *((unsigned char *) q);
+        /* Check if this is a forwarded hostname from a gateway */
+        if (d->telnet_sb_opt == TELOPT_FORWARDED && d->forwarding_enabled) {
+            d->telnet_state = TELNET_STATE_FORWARDING;
+        } else {
+            /* TODO: Start remembering other subnegotiation data. */
+            d->telnet_state = TELNET_STATE_NORMAL;
+        }
+    } else if (d->telnet_state == TELNET_STATE_FORWARDING) {
+        if (*((unsigned char *)q) == TELNET_IAC) {
+            d->telnet_state = TELNET_STATE_IAC;
+        } else {
+            if (d->forwarded_size < 127)
+                d->forwarded_buffer[d->forwarded_size++] = *q;
+        }
 	} else if (*((unsigned char *) q) == TELNET_IAC) {
 	    /* Got TELNET IAC, store for next byte */
 	    d->telnet_state = TELNET_STATE_IAC;
@@ -3702,11 +3702,11 @@ pdescrsecure(int c)
     struct descriptor_data *d;
 
     d = descrdata_by_descr(c);
-	// Consider local connections to always be secure.
-	// This code assumes forwarded is only supported from
-	// the localhost.
-  	if (d && (d->forwarding_enabled || is_local_connection(d)))
-    	return 1;
+    // Consider local connections to always be secure.
+    // This code assumes forwarded is only supported from
+    // the localhost.
+    if (d && (d->forwarding_enabled || is_local_connection(d)))
+    return 1;
     if (d && d->ssl_session)
 	return 1;
     else

--- a/src/interface.c
+++ b/src/interface.c
@@ -305,6 +305,17 @@ queue_ansi(struct descriptor_data *d, const char *msg)
     return strlen(buf);
 }
 
+static int
+is_local_connection(struct descriptor_data *d) {
+  /* Treat anything coming from 127.0.0.1 or localhost as local */
+  /* n.b. that this is potentially broken for ipv6 */
+  if (!strcmp(d->hostname, "127.0.0.1") ||
+      !strcmp(d->hostname, "localhost"))
+    return 1;
+  else
+    return 0;
+}
+
 static void
 dump_users(struct descriptor_data *e, char *user)
 {
@@ -350,7 +361,11 @@ dump_users(struct descriptor_data *e, char *user)
 		) {
 
 #ifdef USE_SSL
-	    secchar = (d->ssl_session ? '@' : ' ');
+	    /* Secure means using SSL or coming from localhost or being forwarded. */
+        if (d->ssl_session || d->forwarding_enabled || is_local_connection(d))
+        	secchar = '@';
+      	else
+        	secchar = ' ';
 #else
 	    secchar = ' ';
 #endif
@@ -1306,6 +1321,8 @@ shutdownsock(struct descriptor_data *d)
 	free((void *) d->hostname);
     if (d->username)
 	free((void *) d->username);
+	if (d->forwarded_buffer)
+	free((void *)d->forwarded_buffer);
 #ifdef MCP_SUPPORT
     mcp_frame_clear(&d->mcpframe);
 #endif
@@ -1405,7 +1422,13 @@ initializesock(int s, const char *hostname, int is_ssl)
     d->telnet_state = TELNET_STATE_NORMAL;
     d->telnet_sb_opt = 0;
     d->short_reads = 0;
-    d->quota = tp_command_burst_size;
+    
+	// Gateway logic
+	d->forwarding_enabled = 0;
+	MALLOC(d->forwarded_buffer, char, 128);
+	d->forwarded_size = 0;
+
+	d->quota = tp_command_burst_size;
     d->last_time = d->connected_at;
     d->last_pinged_at = d->connected_at;
 
@@ -1897,6 +1920,19 @@ process_input(struct descriptor_data *d)
                     }
 		}
 #endif
+
+		// Gateway support.
+		// Copy over the new hostname.
+		if (d->telnet_sb_opt == TELOPT_FORWARDED) {
+			if (d->forwarded_size && d->forwarding_enabled) {
+				d->forwarded_buffer[d->forwarded_size++] = '\0';
+				free((void *) d->hostname);
+				d->hostname = alloc_string(d->forwarded_buffer);
+			}
+			d->forwarded_size = 0;
+		}
+		d->telnet_sb_opt = 0;
+
 		d->telnet_state = TELNET_STATE_NORMAL;
 		break;
 	    case TELNET_IAC:	/* IAC a second time */
@@ -1930,6 +1966,20 @@ process_input(struct descriptor_data *d)
                 process_output(d);
 	    } else
 #endif
+		// If we get a request to do IP forwarding agree to it, 
+		// but only for the localhost.
+		if (*q == TELOPT_FORWARDED) {
+			/* We support TELOPT_FORWARDED */
+			sendbuf[0] = TELNET_IAC;
+			sendbuf[1] = TELNET_DO;
+			sendbuf[2] = *q;
+			sendbuf[3] = '\0';
+			socket_write(d, sendbuf, 3);
+			/* Only support forwarding from the localhost */
+        	if (is_local_connection(d))
+				d->forwarding_enabled = 1;
+		} else
+
 		/* Otherwise, we don't negotiate: send back DONT option */
 	    {
 		sendbuf[0] = TELNET_IAC;
@@ -1966,8 +2016,20 @@ process_input(struct descriptor_data *d)
 	    d->telnet_enabled = 1;
 	} else if (d->telnet_state == TELNET_STATE_SB) {
 	    d->telnet_sb_opt = *((unsigned char *) q);
-	    /* TODO: Start remembering subnegotiation data. */
-	    d->telnet_state = TELNET_STATE_NORMAL;
+		/* Check if this is a forwarded hostname from a gateway */
+		if (d->telnet_sb_opt == TELOPT_FORWARDED && d->forwarding_enabled) {
+			d->telnet_state = TELNET_STATE_FORWARDING;
+		} else {
+			/* TODO: Start remembering other subnegotiation data. */
+			d->telnet_state = TELNET_STATE_NORMAL;
+		}
+	} else if (d->telnet_state == TELNET_STATE_FORWARDING) {
+		if (*((unsigned char *)q) == TELNET_IAC) {
+			d->telnet_state = TELNET_STATE_IAC;
+		} else {
+			if (d->forwarded_size < 127)
+				d->forwarded_buffer[d->forwarded_size++] = *q;
+		}
 	} else if (*((unsigned char *) q) == TELNET_IAC) {
 	    /* Got TELNET IAC, store for next byte */
 	    d->telnet_state = TELNET_STATE_IAC;
@@ -3640,7 +3702,11 @@ pdescrsecure(int c)
     struct descriptor_data *d;
 
     d = descrdata_by_descr(c);
-
+	// Consider local connections to always be secure.
+	// This code assumes forwarded is only supported from
+	// the localhost.
+  	if (d && (d->forwarding_enabled || is_local_connection(d)))
+    	return 1;
     if (d && d->ssl_session)
 	return 1;
     else


### PR DESCRIPTION
This is similar to the X-Forwarded-For request header in HTTP.
The purpose is to provide administrators running a FORWARDED
aware proxy or webclient accurate hostnames in WHO*.

A client must indicate their desire to use this option with
IAC WILL FORWARDED and receive a IAC DO FORWARDED in response,
after which they may at any time send a sequence like:
IAB SB FORWARDED <hostname> IAC SE.

This is only supported for gateways running on the localhost.