### PR TITLE
Do a small linking re-ordering

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -123,7 +123,7 @@ fbmuck: $(INCLUDE)/defines.h ${P} ${OBJ} ${MALLOBJ} Makefile
 	${PRE} ${CC} ${CFLAGS} ${INCL} ${DEFS} -o fbmuck ${OBJ} version.o -lm ${LIBR}
 
 fb-resolver: resolver.o ${MALLOBJ} Makefile
-	${PRE} ${CC} ${CFLAGS} ${INCL} ${DEFS} -o fb-resolver resolver.o ${MALLOBJ} -lm ${LIBR} -lpthread
+	${PRE} ${CC} ${CFLAGS} ${INCL} ${DEFS} -o fb-resolver resolver.o ${MALLOBJ} -lm -lpthread ${LIBR}
 
 prochelp: prochelp.o Makefile
 	${PRE} ${CC} ${CFLAGS} ${INCL} ${DEFS} -o prochelp prochelp.o


### PR DESCRIPTION
-l flag ordering is actually important to cc.  While both the before-this-diff and after-this-diff work, this organises the unix/posix libraries before the third-party libraries
This is optional, but I feel it achieves better clarity.