### PR TITLE
Always include unistd.h on Unix

### DIFF
--- a/include/autoconf.h.in
+++ b/include/autoconf.h.in
@@ -72,9 +72,6 @@
 /* Define to 1 if you have the <sys/types.h> header file. */
 #undef HAVE_SYS_TYPES_H
 
-/* Define to 1 if you have the <unistd.h> header file. */
-#undef HAVE_UNISTD_H
-
 /* Enables memory usage profiling. */
 #undef MALLOC_PROFILING
 

--- a/include/config.h
+++ b/include/config.h
@@ -169,10 +169,6 @@ typedef int dbref;
 #define DEBUGPRINT(...)
 #endif				/* DEBUG */
 
-#ifdef HAVE_UNISTD_H
-# include <unistd.h>
-#endif
-
 #ifdef HAVE_RANDOM
 # define SRANDOM(seed)	srandom((seed))
 # define RANDOM()	random()
@@ -238,6 +234,7 @@ typedef int dbref;
 # include <sys/socket.h>
 # include <sys/time.h>
 # include <sys/wait.h>
+# include <unistd.h>
 #endif
 
 #endif				/* _CONFIG_H */


### PR DESCRIPTION
If we don't have unistd.h, we can't even build at all, on modern systems.  fork() and a lotta useful stuff exists there on posix.  So, simply require it.

TODO: check on dirent.h too.  But because it actually IS optional in Fuzzball because of DIR_AVAILABLE, I leave it for another commit.