### PR TITLE
Add stdbool.h (don't merge, CI check)

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -157,6 +157,7 @@
 #include <limits.h>
 #include <signal.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
I'm most interested in seeing how Windows builds react, as a CI check..  This IS part of the standard C library, so Windows should be okay, but...  I wonder~
I want to see how people react here
https://github.com/fuzzball-muck/fuzzball/issues/354
first though, so don't merge.  I'd also want to find a good use for it and actually use it before adding it, of course.