### PR TITLE
Switch from random() to arc4random()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -215,7 +215,7 @@ dnl
 AC_TYPE_PID_T
 AC_TYPE_SIZE_T
 
-AC_CHECK_FUNCS(mallinfo getrlimit getrusage random pselect)
+AC_CHECK_FUNCS(mallinfo getrlimit getrusage arc4random_uniform pselect)
 AC_CHECK_MEMBER([struct mallinfo.hblks])
 AC_CHECK_MEMBER([struct mallinfo.keepcost])
 AC_CHECK_MEMBER([struct mallinfo.treeoverhead])

--- a/include/config.h
+++ b/include/config.h
@@ -150,7 +150,8 @@
 
 /*
  * Include all the good standard headers here.
- * Not anymore!  TODO: move the stdlib.h include to fbmuck.h
+ * Not anymore!
+ * TODO: figure out what to do with the RANDOM() ifdef and stdlib.h
  * TODO: figure out how to resolve conflict when string.h and crt_malloc.h are included in "wrong" order
  */
 #include <stdlib.h>

--- a/include/config.h
+++ b/include/config.h
@@ -169,9 +169,9 @@ typedef int dbref;
 #define DEBUGPRINT(...)
 #endif				/* DEBUG */
 
-#ifdef HAVE_RANDOM
-# define SRANDOM(seed)	srandom((seed))
-# define RANDOM()	random()
+#ifdef HAVE_ARC4RANDOM_UNIFORM
+# define SRANDOM(seed)	srand((seed))
+# define RANDOM()	arc4random_uniform((unsigned)RAND_MAX + 1)
 #else
 # define SRANDOM(seed)	srand((seed))
 # define RANDOM()	rand()


### PR DESCRIPTION
OSes without arc4random() will use rand()
The usage of arc4random_uniform() with that argument is to guarantee the results have the same range as rand().
arc4random() has no seed function, so we just call srand(), which does not affect arc4random()'s results.  Hey, won't this affect behavior?  The answer is actually no!  SRANDOM() is only ever called once, with a seed of getpid(), meaning repeatability wasn't even desired there.  In the code, only actual srand() is used when a deterministic PRNG is desired.
I've found both rand() and RANDOM() in the code, but not random().  That's a portable mix, already.

I also correct my TODO comment:
I realise it may be necessary to keep stdlib.h here as long as we have our HAVE_RANDOM/HAVE_ARC4RANDOM_UNIFORM ifdef.
I want to get rid of the ifdef, but...  Well, both random() and rand() aren't good for secure uses.  random() does provide better randomness than rand() for trivial/nonsecure uses though.
Having no ifdef at all would be desirable.  But arc4random() is not guaranteed to be available.  Hmm.

@wyld-sw you'll have to regenerate configure after this. :B