### PR TITLE
Use normal commands as examples in help

### DIFF
--- a/docs/help.txt
+++ b/docs/help.txt
@@ -1,4 +1,4 @@
-           MUCK Reference Manual for Muck2.2fb7.00b1+master
+            MUCK Reference Manual for Muck2.2fb7.00b1+master
                    by Revar Desmera <revar@belfry.com>
 
 You may get a listing of topics that you can get help on, either sorted
@@ -166,21 +166,21 @@ Also see: @DESC, LOOK, @LOCK, ROB, @SET and GENDER
 ~
 ~
 SAY
-"<message>
 SAY <message>
+"<message>
 
   Says <message> out loud to everyone in the room.  If your name is Igor,
-and you typed '"Hello everyone!', you will see 'You say, "Hello everyone!"'
+and you typed 'say Hello everyone!', you will see 'You say, "Hello everyone!"'
 and everyone else in the room will see 'Igor says, "Hello everyone!"'
 Also see: POSE, WHISPER and PAGE
 ~
 ~
 POSE
-:<message>
 POSE <message>
+:<message>
 
-  Poses a message to everyone in the room.  This is used for actions.  Ie:
-if your name was Igor, and you typed ':falls down.', everyone would see
+  Poses a message to everyone in the room.  This is used for actions.  i.e.:
+if your name was Igor, and you typed 'pose falls down.', everyone would see
     Igor falls down.
 Also see: SAY, WHISPER and PAGE
 ~
@@ -2398,14 +2398,14 @@ cheatsheet   costs
 CHEATSHEET
 Muck Basics Cheatsheet:
 
-This is Fuzzball Muck, a user-extendible, multi-user chat system.
+This is Fuzzball Muck, a user-extensible, multi-user chat system.
 
 Basic commands:
   move/go <direction>
   get/take <thing>; drop/throw <thing>
   look; look <thing>; look <direction>
   say <message>; "<message>
-  :<message> --- shows your name, with the message after it.  Used for actions.
+  pose <message>; :<message> --- shows your name, with the message after it.  Used for actions.
   whisper <player> = <message>
   inventory
   news

--- a/docs/help.txt
+++ b/docs/help.txt
@@ -172,6 +172,7 @@ SAY <message>
   Says <message> out loud to everyone in the room.  If your name is Igor,
 and you typed 'say Hello everyone!', you will see 'You say, "Hello everyone!"'
 and everyone else in the room will see 'Igor says, "Hello everyone!"'
+There's also an abbreviated form of the 'say' command: '"Hello everyone!'
 Also see: POSE, WHISPER and PAGE
 ~
 ~
@@ -182,6 +183,7 @@ POSE <message>
   Poses a message to everyone in the room.  This is used for actions.  i.e.:
 if your name was Igor, and you typed 'pose falls down.', everyone would see
     Igor falls down.
+There's also an abbreviated form of the 'pose' command: ':falls down.'
 Also see: SAY, WHISPER and PAGE
 ~
 ~

--- a/docs/man.txt
+++ b/docs/man.txt
@@ -1,4 +1,4 @@
-           MUF Reference Manual for Muck2.2fb7.00b1+master
+             MUF Reference Manual for Muck2.2fb7.00b1+master
                    by Revar Desmera <revar@belfry.com>
 
 You may get a listing of topics that you can get help on, either sorted

--- a/docs/mpihelp.txt
+++ b/docs/mpihelp.txt
@@ -1,4 +1,4 @@
-           MPI Reference Manual for Muck2.2fb7.00b1+master
+             MPI Reference Manual for Muck2.2fb7.00b1+master
                    by Revar Desmera <revar@belfry.com>
 
 You may get a listing of topics that you can get help on, either sorted

--- a/docs/muckhelp.html
+++ b/docs/muckhelp.html
@@ -377,6 +377,7 @@
   Says &lt;message&gt; out loud to everyone in the room.  If your name is Igor,
 and you typed 'say Hello everyone!', you will see 'You say, &quot;Hello everyone!&quot;'
 and everyone else in the room will see 'Igor says, &quot;Hello everyone!&quot;'
+There's also an abbreviated form of the 'say' command: '&quot;Hello everyone!'
 <p>Also see:
     <a href="#pose">POSE</a>,
     <a href="#whisper">WHISPER</a> and
@@ -397,6 +398,7 @@ if your name was Igor, and you typed 'pose falls down.', everyone would see
 <pre>
     Igor falls down.
 </pre>
+There's also an abbreviated form of the 'pose' command: ':falls down.'
 <p>Also see:
     <a href="#say">SAY</a>,
     <a href="#whisper">WHISPER</a> and

--- a/docs/muckhelp.html
+++ b/docs/muckhelp.html
@@ -367,15 +367,15 @@
 <!-- HTML_TOPICEND -->
 
 
-<h3 id="say">&quot;&lt;message&gt;
+<h3 id="say">SAY &lt;message&gt;
 <br>
-SAY &lt;message&gt;
+&quot;&lt;message&gt;
 <br>
 
 <br>
 </h3>
   Says &lt;message&gt; out loud to everyone in the room.  If your name is Igor,
-and you typed '&quot;Hello everyone!', you will see 'You say, &quot;Hello everyone!&quot;'
+and you typed 'say Hello everyone!', you will see 'You say, &quot;Hello everyone!&quot;'
 and everyone else in the room will see 'Igor says, &quot;Hello everyone!&quot;'
 <p>Also see:
     <a href="#pose">POSE</a>,
@@ -385,15 +385,15 @@ and everyone else in the room will see 'Igor says, &quot;Hello everyone!&quot;'
 <!-- HTML_TOPICEND -->
 
 
-<h3 id="pose">:&lt;message&gt;
+<h3 id="pose">POSE &lt;message&gt;
 <br>
-POSE &lt;message&gt;
+:&lt;message&gt;
 <br>
 
 <br>
 </h3>
-  Poses a message to everyone in the room.  This is used for actions.  Ie:
-if your name was Igor, and you typed ':falls down.', everyone would see
+  Poses a message to everyone in the room.  This is used for actions.  i.e.:
+if your name was Igor, and you typed 'pose falls down.', everyone would see
 <pre>
     Igor falls down.
 </pre>
@@ -3817,7 +3817,7 @@ otherwise, only Wizards may do so.
 <br>
 
 <br>
-This is Fuzzball Muck, a user-extendible, multi-user chat system.
+This is Fuzzball Muck, a user-extensible, multi-user chat system.
 <br>
 
 <br>
@@ -3829,7 +3829,7 @@ Basic commands:
   get/take &lt;thing&gt;; drop/throw &lt;thing&gt;
   look; look &lt;thing&gt;; look &lt;direction&gt;
   say &lt;message&gt;; &quot;&lt;message&gt;
-  :&lt;message&gt; --- shows your name, with the message after it.  Used for actions.
+  pose &lt;message&gt;; :&lt;message&gt; --- shows your name, with the message after it.  Used for actions.
   whisper &lt;player&gt; = &lt;message&gt;
   inventory
   news

--- a/src/muckhelp.raw
+++ b/src/muckhelp.raw
@@ -19,21 +19,21 @@ The word 'me' refers to yourself. Some things to do when starting out:
 ~
 ~
 SAY
-"<message>
 SAY <message>
+"<message>
 
   Says <message> out loud to everyone in the room.  If your name is Igor,
-and you typed '"Hello everyone!', you will see 'You say, "Hello everyone!"'
+and you typed 'say Hello everyone!', you will see 'You say, "Hello everyone!"'
 and everyone else in the room will see 'Igor says, "Hello everyone!"'
 ~~alsosee POSE,WHISPER,PAGE
 ~
 ~
 POSE
-:<message>
 POSE <message>
+:<message>
 
-  Poses a message to everyone in the room.  This is used for actions.  Ie:
-if your name was Igor, and you typed ':falls down.', everyone would see
+  Poses a message to everyone in the room.  This is used for actions.  i.e.:
+if your name was Igor, and you typed 'pose falls down.', everyone would see
 ~~code
     Igor falls down.
 ~~endcode
@@ -2220,7 +2220,7 @@ otherwise, only Wizards may do so.
 CHEATSHEET
 Muck Basics Cheatsheet:
 
-This is Fuzzball Muck, a user-extendible, multi-user chat system.
+This is Fuzzball Muck, a user-extensible, multi-user chat system.
 
 Basic commands:
 ~~code
@@ -2228,7 +2228,7 @@ Basic commands:
   get/take <thing>; drop/throw <thing>
   look; look <thing>; look <direction>
   say <message>; "<message>
-  :<message> --- shows your name, with the message after it.  Used for actions.
+  pose <message>; :<message> --- shows your name, with the message after it.  Used for actions.
   whisper <player> = <message>
   inventory
   news

--- a/src/muckhelp.raw
+++ b/src/muckhelp.raw
@@ -25,6 +25,7 @@ SAY <message>
   Says <message> out loud to everyone in the room.  If your name is Igor,
 and you typed 'say Hello everyone!', you will see 'You say, "Hello everyone!"'
 and everyone else in the room will see 'Igor says, "Hello everyone!"'
+There's also an abbreviated form of the 'say' command: '"Hello everyone!'
 ~~alsosee POSE,WHISPER,PAGE
 ~
 ~
@@ -37,6 +38,7 @@ if your name was Igor, and you typed 'pose falls down.', everyone would see
 ~~code
     Igor falls down.
 ~~endcode
+There's also an abbreviated form of the 'pose' command: ':falls down.'
 ~~alsosee SAY,WHISPER,PAGE
 ~
 ~


### PR DESCRIPTION
Have examples use say and pose rather than " and : shorthands.  Shorthands are still documented.
Also correct typos.