### PR TITLE
Remove extra newline in muckhelp.raw

### DIFF
--- a/docs/help.txt
+++ b/docs/help.txt
@@ -2387,4 +2387,3 @@ Costs:
 Wizards don't need money to do anything.
 ~
 ~
-

--- a/docs/muckhelp.html
+++ b/docs/muckhelp.html
@@ -3792,5 +3792,5 @@ Wizards don't need money to do anything.
 <!-- HTML_TOPICEND -->
 
 
-<h3 id=""></body>
+</body>
 </html>

--- a/src/muckhelp.raw
+++ b/src/muckhelp.raw
@@ -2215,4 +2215,3 @@ Costs:
 Wizards don't need money to do anything.
 ~
 ~
-


### PR DESCRIPTION
It was adding a spurious H3 element to the html version.  I noticed the MPI and MUF manuals didn't have this blank line, nor that extra H3.