### PR TITLE
Add blank line to changesfb7

### DIFF
--- a/docs/changesfb7
+++ b/docs/changesfb7
@@ -357,3 +357,4 @@ When an array is pinned, changes to any dup'ed copy on the stack will make chang
 -   Cancel - "x" command quits without saving
 -   Macro creation - new macros staring with a digit or period are invalid
 -   Macro listing - display includes macros outside a-z range
+


### PR DESCRIPTION
Out of a courtesy to users who will have a huge pile of text fly into their screen.
I noticed previous changesfb* files have one or multiple blank lines at the bottom.