### PR TITLE
Fix up includes a bit, part 1 of 2 or more

### DIFF
--- a/include/compile.h
+++ b/include/compile.h
@@ -8,6 +8,8 @@
 #ifndef _COMPILE_H
 #define _COMPILE_H
 
+#include "config.h"
+
 /*
  * @TODO free_prog_real is a static in compile.c
  *       It is inappropriate for a define that uses it to be in a public

--- a/include/edit.h
+++ b/include/edit.h
@@ -1,6 +1,8 @@
 #ifndef _EDIT_H
 #define _EDIT_H
 
+#include "config.h"
+
 struct macrotable {
     char *name;
     char *definition;

--- a/include/edit.h
+++ b/include/edit.h
@@ -2,6 +2,7 @@
 #define _EDIT_H
 
 #include "config.h"
+#include "inst.h"
 
 struct macrotable {
     char *name;

--- a/include/fbmath.h
+++ b/include/fbmath.h
@@ -3,6 +3,7 @@
 
 #include <float.h>
 #include <math.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #if defined(HUGE_VAL)

--- a/include/fbstrings.h
+++ b/include/fbstrings.h
@@ -9,6 +9,9 @@
 #ifndef _FBSTRINGS_H
 #define _FBSTRINGS_H
 
+#include <stddef.h>
+#include "config.h"
+
 /**
  * Turn 's' into an empty string if it is NULL.
  *

--- a/include/hashtab.h
+++ b/include/hashtab.h
@@ -1,6 +1,8 @@
 #ifndef _HASHTAB_H
 #define _HASHTAB_H
 
+#include "config.h"
+
 /* Possible data types that may be stored in a hash table */
 union u_hash_data {
     int ival;                   /* Store compiler tokens here */

--- a/include/interp.h
+++ b/include/interp.h
@@ -117,7 +117,6 @@ struct mufwatchpidlist {
     int pid;
 };
 
-int dequeue_prog_real(dbref, int, const char *, const int);
 #define dequeue_prog(x,i) dequeue_prog_real(x,i,__FILE__,__LINE__)
 
 #define STD_REGUID 0

--- a/include/interp.h
+++ b/include/interp.h
@@ -117,8 +117,6 @@ struct mufwatchpidlist {
     int pid;
 };
 
-#define dequeue_prog(x,i) dequeue_prog_real(x,i,__FILE__,__LINE__)
-
 #define STD_REGUID 0
 #define STD_SETUID 1
 #define STD_HARDUID 2

--- a/include/interp.h
+++ b/include/interp.h
@@ -4,7 +4,6 @@
 #include "array.h"
 #include "fbstrings.h"
 #include "inst.h"
-#include "timequeue.h"
 
 /* Some icky machine/compiler #defines. --jim */
 #ifdef MIPS

--- a/include/interp.h
+++ b/include/interp.h
@@ -117,6 +117,7 @@ struct mufwatchpidlist {
     int pid;
 };
 
+int dequeue_prog_real(dbref, int, const char *, const int);
 #define dequeue_prog(x,i) dequeue_prog_real(x,i,__FILE__,__LINE__)
 
 #define STD_REGUID 0

--- a/include/interp.h
+++ b/include/interp.h
@@ -4,6 +4,7 @@
 #include "array.h"
 #include "fbstrings.h"
 #include "inst.h"
+#include "timequeue.h"
 
 /* Some icky machine/compiler #defines. --jim */
 #ifdef MIPS

--- a/include/mcpgui.h
+++ b/include/mcpgui.h
@@ -4,6 +4,9 @@
 #ifndef _MCPGUI_H
 #define _MCPGUI_H
 
+#include "interp.h"
+#include "mcp.h"
+
 /*
  * Error results.
  */

--- a/include/move.h
+++ b/include/move.h
@@ -1,6 +1,8 @@
 #ifndef _MOVE_H
 #define _MOVE_H
 
+#include "config.h"
+
 void enter_room(int descr, dbref player, dbref loc, dbref exit);
 void moveto(dbref what, dbref where);
 void send_contents(int descr, dbref loc, dbref dest);

--- a/include/msgparse.h
+++ b/include/msgparse.h
@@ -1,6 +1,9 @@
 #ifndef _MSGPARSE_H
 #define _MSGPARSE_H
 
+#include <time.h>
+#include "config.h"
+
 #define MAX_MFUN_NAME_LEN 16
 #define MAX_MFUN_LIST_LEN 512
 #define MPI_MAX_VARIABLES 32

--- a/include/mufevent.h
+++ b/include/mufevent.h
@@ -2,6 +2,7 @@
 #define _MUFEVENT_H
 
 #include "array.h"
+#include "interp.h"
 
 stk_array *get_mufevent_pids(stk_array * nw, dbref ref);
 stk_array *get_mufevent_pidinfo(stk_array * nw, int pid, int pinned);

--- a/include/player.h
+++ b/include/player.h
@@ -1,6 +1,8 @@
 #ifndef _PLAYER_H
 #define _PLAYER_H
 
+#include "config.h"
+
 void add_player(dbref who);
 int check_password(dbref player, const char *password);
 void change_player_name(dbref player, const char *name);

--- a/include/predicates.h
+++ b/include/predicates.h
@@ -1,6 +1,9 @@
 #ifndef _PREDICATES_H
 #define _PREDICATES_H
 
+#include "config.h"
+#include "db.h"
+
 int can_doit(int descr, dbref player, dbref thing, const char *default_fail_msg);
 int can_link(dbref who, dbref what);
 int can_link_to(dbref who, object_flag_type what_type, dbref where);

--- a/include/props.h
+++ b/include/props.h
@@ -9,6 +9,8 @@
 #ifndef _PROPS_H
 #define _PROPS_H
 
+#include "config.h"
+
 /*
  * Property data union to support all available property types.
  *

--- a/include/timequeue.h
+++ b/include/timequeue.h
@@ -20,6 +20,7 @@ int add_muf_queue_event(int descr, dbref player, dbref loc, dbref trig, dbref pr
 int control_process(dbref player, int procnum);
 int dequeue_process(int procnum);
 int dequeue_prog_real(dbref, int, const char *, const int);
+#define dequeue_prog(x,i) dequeue_prog_real(x,i,__FILE__,__LINE__)
 int dequeue_timers(int procnum, char *timerid);
 void envpropqueue(int descr, dbref player, dbref where, dbref trigger, dbref what,
                          dbref xclude, const char *propname, const char *toparg, int mlev,


### PR DESCRIPTION
The goal of these diffs is to get more includes into the files they belong in.  This is in preparation for using iwyu, https://include-what-you-use.org/ to help us move standard C header includes out of config.h and into the files they belong in.

These results come from me applying the automatic fixes from iwyu and seeing what broke, and fixing what broke.  (no!  this pull request does not include the automatic iwyu fixes.  those will come in a second PR)