### PR TITLE
Regenerate minimaldb

### DIFF
--- a/dbs/minimal/data/minimal.db
+++ b/dbs/minimal/data/minimal.db
@@ -188,12 +188,6 @@ Room Zero
 *Props*
 _/de:2:You are in Room Zero. It's very dark here.
 _/osc:2:is briefly visible through the mist.
-_sys/dumpinterval:3:14400
-_sys/lastdumptime:3:1551890386
-_sys/max_connects:3:1
-_sys/maxpennies:3:10000
-_sys/shutdowntime:3:1551890386
-_sys/startuptime:3:1551890371
 *End*
 -1
 -1

--- a/dbs/minimal/data/minimal.db
+++ b/dbs/minimal/data/minimal.db
@@ -1,165 +1,164 @@
 ***Foxen9 TinyMUCK DUMP Format***
 2
 1
-158
-autolook_cmd=look
-cpennies=Pennies
-cpenny=Penny
-pennies=pennies
-penny=penny
-description_default=You see nothing special.
-dumpdone_mesg=## Save complete. ##
-dumping_mesg=## Pausing to save database. This may take a while. ##
-dumpwarn_mesg=## Game will pause to save the database in a few minutes. ##
-file_connection_help=data/connect-help.txt
-file_credits=data/credits.txt
-file_editor_help=data/edit-help.txt
-file_help=data/help.txt
-file_help_dir=data/help
-file_info_dir=data/info/
-file_log_cmd_times=logs/cmd-times
-file_log_commands=logs/commands
-file_log_gripes=logs/gripes
-file_log_malloc=logs/malloc
-file_log_muf_errors=logs/muf-errors
-file_log_programs=logs/programs
-file_log_sanfix=logs/sanfixed
-file_log_sanity=logs/sanity
-file_log_status=logs/status
-file_log_stderr=logs/fbmuck.err
-file_log_stdout=logs/fbmuck
-file_log_user=logs/user
-file_man=data/man.txt
-file_man_dir=data/man
-file_motd=data/motd.txt
-file_mpihelp=data/mpihelp.txt
-file_mpihelp_dir=data/mpihelp
-file_news=data/news.txt
-file_news_dir=data/news
-file_sysparms=data/parmfile.cfg
-file_welcome_screen=data/welcome.txt
-idle_boot_mesg=Autodisconnecting for inactivity.
-huh_mesg=Huh?  (Type "help" for help.)
-leave_mesg=Come back later!
-muckname=TygryssMUCK
-playermax_bootmesg=Sorry, but there are too many players online.  Please try reconnecting in a few minutes.
-playermax_warnmesg=You likely won't be able to connect right now, since too many players are online.
-gender_prop=sex
-register_mesg=Sorry, you can get a character by e-mailing XXXX@machine.net.address with a charname and password.
-ssl_cert_file=data/server.pem
-ssl_key_file=data/server.pem
-ssl_keyfile_passwd=
+157
+%autolook_cmd=look
+%cpennies=Pennies
+%cpenny=Penny
+%pennies=pennies
+%penny=penny
+%dumpdone_mesg=## Save complete. ##
+%dumping_mesg=## Pausing to save database. This may take a while. ##
+%dumpwarn_mesg=## Game will pause to save the database in a few minutes. ##
+%file_connection_help=data/connect-help.txt
+%file_credits=data/credits.txt
+%file_editor_help=data/edit-help.txt
+%file_help=data/help.txt
+%file_help_dir=data/help
+%file_info_dir=data/info/
+%file_log_cmd_times=logs/cmd-times
+%file_log_commands=logs/commands
+%file_log_gripes=logs/gripes
+%file_log_malloc=logs/malloc
+%file_log_muf_errors=logs/muf-errors
+%file_log_programs=logs/programs
+%file_log_sanfix=logs/sanfixed
+%file_log_sanity=logs/sanity
+%file_log_status=logs/status
+%file_log_stderr=logs/fbmuck.err
+%file_log_stdout=logs/fbmuck
+%file_log_user=logs/user
+%file_man=data/man.txt
+%file_man_dir=data/man
+%file_motd=data/motd.txt
+%file_mpihelp=data/mpihelp.txt
+%file_mpihelp_dir=data/mpihelp
+%file_news=data/news.txt
+%file_news_dir=data/news
+%file_sysparms=data/parmfile.cfg
+%file_welcome_screen=data/welcome.txt
+%idle_boot_mesg=Autodisconnecting for inactivity.
+%description_default=You see nothing special.
+%huh_mesg=Huh?  (Type "help" for help.)
+%leave_mesg=Come back later!
+%muckname=TygryssMUCK
+%playermax_bootmesg=Sorry, but there are too many players online.  Please try reconnecting in a few minutes.
+%playermax_warnmesg=You likely won't be able to connect right now, since too many players are online.
+%gender_prop=sex
+%register_mesg=Sorry, you can get a character by e-mailing XXXX@machine.net.address with a charname and password.
+%ssl_cert_file=data/server.pem
+%ssl_key_file=data/server.pem
+%ssl_keyfile_passwd=
 %ssl_cipher_preference_list=ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA
 %ssl_min_protocol_version=None
-pcreate_flags=B
-reserved_names=
-reserved_player_names=
-aging_time= 90d  0:00:00
-dump_interval=  0d  4:00:00
-dump_warntime=  0d  0:02:00
-idle_ping_time=  0d  0:00:55
-maxidle=  0d  2:00:00
-clean_interval=  0d  0:15:00
+%pcreate_flags=B
+%reserved_names=
+%reserved_player_names=
+%aging_time= 90d  0:00:00
+%dump_interval=  0d  4:00:00
+%dump_warntime=  0d  0:02:00
+%idle_ping_time=  0d  0:00:55
+%maxidle=  0d  2:00:00
+%clean_interval=  0d  0:15:00
 %pname_history_threshold= 30d  0:00:00
-player_name_limit=16
-exit_cost=1
-link_cost=1
-lookup_cost=0
-max_object_endowment=100
-object_cost=10
-room_cost=10
-max_pennies=10000
-penny_rate=8
-start_pennies=50
-kill_base_cost=100
-kill_bonus=50
-kill_min_cost=10
-listen_mlev=3
-cmd_log_threshold_msec=1000
-max_force_level=1
-mpi_max_commands=2048
-addpennies_muf_mlev=2
-instr_slice=2000
-max_instr_count=20000
-max_ml4_preempt_count=0
-max_ml4_nested_interp_loop_count=0
-max_nested_interp_loop_count=16
-max_plyr_processes=32
-max_process_limit=400
-mcp_muf_mlev=3
-movepennies_muf_mlev=2
-pennies_muf_mlev=1
-process_timer_limit=4
-userlog_mlev=3
-playermax_limit=56
-command_burst_size=500
-command_time_msec=1000
-commands_per_time=2
-max_output=131071
-free_frames_pool=8
-max_loaded_objs=5
-pause_min=0
-default_room_parent=#0
-lost_and_found=#0
-player_start=#0
-toad_default_recipient=#1
-7bit_thing_names=yes
-7bit_other_names=no
-enable_home=yes
-enable_match_yield=yes
-enable_prefix=no
-recognize_null_command=no
-verbose_clone=no
-verbose_examine=yes
-dark_sleepers=no
-exit_darking=yes
-thing_darking=yes
-who_hides_dark=yes
-compatible_priorities=yes
-realms_control=no
-toad_recycle=no
-diskbase_propvals=yes
-dbdump_warning=yes
-dumpdone_warning=yes
-starttls_allow=no
-idleboot=yes
-idle_ping_enable=yes
-restrict_kill=yes
-allow_listeners=yes
-allow_listeners_env=yes
-allow_listeners_obj=yes
-log_commands=yes
-log_failed_commands=no
-log_interactive=yes
-log_programs=yes
-allow_zombies=yes
-wiz_vehicles=no
-ignore_support=yes
-ignore_bidirectional=yes
-m3_huh=no
-strict_god_priv=yes
+%player_name_limit=16
+%exit_cost=1
+%link_cost=1
+%lookup_cost=0
+%max_object_endowment=100
+%object_cost=10
+%room_cost=10
+%max_pennies=10000
+%penny_rate=8
+%start_pennies=50
+%kill_base_cost=100
+%kill_bonus=50
+%kill_min_cost=10
+%listen_mlev=3
+%cmd_log_threshold_msec=1000
+%max_force_level=1
+%mpi_max_commands=2048
+%addpennies_muf_mlev=2
+%instr_slice=2000
+%max_instr_count=20000
+%max_ml4_preempt_count=0
+%max_ml4_nested_interp_loop_count=0
+%max_nested_interp_loop_count=16
+%max_plyr_processes=32
+%max_process_limit=400
+%mcp_muf_mlev=3
+%movepennies_muf_mlev=2
+%pennies_muf_mlev=1
+%process_timer_limit=4
+%userlog_mlev=3
+%playermax_limit=56
+%command_burst_size=500
+%command_time_msec=1000
+%commands_per_time=2
+%max_output=131071
+%free_frames_pool=8
+%max_loaded_objs=5
+%pause_min=0
+%default_room_parent=#0
+%lost_and_found=#0
+%player_start=#0
+%toad_default_recipient=#1
+%7bit_thing_names=yes
+%7bit_other_names=no
+%enable_home=yes
+%enable_match_yield=yes
+%enable_prefix=no
+%recognize_null_command=no
+%verbose_clone=no
+%verbose_examine=yes
+%dark_sleepers=no
+%exit_darking=yes
+%thing_darking=yes
+%who_hides_dark=yes
+%compatible_priorities=yes
+%realms_control=no
+%toad_recycle=no
+%diskbase_propvals=yes
+%dbdump_warning=yes
+%dumpdone_warning=yes
+%starttls_allow=no
+%idleboot=yes
+%idle_ping_enable=yes
+%restrict_kill=yes
+%allow_listeners=yes
+%allow_listeners_env=yes
+%allow_listeners_obj=yes
+%log_commands=yes
+%log_failed_commands=no
+%log_interactive=yes
+%log_programs=yes
+%autolink_actions=no
+%allow_zombies=yes
+%wiz_vehicles=no
+%ignore_support=yes
+%ignore_bidirectional=yes
+%m3_huh=no
+%strict_god_priv=yes
 %tab_input_replaced_with_space=yes
-autolink_actions=no
-teleport_to_player=yes
-secure_teleport=no
-secure_thing_movement=no
-do_mpi_parsing=yes
-consistent_lock_source=yes
-expanded_debug_trace=yes
-force_mlev1_name_notify=yes
-muf_comments_strict=yes
-muf_string_math=no
-optimize_muf=yes
-playermax=no
-quiet_moves=no
-lock_envcheck=no
-show_legacy_props=no
-registration=yes
+%teleport_to_player=yes
+%secure_teleport=no
+%secure_thing_movement=no
+%do_mpi_parsing=yes
+%consistent_lock_source=yes
+%expanded_debug_trace=yes
+%force_mlev1_name_notify=yes
+%muf_comments_strict=yes
+%optimize_muf=yes
+%playermax=no
+%quiet_moves=no
+%lock_envcheck=no
+%show_legacy_props=no
+%registration=yes
 %server_cipher_preference=yes
-periodic_program_purge=yes
+%periodic_program_purge=yes
 %pname_history_reporting=yes
-secure_who=no
-use_hostnames=no
+%secure_who=no
+%use_hostnames=no
 #1
 One
 0
@@ -167,8 +166,8 @@ One
 -1
 1310739
 1435685445
-1456843742
-1
+1551890386
+2
 1435685445
 *Props*
 _/de:2:You see Number One.
@@ -183,12 +182,18 @@ Room Zero
 -1
 0
 1435685445
-1456843733
-1
+1551890378
+2
 1435685445
 *Props*
 _/de:2:You are in Room Zero. It's very dark here.
 _/osc:2:is briefly visible through the mist.
+_sys/dumpinterval:3:14400
+_sys/lastdumptime:3:1551890386
+_sys/max_connects:3:1
+_sys/maxpennies:3:10000
+_sys/shutdowntime:3:1551890386
+_sys/startuptime:3:1551890371
 *End*
 -1
 -1

--- a/game/data/minimal.db
+++ b/game/data/minimal.db
@@ -188,12 +188,6 @@ Room Zero
 *Props*
 _/de:2:You are in Room Zero. It's very dark here.
 _/osc:2:is briefly visible through the mist.
-_sys/dumpinterval:3:14400
-_sys/lastdumptime:3:1551890386
-_sys/max_connects:3:1
-_sys/maxpennies:3:10000
-_sys/shutdowntime:3:1551890386
-_sys/startuptime:3:1551890371
 *End*
 -1
 -1

--- a/game/data/minimal.db
+++ b/game/data/minimal.db
@@ -1,165 +1,164 @@
 ***Foxen9 TinyMUCK DUMP Format***
 2
 1
-158
-autolook_cmd=look
-cpennies=Pennies
-cpenny=Penny
-pennies=pennies
-penny=penny
-description_default=You see nothing special.
-dumpdone_mesg=## Save complete. ##
-dumping_mesg=## Pausing to save database. This may take a while. ##
-dumpwarn_mesg=## Game will pause to save the database in a few minutes. ##
-file_connection_help=data/connect-help.txt
-file_credits=data/credits.txt
-file_editor_help=data/edit-help.txt
-file_help=data/help.txt
-file_help_dir=data/help
-file_info_dir=data/info/
-file_log_cmd_times=logs/cmd-times
-file_log_commands=logs/commands
-file_log_gripes=logs/gripes
-file_log_malloc=logs/malloc
-file_log_muf_errors=logs/muf-errors
-file_log_programs=logs/programs
-file_log_sanfix=logs/sanfixed
-file_log_sanity=logs/sanity
-file_log_status=logs/status
-file_log_stderr=logs/fbmuck.err
-file_log_stdout=logs/fbmuck
-file_log_user=logs/user
-file_man=data/man.txt
-file_man_dir=data/man
-file_motd=data/motd.txt
-file_mpihelp=data/mpihelp.txt
-file_mpihelp_dir=data/mpihelp
-file_news=data/news.txt
-file_news_dir=data/news
-file_sysparms=data/parmfile.cfg
-file_welcome_screen=data/welcome.txt
-idle_boot_mesg=Autodisconnecting for inactivity.
-huh_mesg=Huh?  (Type "help" for help.)
-leave_mesg=Come back later!
-muckname=TygryssMUCK
-playermax_bootmesg=Sorry, but there are too many players online.  Please try reconnecting in a few minutes.
-playermax_warnmesg=You likely won't be able to connect right now, since too many players are online.
-gender_prop=sex
-register_mesg=Sorry, you can get a character by e-mailing XXXX@machine.net.address with a charname and password.
-ssl_cert_file=data/server.pem
-ssl_key_file=data/server.pem
-ssl_keyfile_passwd=
+157
+%autolook_cmd=look
+%cpennies=Pennies
+%cpenny=Penny
+%pennies=pennies
+%penny=penny
+%dumpdone_mesg=## Save complete. ##
+%dumping_mesg=## Pausing to save database. This may take a while. ##
+%dumpwarn_mesg=## Game will pause to save the database in a few minutes. ##
+%file_connection_help=data/connect-help.txt
+%file_credits=data/credits.txt
+%file_editor_help=data/edit-help.txt
+%file_help=data/help.txt
+%file_help_dir=data/help
+%file_info_dir=data/info/
+%file_log_cmd_times=logs/cmd-times
+%file_log_commands=logs/commands
+%file_log_gripes=logs/gripes
+%file_log_malloc=logs/malloc
+%file_log_muf_errors=logs/muf-errors
+%file_log_programs=logs/programs
+%file_log_sanfix=logs/sanfixed
+%file_log_sanity=logs/sanity
+%file_log_status=logs/status
+%file_log_stderr=logs/fbmuck.err
+%file_log_stdout=logs/fbmuck
+%file_log_user=logs/user
+%file_man=data/man.txt
+%file_man_dir=data/man
+%file_motd=data/motd.txt
+%file_mpihelp=data/mpihelp.txt
+%file_mpihelp_dir=data/mpihelp
+%file_news=data/news.txt
+%file_news_dir=data/news
+%file_sysparms=data/parmfile.cfg
+%file_welcome_screen=data/welcome.txt
+%idle_boot_mesg=Autodisconnecting for inactivity.
+%description_default=You see nothing special.
+%huh_mesg=Huh?  (Type "help" for help.)
+%leave_mesg=Come back later!
+%muckname=TygryssMUCK
+%playermax_bootmesg=Sorry, but there are too many players online.  Please try reconnecting in a few minutes.
+%playermax_warnmesg=You likely won't be able to connect right now, since too many players are online.
+%gender_prop=sex
+%register_mesg=Sorry, you can get a character by e-mailing XXXX@machine.net.address with a charname and password.
+%ssl_cert_file=data/server.pem
+%ssl_key_file=data/server.pem
+%ssl_keyfile_passwd=
 %ssl_cipher_preference_list=ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA
 %ssl_min_protocol_version=None
-pcreate_flags=B
-reserved_names=
-reserved_player_names=
-aging_time= 90d  0:00:00
-dump_interval=  0d  4:00:00
-dump_warntime=  0d  0:02:00
-idle_ping_time=  0d  0:00:55
-maxidle=  0d  2:00:00
-clean_interval=  0d  0:15:00
+%pcreate_flags=B
+%reserved_names=
+%reserved_player_names=
+%aging_time= 90d  0:00:00
+%dump_interval=  0d  4:00:00
+%dump_warntime=  0d  0:02:00
+%idle_ping_time=  0d  0:00:55
+%maxidle=  0d  2:00:00
+%clean_interval=  0d  0:15:00
 %pname_history_threshold= 30d  0:00:00
-player_name_limit=16
-exit_cost=1
-link_cost=1
-lookup_cost=0
-max_object_endowment=100
-object_cost=10
-room_cost=10
-max_pennies=10000
-penny_rate=8
-start_pennies=50
-kill_base_cost=100
-kill_bonus=50
-kill_min_cost=10
-listen_mlev=3
-cmd_log_threshold_msec=1000
-max_force_level=1
-mpi_max_commands=2048
-addpennies_muf_mlev=2
-instr_slice=2000
-max_instr_count=20000
-max_ml4_preempt_count=0
-max_ml4_nested_interp_loop_count=0
-max_nested_interp_loop_count=16
-max_plyr_processes=32
-max_process_limit=400
-mcp_muf_mlev=3
-movepennies_muf_mlev=2
-pennies_muf_mlev=1
-process_timer_limit=4
-userlog_mlev=3
-playermax_limit=56
-command_burst_size=500
-command_time_msec=1000
-commands_per_time=2
-max_output=131071
-free_frames_pool=8
-max_loaded_objs=5
-pause_min=0
-default_room_parent=#0
-lost_and_found=#0
-player_start=#0
-toad_default_recipient=#1
-7bit_thing_names=yes
-7bit_other_names=no
-enable_home=yes
-enable_match_yield=yes
-enable_prefix=no
-recognize_null_command=no
-verbose_clone=no
-verbose_examine=yes
-dark_sleepers=no
-exit_darking=yes
-thing_darking=yes
-who_hides_dark=yes
-compatible_priorities=yes
-realms_control=no
-toad_recycle=no
-diskbase_propvals=yes
-dbdump_warning=yes
-dumpdone_warning=yes
-starttls_allow=no
-idleboot=yes
-idle_ping_enable=yes
-restrict_kill=yes
-allow_listeners=yes
-allow_listeners_env=yes
-allow_listeners_obj=yes
-log_commands=yes
-log_failed_commands=no
-log_interactive=yes
-log_programs=yes
-allow_zombies=yes
-wiz_vehicles=no
-ignore_support=yes
-ignore_bidirectional=yes
-m3_huh=no
-strict_god_priv=yes
+%player_name_limit=16
+%exit_cost=1
+%link_cost=1
+%lookup_cost=0
+%max_object_endowment=100
+%object_cost=10
+%room_cost=10
+%max_pennies=10000
+%penny_rate=8
+%start_pennies=50
+%kill_base_cost=100
+%kill_bonus=50
+%kill_min_cost=10
+%listen_mlev=3
+%cmd_log_threshold_msec=1000
+%max_force_level=1
+%mpi_max_commands=2048
+%addpennies_muf_mlev=2
+%instr_slice=2000
+%max_instr_count=20000
+%max_ml4_preempt_count=0
+%max_ml4_nested_interp_loop_count=0
+%max_nested_interp_loop_count=16
+%max_plyr_processes=32
+%max_process_limit=400
+%mcp_muf_mlev=3
+%movepennies_muf_mlev=2
+%pennies_muf_mlev=1
+%process_timer_limit=4
+%userlog_mlev=3
+%playermax_limit=56
+%command_burst_size=500
+%command_time_msec=1000
+%commands_per_time=2
+%max_output=131071
+%free_frames_pool=8
+%max_loaded_objs=5
+%pause_min=0
+%default_room_parent=#0
+%lost_and_found=#0
+%player_start=#0
+%toad_default_recipient=#1
+%7bit_thing_names=yes
+%7bit_other_names=no
+%enable_home=yes
+%enable_match_yield=yes
+%enable_prefix=no
+%recognize_null_command=no
+%verbose_clone=no
+%verbose_examine=yes
+%dark_sleepers=no
+%exit_darking=yes
+%thing_darking=yes
+%who_hides_dark=yes
+%compatible_priorities=yes
+%realms_control=no
+%toad_recycle=no
+%diskbase_propvals=yes
+%dbdump_warning=yes
+%dumpdone_warning=yes
+%starttls_allow=no
+%idleboot=yes
+%idle_ping_enable=yes
+%restrict_kill=yes
+%allow_listeners=yes
+%allow_listeners_env=yes
+%allow_listeners_obj=yes
+%log_commands=yes
+%log_failed_commands=no
+%log_interactive=yes
+%log_programs=yes
+%autolink_actions=no
+%allow_zombies=yes
+%wiz_vehicles=no
+%ignore_support=yes
+%ignore_bidirectional=yes
+%m3_huh=no
+%strict_god_priv=yes
 %tab_input_replaced_with_space=yes
-autolink_actions=no
-teleport_to_player=yes
-secure_teleport=no
-secure_thing_movement=no
-do_mpi_parsing=yes
-consistent_lock_source=yes
-expanded_debug_trace=yes
-force_mlev1_name_notify=yes
-muf_comments_strict=yes
-muf_string_math=no
-optimize_muf=yes
-playermax=no
-quiet_moves=no
-lock_envcheck=no
-show_legacy_props=no
-registration=yes
+%teleport_to_player=yes
+%secure_teleport=no
+%secure_thing_movement=no
+%do_mpi_parsing=yes
+%consistent_lock_source=yes
+%expanded_debug_trace=yes
+%force_mlev1_name_notify=yes
+%muf_comments_strict=yes
+%optimize_muf=yes
+%playermax=no
+%quiet_moves=no
+%lock_envcheck=no
+%show_legacy_props=no
+%registration=yes
 %server_cipher_preference=yes
-periodic_program_purge=yes
+%periodic_program_purge=yes
 %pname_history_reporting=yes
-secure_who=no
-use_hostnames=no
+%secure_who=no
+%use_hostnames=no
 #1
 One
 0
@@ -167,8 +166,8 @@ One
 -1
 1310739
 1435685445
-1456843742
-1
+1551890386
+2
 1435685445
 *Props*
 _/de:2:You see Number One.
@@ -183,12 +182,18 @@ Room Zero
 -1
 0
 1435685445
-1456843733
-1
+1551890378
+2
 1435685445
 *Props*
 _/de:2:You are in Room Zero. It's very dark here.
 _/osc:2:is briefly visible through the mist.
+_sys/dumpinterval:3:14400
+_sys/lastdumptime:3:1551890386
+_sys/max_connects:3:1
+_sys/maxpennies:3:10000
+_sys/shutdowntime:3:1551890386
+_sys/startuptime:3:1551890371
 *End*
 -1
 -1


### PR DESCRIPTION
Did this by wiping sysparms from db manually and saving what fuzzball itself saves back to db.
Does anyone know what the now-gone sysparm is?  I remember some have been recently removed.  (and the number is 157 instead of 158 now...)

I manually deleted all but one sysparm in minimaldb, changed 158 to 1, and fuzzball was able to start.  I then started, did at-shutdown, and voila, minimaldb was made again.
I want to figure out how to make the smallest minimaldb possible, but UNTIL THEN, this at least makes all sysparms show up as [default] when they are default.  That is a good success.

I do realise some extra props are at the bottom.

Onward to trueminimaldb!