### PR TITLE
Add some includes to .c files

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -6,7 +6,6 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
-#include <assert.h>
 #include <float.h>
 #include <math.h>
 #include <stdio.h>

--- a/src/compile.c
+++ b/src/compile.c
@@ -18,6 +18,7 @@
 #include "compile.h"
 #include "db.h"
 #include "edit.h"
+#include "fbmath.h"
 #include "fbstrings.h"
 #include "game.h"
 #include "hashtab.h"

--- a/src/db.c
+++ b/src/db.c
@@ -1,5 +1,10 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
+#include "boolexp.h"
 #include "compile.h"
 #include "db.h"
 #ifdef DISKBASE

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -1,3 +1,8 @@
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
 #include "compile.h"

--- a/src/diskprop.c
+++ b/src/diskprop.c
@@ -1,5 +1,3 @@
-#include "config.h"
-
 #ifdef DISKBASE
 #include "db.h"
 #include "diskprop.h"

--- a/src/diskprop.c
+++ b/src/diskprop.c
@@ -1,3 +1,5 @@
+#include "config.h"
+
 #ifdef DISKBASE
 #include "db.h"
 #include "diskprop.h"

--- a/src/edit.c
+++ b/src/edit.c
@@ -5,8 +5,14 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
+#include "array.h"
 #include "boolexp.h"
 #include "commands.h"
 #include "compile.h"

--- a/src/events.c
+++ b/src/events.c
@@ -1,3 +1,5 @@
+#include <time.h>
+
 #include "config.h"
 
 #include "compile.h"

--- a/src/fbmath.c
+++ b/src/fbmath.c
@@ -5,6 +5,8 @@
 #include <string.h>
 #include <time.h>
 
+#include "config.h"
+
 #include "fbmath.h"
 #include "inst.h"
 

--- a/src/fbmath.c
+++ b/src/fbmath.c
@@ -1,4 +1,9 @@
-#include "config.h"
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 
 #include "fbmath.h"
 #include "inst.h"

--- a/src/fbsignal.c
+++ b/src/fbsignal.c
@@ -1,11 +1,16 @@
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+
 #include "config.h"
 
+#include "autoconf.h"
 #include "fbsignal.h"
 #include "db.h"
 #include "game.h"
 #include "interface.h"
 #include "log.h"
-#include "tune.h"
 
 #ifndef WIN32
 

--- a/src/fbsignal.c
+++ b/src/fbsignal.c
@@ -11,6 +11,7 @@
 #include "game.h"
 #include "interface.h"
 #include "log.h"
+#include "tune.h"
 
 #ifndef WIN32
 

--- a/src/fbstrings.c
+++ b/src/fbstrings.c
@@ -6,11 +6,17 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
 #include "db.h"
 #include "fbstrings.h"
 #include "game.h"
+#include "inst.h"
 #include "mpi.h"
 #include "props.h"
 #include "tune.h"

--- a/src/fbtime.c
+++ b/src/fbtime.c
@@ -1,7 +1,10 @@
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
 #include "config.h"
 
 #include "db.h"
-#include "fbstrings.h"
 #include "fbtime.h"
 
 void

--- a/src/fbtime.c
+++ b/src/fbtime.c
@@ -5,6 +5,7 @@
 #include "config.h"
 
 #include "db.h"
+#include "fbstrings.h"
 #include "fbtime.h"
 
 void

--- a/src/game.c
+++ b/src/game.c
@@ -7,6 +7,13 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <ctype.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
 #include "config.h"
 
 #include "commands.h"
@@ -19,7 +26,6 @@
 #include "events.h"
 #include "fbsignal.h"
 #include "fbstrings.h"
-#include "fbtime.h"
 #include "game.h"
 #include "interface.h"
 #include "log.h"

--- a/src/game.c
+++ b/src/game.c
@@ -26,6 +26,7 @@
 #include "events.h"
 #include "fbsignal.h"
 #include "fbstrings.h"
+#include "fbtime.h"
 #include "game.h"
 #include "interface.h"
 #include "log.h"

--- a/src/hashtab.c
+++ b/src/hashtab.c
@@ -2,6 +2,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "config.h"
+
+#include "fbstrings.h"
 #include "hashtab.h"
 
 /* hash:  compute hash value for a string

--- a/src/hashtab.c
+++ b/src/hashtab.c
@@ -1,6 +1,7 @@
-#include "config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-#include "fbstrings.h"
 #include "hashtab.h"
 
 /* hash:  compute hash value for a string

--- a/src/help.c
+++ b/src/help.c
@@ -19,6 +19,7 @@
 #include "commands.h"
 #include "db.h"
 #include "fbstrings.h"
+#include "fbtime.h"
 #include "game.h"
 #include "interface.h"
 #include "log.h"

--- a/src/help.c
+++ b/src/help.c
@@ -8,12 +8,17 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
 #include "config.h"
 
 #include "commands.h"
 #include "db.h"
 #include "fbstrings.h"
-#include "fbtime.h"
 #include "game.h"
 #include "interface.h"
 #include "log.h"

--- a/src/interface.c
+++ b/src/interface.c
@@ -7,8 +7,19 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+
 #include "config.h"
 
+#include "autoconf.h"
 #include "commands.h"
 #include "db.h"
 #include "defines.h"
@@ -27,7 +38,6 @@
 #include "mcpgui.h"
 #endif
 #include "mpi.h"
-#include "msgparse.h"
 #include "mufevent.h"
 #include "player.h"
 #include "predicates.h"

--- a/src/interface.c
+++ b/src/interface.c
@@ -38,6 +38,7 @@
 #include "mcpgui.h"
 #endif
 #include "mpi.h"
+#include "msgparse.h"
 #include "mufevent.h"
 #include "player.h"
 #include "predicates.h"

--- a/src/interface_ssl.c
+++ b/src/interface_ssl.c
@@ -1,6 +1,6 @@
-#ifdef USE_SSL
-
 #include "config.h"
+
+#ifdef USE_SSL
 
 #include "interface_ssl.h"
 #include "log.h"

--- a/src/interface_ssl.c
+++ b/src/interface_ssl.c
@@ -1,5 +1,3 @@
-#include "config.h"
-
 #ifdef USE_SSL
 
 #include "interface_ssl.h"

--- a/src/interface_ssl.c
+++ b/src/interface_ssl.c
@@ -1,5 +1,7 @@
 #ifdef USE_SSL
 
+#include "config.h"
+
 #include "interface_ssl.h"
 #include "log.h"
 

--- a/src/interp.c
+++ b/src/interp.c
@@ -1,5 +1,11 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
 #include "config.h"
 
+#include "array.h"
 #include "boolexp.h"
 #include "compile.h"
 #include "db.h"

--- a/src/log.c
+++ b/src/log.c
@@ -1,7 +1,12 @@
+#include <ctype.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
 #include "config.h"
 
 #include "db.h"
-#include "fbtime.h"
 #include "fbstrings.h"
 #include "inst.h"
 #include "log.h"

--- a/src/log.c
+++ b/src/log.c
@@ -7,6 +7,7 @@
 #include "config.h"
 
 #include "db.h"
+#include "fbtime.h"
 #include "fbstrings.h"
 #include "inst.h"
 #include "log.h"

--- a/src/look.c
+++ b/src/look.c
@@ -6,6 +6,12 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
 #include "config.h"
 
 #include "boolexp.h"

--- a/src/match.c
+++ b/src/match.c
@@ -1,3 +1,8 @@
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
 #include "db.h"

--- a/src/mcp.c
+++ b/src/mcp.c
@@ -6,6 +6,11 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
 #ifdef MCP_SUPPORT

--- a/src/mcpgui.c
+++ b/src/mcpgui.c
@@ -1,3 +1,8 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
 #ifdef MCP_SUPPORT

--- a/src/mcppkgs.c
+++ b/src/mcppkgs.c
@@ -1,10 +1,17 @@
 #include "config.h"
 
 #ifdef MCP_SUPPORT
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "compile.h"
 #include "db.h"
 #include "edit.h"
 #include "fbstrings.h"
+#include "inst.h"
 #include "interface.h"
 #include "log.h"
 #include "mcp.h"

--- a/src/mfuns.c
+++ b/src/mfuns.c
@@ -1,7 +1,14 @@
+#include <ctype.h>
+#include <limits.h>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
 #include "config.h"
 
 #include "db.h"
-#include "fbmath.h"
 #include "fbstrings.h"
 #include "fbtime.h"
 #include "game.h"

--- a/src/mfuns.c
+++ b/src/mfuns.c
@@ -9,6 +9,7 @@
 #include "config.h"
 
 #include "db.h"
+#include "fbmath.h"
 #include "fbstrings.h"
 #include "fbtime.h"
 #include "game.h"

--- a/src/mfuns2.c
+++ b/src/mfuns2.c
@@ -1,9 +1,14 @@
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
 #include "config.h"
 
 #include "boolexp.h"
 #include "color.h"
 #include "db.h"
-#include "fbmath.h"
 #include "fbstrings.h"
 #include "game.h"
 #include "interp.h"

--- a/src/mfuns2.c
+++ b/src/mfuns2.c
@@ -9,6 +9,7 @@
 #include "boolexp.h"
 #include "color.h"
 #include "db.h"
+#include "fbmath.h"
 #include "fbstrings.h"
 #include "game.h"
 #include "interp.h"

--- a/src/move.c
+++ b/src/move.c
@@ -6,13 +6,15 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <stdio.h>
+#include <string.h>
+
 #include "config.h"
 
 #include "boolexp.h"
 #include "commands.h"
 #include "db.h"
 #include "edit.h"
-#include "fbstrings.h"
 #include "fbtime.h"
 #include "game.h"
 #include "interface.h"

--- a/src/move.c
+++ b/src/move.c
@@ -15,6 +15,7 @@
 #include "commands.h"
 #include "db.h"
 #include "edit.h"
+#include "fbstrings.h"
 #include "fbtime.h"
 #include "game.h"
 #include "interface.h"

--- a/src/msgparse.c
+++ b/src/msgparse.c
@@ -1,5 +1,12 @@
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
 #include "config.h"
 
+#include "boolexp.h"
 #include "db.h"
 #include "fbstrings.h"
 #include "game.h"

--- a/src/mufevent.c
+++ b/src/mufevent.c
@@ -1,3 +1,8 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
 #include "config.h"
 
 #include "array.h"

--- a/src/p_array.c
+++ b/src/p_array.c
@@ -1,3 +1,8 @@
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
 #include "array.h"

--- a/src/p_connects.c
+++ b/src/p_connects.c
@@ -1,3 +1,5 @@
+#include <stddef.h>
+
 #include "config.h"
 
 #include "array.h"

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -1,5 +1,10 @@
+#include <ctype.h>
+#include <stdlib.h>
+#include <time.h>
+
 #include "config.h"
 
+#include "array.h"
 #include "boolexp.h"
 #include "compile.h"
 #include "db.h"

--- a/src/p_float.c
+++ b/src/p_float.c
@@ -1,7 +1,7 @@
+#include <float.h>
 #include <math.h>
 #include <stdio.h>
 #include <string.h>
-#include <float.h>
 
 #include "config.h"
 

--- a/src/p_float.c
+++ b/src/p_float.c
@@ -1,3 +1,8 @@
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+#include <float.h>
+
 #include "config.h"
 
 #include "db.h"

--- a/src/p_math.c
+++ b/src/p_math.c
@@ -1,3 +1,8 @@
+#include <float.h>
+#include <limits.h>
+#include <math.h>
+#include <string.h>
+
 #include "config.h"
 
 #include "db.h"

--- a/src/p_mcp.c
+++ b/src/p_mcp.c
@@ -1,3 +1,7 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
 #ifdef MCP_SUPPORT

--- a/src/p_misc.c
+++ b/src/p_misc.c
@@ -1,5 +1,12 @@
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
 #include "config.h"
 
+#include "array.h"
 #include "boolexp.h"
 #include "compile.h"
 #include "db.h"

--- a/src/p_props.c
+++ b/src/p_props.c
@@ -1,3 +1,7 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
 #include "array.h"

--- a/src/p_regex.c
+++ b/src/p_regex.c
@@ -1,7 +1,13 @@
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
 #include "array.h"
 #include "db.h"
+#include "fbstrings.h"
 #include "hashtab.h"
 #include "inst.h"
 #include "interp.h"

--- a/src/p_stack.c
+++ b/src/p_stack.c
@@ -1,3 +1,9 @@
+#include <ctype.h>
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
 #include "array.h"

--- a/src/p_strings.c
+++ b/src/p_strings.c
@@ -1,5 +1,12 @@
+#include <ctype.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
+#include "array.h"
 #include "boolexp.h"
 #include "color.h"
 #include "db.h"

--- a/src/player.c
+++ b/src/player.c
@@ -6,6 +6,12 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
 #include "config.h"
 
 #include "commands.h"
@@ -21,6 +27,7 @@
 #include "log.h"
 #include "move.h"
 #include "player.h"
+#include "props.h"
 #include "timequeue.h"
 #include "tune.h"
 

--- a/src/propdirs.c
+++ b/src/propdirs.c
@@ -8,6 +8,8 @@
  * see LICENSE.md for full details.
  */
 
+#include <string.h>
+
 #include "config.h"
 
 #include "db.h"

--- a/src/property.c
+++ b/src/property.c
@@ -9,6 +9,11 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
 #include "boolexp.h"

--- a/src/props.c
+++ b/src/props.c
@@ -9,6 +9,9 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "config.h"
 

--- a/src/sanity.c
+++ b/src/sanity.c
@@ -9,6 +9,12 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <ctype.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
 #include "boolexp.h"

--- a/src/set.c
+++ b/src/set.c
@@ -5,6 +5,12 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <ctype.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
 #include "boolexp.h"

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -1,3 +1,6 @@
+#include <stddef.h>
+#include <stdint.h>
+
 #include "config.h"
 
 #include "sha1.h"

--- a/src/speech.c
+++ b/src/speech.c
@@ -5,6 +5,8 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <stdio.h>
+
 #include "config.h"
 
 #include "commands.h"

--- a/src/timequeue.c
+++ b/src/timequeue.c
@@ -5,6 +5,11 @@
  *
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
 #include "config.h"
 
 #include "array.h"

--- a/src/tune.c
+++ b/src/tune.c
@@ -6,6 +6,11 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "config.h"
 
 #include "array.h"

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -5,6 +5,12 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
 #include "config.h"
 
 #include "boolexp.h"


### PR DESCRIPTION
.h files will be done in a separate pull request.  Removing includes from config.h will be done in a separate pull request, too.

Unfortunately, even though I started also removing some includes, I realised I don't know the code well enough to safely do that.  There are a lotta ifdefs, especially platform-related stuff.
In this pull request, I only add standard C headers, no unix/posix ones.  I also chose not to add assert.h includes. EDIT: I do add some unix/posix headers, but only ones from the "include all the good standard headers here" section of config.h that work on Windows too.

I'd like to see all CI checks pass before this is merged, in case I made a mistake.  So much repetitive text, slightly dizzy. uwu

This should be a harmless pull request.  The only thing that might cause consequences are if any standard header other than assert.h also has "hey, define or undefine X _**before**_ including Y.h" but I don't think we have anything like that in fbmuck.