### PR TITLE
Remove most includes from config.h

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -150,21 +150,9 @@
 
 /*
  * Include all the good standard headers here.
+ * Not anymore!  TODO: move the stdlib.h include to fbmuck.h
  */
-#include <ctype.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <limits.h>
-#include <signal.h>
-#include <stdarg.h>
-#include <stdbool.h>
-#include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <time.h>
 
 typedef int dbref;
 

--- a/include/config.h
+++ b/include/config.h
@@ -151,8 +151,10 @@
 /*
  * Include all the good standard headers here.
  * Not anymore!  TODO: move the stdlib.h include to fbmuck.h
+ * TODO: figure out how to resolve conflict when string.h and crt_malloc.h are included in "wrong" order
  */
 #include <stdlib.h>
+#include <string.h>
 
 typedef int dbref;
 

--- a/src/compile.c
+++ b/src/compile.c
@@ -7,6 +7,7 @@
 
 #include <ctype.h>
 #include <limits.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/interface.c
+++ b/src/interface.c
@@ -11,6 +11,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/interface_ssl.c
+++ b/src/interface_ssl.c
@@ -2,8 +2,6 @@
 
 #ifdef USE_SSL
 
-#include <string.h>
-
 #include "interface_ssl.h"
 #include "log.h"
 

--- a/src/interface_ssl.c
+++ b/src/interface_ssl.c
@@ -2,6 +2,8 @@
 
 #ifdef USE_SSL
 
+#include <string.h>
+
 #include "interface_ssl.h"
 #include "log.h"
 

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #define NUM_THREADS 5
 

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -5,6 +5,7 @@
 #include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define NUM_THREADS 5

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -4,6 +4,7 @@
 #include <fcntl.h>
 #include <pthread.h>
 #include <signal.h>
+#include <stdio.h>
 #include <string.h>
 
 #define NUM_THREADS 5

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -27,8 +27,6 @@
 #define strtok_r	strtok_s
 #define tzname		_tzname
 #define unlink		_unlink
-#define vsnprintf(str, size, format, ...) \
-			_vsnprintf_s(str, size, _TRUNCATE, format, __VA_ARGS__)
 #define write(fd, buf, count) \
 			send(fd, (char *)buf, count, 0)
 

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -19,8 +19,6 @@
 #define popen		_popen
 #define read(fd, buf, count) \
 			recv(fd, (char *)buf, count, 0)
-#define snprintf(str, size, format, ...) \
-			_snprintf_s(str, size, _TRUNCATE, format, __VA_ARGS__)
 #define strcasecmp	_stricmp
 #define strdup		_strdup
 #define strncasecmp	_strnicmp


### PR DESCRIPTION
I removed all the includes that weren't under ifdefs, EXCEPT
stdlib.h is used in config.h in relation to RANDOM
TODO: move that include to a fbmuck.h file
better TODO: get rid of our random-related ifdefing and defining, if possible.

Includes were also added as needed.

TODO: figure out what includes we can remove elsewhere.  I've added a lotta includes, but this is the first time I've removed any.
This PR is 100% safe though, to my knowledge.  Tested on FreeBSD.  Interested in Travis and AppVeyor results.