### PR TITLE
Continue docs - crt_malloc

### DIFF
--- a/include/crt_malloc.h
+++ b/include/crt_malloc.h
@@ -1,9 +1,23 @@
+/** @file crt_malloc.h
+ *
+ * This is the header file for the crt_malloc system, which is used for
+ * memory profiling.  This system is only turned on when MALLOC_PROFILING
+ * is defined.
+ *
+ * It overrides memory handling calls in order to inject profiling
+ * equivalents.
+ *
+ * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
+ */
 #ifndef _CRT_MALLOC_H
 #define _CRT_MALLOC_H
 
 #include "config.h"
 
+/* This is a define for some compilers */
 #undef strdup
+
+/* These defines override memory allocators with CrT equivalents. */
 
 #define malloc(x)            CrT_malloc(           x,    __FILE__, __LINE__)
 #define calloc(x,y)          CrT_calloc(           x, y, __FILE__, __LINE__)
@@ -13,14 +27,119 @@
 #define alloc_string(x)      CrT_alloc_string(     x,    __FILE__, __LINE__)
 #define alloc_prog_string(x) CrT_alloc_prog_string(x,    __FILE__, __LINE__)
 
+/**
+ * This is the wrapper for alloc_string
+ *
+ * It works just like alloc_string, except it takes a file and line for tracking
+ * purposes.  File should usually be __FILE__ and line __LINE__.  The
+ * memory for 'file' is not copied and therefore must not be deallocated.
+ *
+ * @param string the string to copy
+ * @param file the originating file
+ * @param line the originating line
+ * @return a copy of 'string'
+ */
 char *CrT_alloc_string(const char *, const char *, int);
+
+/**
+ * This is the wrapper for alloc_prog_string
+ *
+ * It works just like alloc_prog_string, except it takes a file and line for
+ * tracking purposes.  File should usually be __FILE__ and line __LINE__.  The
+ * memory for 'file' is not copied and therefore must not be deallocated.
+ *
+ * @param s the string to copy
+ * @param file the originating file
+ * @param line the originating line
+ * @return a copy of 's' wrapped in a shared_string struct
+ */
 struct shared_string *CrT_alloc_prog_string(const char *, const char *, int);
+
+/**
+ * This is the wrapper for calloc
+ *
+ * It works just like calloc, except it takes a file and line for tracking
+ * purposes.  File should usually be __FILE__ and line __LINE__.  The
+ * memory for 'file' is not copied and therefore must not be deallocated.
+ *
+ * @param num the number of elements to allocate
+ * @param siz the size of the elements to allocate
+ * @param file the originating file
+ * @param line the originating line
+ * @return allocated and tracked memory block
+ */
 void *CrT_calloc(size_t num, size_t size, const char *whatfile, int whatline);
+
+/**
+ * This is the wrapper for free
+ *
+ * It works just like free, except it takes a file and line for tracking
+ * purposes.  File should usually be __FILE__ and line __LINE__.  The
+ * memory for 'file' is not copied and therefore must not be deallocated.
+ *
+ * @param p the memory block to free
+ * @param file the originating file
+ * @param line the originating line
+ */
 void CrT_free(void *p, const char *whatfile, int whatline);
+
+/**
+ * This is the wrapper for malloc.
+ *
+ * It works just like malloc except it takes a file and line argument pair
+ * in order to track where the call came from.  __FILE__ and __LINE__ should
+ * be used.  The memory passed into 'file' must not be deleted; a copy is
+ * not made.
+ *
+ * @param size the size of the memory block to allocate.
+ * @param file the file the originated this request.
+ * @param line the line that originaed this request.
+ */
 void *CrT_malloc(size_t size, const char *whatfile, int whatline);
+
+/**
+ * This is the wrapper for realloc
+ *
+ * It works just like realloc, except it takes a file and line for tracking
+ * purposes.  File should usually be __FILE__ and line __LINE__.  The
+ * memory for 'file' is not copied and therefore must not be deallocated.
+ *
+ * @param p the memory block to resize
+ * @param size the new size
+ * @param file the originating file
+ * @param line the originating line
+ * @return allocated and tracked memory block
+ */
 void *CrT_realloc(void *p, size_t size, const char *whatfile, int whatline);
+
+/**
+ * This is the wrapper for strdup
+ *
+ * It works just like strdup, except it takes a file and line for
+ * tracking purposes.  File should usually be __FILE__ and line __LINE__.  The
+ * memory for 'file' is not copied and therefore must not be deallocated.
+ *
+ * @param s the string to copy
+ * @param file the originating file
+ * @param line the originating line
+ * @return a copy of 's'
+ */
 char *CrT_strdup(const char *, const char *, int);
+
+/**
+ * Send memory profile summary to a given player
+ *
+ * @param player the dbref of the player to notify
+ */
 void CrT_summarize(dbref player);
+
+/**
+ * Summarize ram usage and write it to a file
+ *
+ * @private
+ * @param file the file name to write to.
+ * @param comment a comment to put at the top of the file, or NULL for none.
+ */
 void CrT_summarize_to_file(const char *file, const char *comment);
 
-#endif				/* _CRT_MALLOC_H */
+#endif /* _CRT_MALLOC_H */

--- a/src/compile.c
+++ b/src/compile.c
@@ -3243,7 +3243,7 @@ is_preprocessor_conditional(const char *tmpptr)
  *
  * 'Depth' is a funny thing here.  It isn't really used the same as depth
  * in, say, do_new_comment where it is the recursion depth.  What it really
- * means is, are we doing is controlling if we use the recursive comment
+ * means is, All we are doing is controlling if we use the recursive comment
  * code or not.  It is, in fact, really kind of superfluous because
  * it is set according to the binary value of cstat->force_comment which
  * is also used in this call.
@@ -4761,7 +4761,7 @@ prealloc_inst(COMPSTATE * cstat)
         cstat->nextinst = nu;
     } else {
         for (ptr = cstat->nextinst; ptr->next; ptr = ptr->next) ;
-            ptr->next = nu;
+        ptr->next = nu;
     }
 
     nu->no = cstat->nowords;
@@ -4776,7 +4776,7 @@ prealloc_inst(COMPSTATE * cstat)
  * are basically primitives, but from a compiler perspective are special
  * constructs.
  *
- * This includes procedure definitions (: and ;), and all the different
+ * This includes procedure definitions (':' and ';'), and all the different
  * loop/branch constructs (IF, BEGIN, WHILE, etc.)
  *
  * The original documentation had the following note regarding branches:

--- a/src/set.c
+++ b/src/set.c
@@ -1132,7 +1132,7 @@ do_propset(int descr, dbref player, const char *name, const char *prop)
  * is no object name, then the registration target is cleared.  Otherwise,
  * object is registered to the given name.
  *
- * See help @register on the MUCK for a more consice explanation :)
+ * See help @register on the MUCK for a more concice explanation :)
  *
  * This does permission checking.
  *


### PR DESCRIPTION
This has the documentation for crt_malloc and also for a few other things, mostly things @nyanster found in past PR's.

I removed all the weird emacs markup code.  I think that was for some function indexing feature that is now common in most modern editors without weird markup needed.  I haven't seen that any place else (even in any other project) so I doubt its a commonplace need :)