### PR TITLE
Move dbref typedef to fbmuck.h

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -10,6 +10,7 @@
 #define _COMMANDS_H
 
 #include "config.h"
+#include "fbmuck.h"
 
 /*
  * This file is grouped alphabetically just to make it slightly easier to find

--- a/include/compile.h
+++ b/include/compile.h
@@ -11,6 +11,7 @@
 #include <stddef.h>
 
 #include "config.h"
+#include "fbmuck.h"
 
 /*
  * @TODO free_prog_real is a static in compile.c

--- a/include/config.h
+++ b/include/config.h
@@ -157,8 +157,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-typedef int dbref;
-
 #ifdef DEBUG
 # undef NDEBUG
 #include <assert.h>

--- a/include/crt_malloc.h
+++ b/include/crt_malloc.h
@@ -15,6 +15,7 @@
 #include <stddef.h>
 
 #include "config.h"
+#include "fbmuck.h"
 
 /* This is a define for some compilers */
 #undef strdup

--- a/include/db.h
+++ b/include/db.h
@@ -12,6 +12,7 @@
 #include <time.h>
 
 #include "config.h"
+#include "fbmuck.h"
 
 /* This is used to identify the database dump file */
 #define DB_VERSION_STRING "***Foxen9 TinyMUCK DUMP Format***"

--- a/include/fbmuck.h
+++ b/include/fbmuck.h
@@ -1,0 +1,6 @@
+#ifndef FBMUCK_H
+#define FBMUCK_H
+
+typedef int dbref;
+
+#endif /* !FBMUCK_H */

--- a/include/fbstrings.h
+++ b/include/fbstrings.h
@@ -10,7 +10,9 @@
 #define _FBSTRINGS_H
 
 #include <stddef.h>
+
 #include "config.h"
+#include "fbmuck.h"
 
 /**
  * Turn 's' into an empty string if it is NULL.

--- a/include/interface.h
+++ b/include/interface.h
@@ -6,6 +6,7 @@
 
 #include "autoconf.h"
 #include "config.h"
+#include "fbmuck.h"
 
 #ifdef MCP_SUPPORT
 #include "mcp.h"

--- a/include/props.h
+++ b/include/props.h
@@ -12,6 +12,7 @@
 #include <stdio.h>
 
 #include "config.h"
+#include "fbmuck.h"
 
 /*
  * Property data union to support all available property types.


### PR DESCRIPTION
This is the first of likely many things that can be moved out of config.h, as it is not meant to be configured, neither by user nor by autoconf.  As the dbref typedef is pretty generic, I give it its own generic/miscellaneous header file.

The define is intentionally FBMUCK_H and not _FBMUCK_H
Having defines start with an underscore isn't a good idea.  I believe they're reserved for C implementations, and I can double-check on that if necessary.
TODO: change our current defines to not start with an _ underscore.
potential TODO: see if it's possible to have the MUCK not break when dbref is typedef'd to a different type.