### PR TITLE
Fix our defined macros

### DIFF
--- a/include/array.h
+++ b/include/array.h
@@ -6,8 +6,8 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
-#ifndef _ARRAY_H
-#define _ARRAY_H
+#ifndef ARRAY_H
+#define ARRAY_H
 
 #include <stddef.h>  /* for offsetof() */
 #include "config.h"
@@ -596,4 +596,4 @@ void array_init_active_list(stk_array_list *list);
  */
 void array_free_all_on_list(stk_array_list *list);
 
-#endif      /* _ARRAY_H */
+#endif /* !ARRAY_H */

--- a/include/boolexp.h
+++ b/include/boolexp.h
@@ -6,8 +6,8 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
-#ifndef _BOOLEXP_H
-#define _BOOLEXP_H
+#ifndef BOOLEXP_H
+#define BOOLEXP_H
 
 #include <stddef.h>
 
@@ -177,4 +177,4 @@ int test_lock_false_default(int descr, dbref player, dbref thing, const char *lo
  */ 
 const char *unparse_boolexp(dbref player, struct boolexp *b, int fullname);
 
-#endif      /* _BOOLEXP_H */
+#endif /* !BOOLEXP_H */

--- a/include/color.h
+++ b/include/color.h
@@ -5,8 +5,8 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
-#ifndef _COLOR_H
-#define _COLOR_H
+#ifndef COLOR_H
+#define COLOR_H
 
 /* ANSI attributes and color codes */
 
@@ -38,4 +38,4 @@
 #define ANSI_BG_CYAN    "\033[46m"
 #define ANSI_BG_WHITE   "\033[47m"
 
-#endif      /* _COLOR_H */
+#endif /* !COLOR_H */

--- a/include/commands.h
+++ b/include/commands.h
@@ -6,8 +6,8 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
-#ifndef _COMMANDS_H
-#define _COMMANDS_H
+#ifndef COMMANDS_H
+#define COMMANDS_H
 
 #include "config.h"
 #include "fbmuck.h"
@@ -1643,4 +1643,4 @@ void do_wall(dbref player, const char *message);
 void do_whisper(int descr, dbref player, const char *arg1, const char *arg2);
 
 
-#endif      /* _COMMANDS_H */
+#endif /* !COMMANDS_H */

--- a/include/compile.h
+++ b/include/compile.h
@@ -5,8 +5,8 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
-#ifndef _COMPILE_H
-#define _COMPILE_H
+#ifndef COMPILE_H
+#define COMPILE_H
 
 #include <stddef.h>
 
@@ -156,4 +156,4 @@ size_t size_prog(dbref prog);
  */
 void uncompile_program(dbref i);
 
-#endif /* _COMPILE_H */
+#endif /* !COMPILE_H */

--- a/include/config.h
+++ b/include/config.h
@@ -10,8 +10,8 @@
  * Most of the goodies that used to be here are now in @tune.
  */
 
-#ifndef _CONFIG_H
-#define _CONFIG_H
+#ifndef CONFIG_H
+#define CONFIG_H
 
 #include "autoconf.h"
 
@@ -235,4 +235,4 @@
 # include <unistd.h>
 #endif
 
-#endif				/* _CONFIG_H */
+#endif /* !CONFIG_H */

--- a/include/crt_malloc.h
+++ b/include/crt_malloc.h
@@ -9,8 +9,8 @@
  *
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
-#ifndef _CRT_MALLOC_H
-#define _CRT_MALLOC_H
+#ifndef CRT_MALLOC_H
+#define CRT_MALLOC_H
 
 #include <stddef.h>
 
@@ -145,4 +145,4 @@ void CrT_summarize(dbref player);
  */
 void CrT_summarize_to_file(const char *file, const char *comment);
 
-#endif /* _CRT_MALLOC_H */
+#endif /* !CRT_MALLOC_H */

--- a/include/db.h
+++ b/include/db.h
@@ -5,8 +5,8 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
-#ifndef _DB_H
-#define _DB_H
+#ifndef DB_H
+#define DB_H
 
 #include <stdio.h>
 #include <time.h>
@@ -1029,4 +1029,4 @@ void unparse_object(dbref player, dbref object, char *buffer, size_t size);
  */
 void unset_source(dbref action);
 
-#endif /* _DB_H */
+#endif /* !DB_H */

--- a/include/dbsearch.h
+++ b/include/dbsearch.h
@@ -7,8 +7,8 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
-#ifndef _DBSEARCH_H
-#define _DBSEARCH_H
+#ifndef DBSEARCH_H
+#define DBSEARCH_H
 
 #include <stddef.h>
 
@@ -90,4 +90,4 @@ int checkflags(dbref what, struct flgchkdat check);
  */
 int init_checkflags(dbref player, const char *flags, struct flgchkdat *check);
 
-#endif      /* _DBSEARCH_H */
+#endif /* !DBSEARCH_H */

--- a/include/debugger.h
+++ b/include/debugger.h
@@ -6,8 +6,8 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
-#ifndef _DEBUGGER_H
-#define _DEBUGGER_H
+#ifndef DEBUGGER_H
+#define DEBUGGER_H
 
 #include "config.h"
 
@@ -79,4 +79,4 @@ int muf_debugger(int descr, dbref player, dbref program, const char *text, struc
  */
 char *show_line_prims(dbref program, struct inst *pc, int maxprims, int markpc);
 
-#endif /* _DEBUGGER_H */
+#endif /* !DEBUGGER_H */

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -1,5 +1,5 @@
-#ifndef _DEFAULTS_H
-#define _DEFAULTS_H
+#ifndef DEFAULTS_H
+#define DEFAULTS_H
 
 #define DUMPWARN_MESG   "## Game will pause to save the database in a few minutes. ##"
 #define DUMPING_MESG    "## Pausing to save database. This may take a while. ##"
@@ -409,4 +409,4 @@
 #define LOG_FILE "logs/fbmuck"			/* Log stdout to ...		*/
 #define LOG_ERR_FILE "logs/fbmuck.err"		/* Log stderr to ...	*/
 
-#endif				/* _DEFAULTS_H */
+#endif /* !DEFAULTS_H */

--- a/include/diskprop.h
+++ b/include/diskprop.h
@@ -21,4 +21,4 @@ void unloadprops_with_prejudice(dbref obj);
 void undirtyprops(dbref obj);
 
 #endif /* !DISKPROP_H */
-#endif
+#endif /* DISKBASE */

--- a/include/diskprop.h
+++ b/include/diskprop.h
@@ -1,8 +1,8 @@
 #include "config.h"
 
 #ifdef DISKBASE
-#ifndef _DISKPROP_H
-#define _DISKPROP_H
+#ifndef DISKPROP_H
+#define DISKPROP_H
 
 #include "props.h"
 
@@ -20,5 +20,5 @@ void skipproperties(FILE * f, dbref obj);
 void unloadprops_with_prejudice(dbref obj);
 void undirtyprops(dbref obj);
 
-#endif				/* _DISKPROP_H */
+#endif /* !DISKPROP_H */
 #endif

--- a/include/edit.h
+++ b/include/edit.h
@@ -1,5 +1,5 @@
-#ifndef _EDIT_H
-#define _EDIT_H
+#ifndef EDIT_H
+#define EDIT_H
 
 #include <stdio.h>
 
@@ -47,4 +47,4 @@ struct line *read_program(dbref i);
 void write_program(struct line *first, dbref i);
 
 
-#endif				/* _EDIT_H */
+#endif /* !EDIT_H */

--- a/include/events.h
+++ b/include/events.h
@@ -1,5 +1,5 @@
-#ifndef _EVENTS_H
-#define _EVENTS_H
+#ifndef EVENTS_H
+#define EVENTS_H
 
 #include <time.h>
 
@@ -7,4 +7,4 @@ void dump_db_now(void);
 void next_muckevent(void);
 time_t next_muckevent_time(void);
 
-#endif				/* _EVENTS_H */
+#endif /* !EVENTS_H */

--- a/include/fbmath.h
+++ b/include/fbmath.h
@@ -1,5 +1,5 @@
-#ifndef _FBMATH_H
-#define _FBMATH_H
+#ifndef FBMATH_H
+#define FBMATH_H
 
 #include <float.h>
 #include <math.h>
@@ -36,4 +36,4 @@ void MD5hex(void *dest, const void *orig, size_t len);
 int no_good(double test);
 uint32_t rnd(void *buffer);
 
-#endif				/* _FBMATH_H */
+#endif				/* !FBMATH_H */

--- a/include/fbmath.h
+++ b/include/fbmath.h
@@ -36,4 +36,4 @@ void MD5hex(void *dest, const void *orig, size_t len);
 int no_good(double test);
 uint32_t rnd(void *buffer);
 
-#endif				/* !FBMATH_H */
+#endif /* !FBMATH_H */

--- a/include/fbsignal.h
+++ b/include/fbsignal.h
@@ -1,5 +1,5 @@
-#ifndef _FBSIGNAL_H
-#define _FBSIGNAL_H
+#ifndef FBSIGNAL_H
+#define FBSIGNAL_H
 
 void set_dumper_signals(void);
 void set_signals(void);
@@ -8,4 +8,4 @@ void set_signals(void);
 extern sigset_t pselect_signal_mask;
 #endif
 
-#endif				/* _FBSIGNAL_H */
+#endif /* !FBSIGNAL_H */

--- a/include/fbstrings.h
+++ b/include/fbstrings.h
@@ -6,8 +6,8 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
-#ifndef _FBSTRINGS_H
-#define _FBSTRINGS_H
+#ifndef FBSTRINGS_H
+#define FBSTRINGS_H
 
 #include <stddef.h>
 
@@ -597,4 +597,4 @@ void toupper_string(char **s);
  */
 int truestr(const char *buf);
 
-#endif   /* _FBSTRINGS_H */
+#endif /* !FBSTRINGS_H */

--- a/include/fbtime.h
+++ b/include/fbtime.h
@@ -1,5 +1,5 @@
-#ifndef _FBTIME_H
-#define _FBTIME_H
+#ifndef FBTIME_H
+#define FBTIME_H
 
 #include <time.h>
 
@@ -22,4 +22,4 @@ void ts_modifyobject(dbref thing);
 void ts_newobject(dbref thing);
 void ts_useobject(dbref thing);
 
-#endif				/* _FBTIME_H */
+#endif /* !FBTIME_H */

--- a/include/game.h
+++ b/include/game.h
@@ -1,5 +1,5 @@
-#ifndef _GAME_H
-#define _GAME_H
+#ifndef GAME_H
+#define GAME_H
 
 #include <stdio.h>
 
@@ -79,4 +79,4 @@ int init_game(const char *infile, const char *outfile);
 void panic(const char *);
 void process_command(int descr, dbref player, const char *command);
 
-#endif				/* _GAME_H */
+#endif /* !GAME_H */

--- a/include/hashtab.h
+++ b/include/hashtab.h
@@ -1,5 +1,5 @@
-#ifndef _HASHTAB_H
-#define _HASHTAB_H
+#ifndef HASHTAB_H
+#define HASHTAB_H
 
 #include "config.h"
 
@@ -31,4 +31,4 @@ int free_hash(const char *name, hash_tab * table, unsigned size);
 unsigned int hash(const char *s, unsigned int hash_size);
 void kill_hash(hash_tab * table, unsigned size, int freeptrs);
 
-#endif				/* _HASHTAB_H */
+#endif /* !HASHTAB_H */

--- a/include/inst.h
+++ b/include/inst.h
@@ -5,8 +5,8 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
-#ifndef _INST_H
-#define _INST_H
+#ifndef INST_H
+#define INST_H
 
 #include <stddef.h>
 
@@ -107,4 +107,4 @@ struct inst {                   /* instruction */
     } data;
 };
 
-#endif          /* _INST_H */
+#endif /* !INST_H */

--- a/include/interface.h
+++ b/include/interface.h
@@ -1,5 +1,5 @@
-#ifndef _INTERFACE_H
-#define _INTERFACE_H
+#ifndef INTERFACE_H
+#define INTERFACE_H
 
 #include <stddef.h>
 #include <time.h>
@@ -215,4 +215,4 @@ void spit_file(dbref player, const char *filename);
 void wall_and_flush(const char *msg);
 void wall_wizards(const char *msg);
 
-#endif				/* _INTERFACE_H */
+#endif /* !INTERFACE_H */

--- a/include/interface_ssl.h
+++ b/include/interface_ssl.h
@@ -1,5 +1,5 @@
-#ifndef _INTERFACE_SSL_H
-#define _INTERFACE_SSL_H
+#ifndef INTERFACE_SSL_H
+#define INTERFACE_SSL_H
 
 // Needed for USE_SSL
 #include "config.h"
@@ -19,24 +19,26 @@
 # endif
 
 // Backwards-compatibility for valid SSL protocol versions that are not supported.
-# define SSL_UNSUPPORTED_PROTOCOL -2
+#define SSL_UNSUPPORTED_PROTOCOL -2
 
-// Build a lookup table to convert protocol version string to integer
-//
-// Unfortunately OpenSSL lacks an easy way of pragmatically determining what protocols are
-// supported at runtime.  Thus, build a reference table according to compile-time constants.
-// Unavailable protocols are marked with SSL_UNSUPPORTED_PROTOCOL.
-//
-// See 'set_protocol_version' and 'protocol_from_string' in
-// https://github.com/openssl/openssl/blob/OpenSSL_1_1_0-stable/test/ssltest_old.c
-//
-// To further complicate matters, OpenSSL plans to remove support for older SSL versions over time.
-// Fuzzball needs to provide a fallback to make sure existing setups specifying removed protocol
-// versions will get a useful error message pointing to the problem, instead of entirely failing to
-// compile.
-//
-// FB_PROTOCOL_VERSION  Copy OpenSSL's PROTOCOL_VERSION if defined, otherwise SSL_UNSUPPORTED_PROTOCOL
-// FB_PROTOCOL_NAME     Friendly name for error messages, blank if not available
+/*
+ * Build a lookup table to convert protocol version string to integer
+ *
+ * Unfortunately OpenSSL lacks an easy way of pragmatically determining what protocols are
+ * supported at runtime.  Thus, build a reference table according to compile-time constants.
+ * Unavailable protocols are marked with SSL_UNSUPPORTED_PROTOCOL.
+ *
+ * See 'set_protocol_version' and 'protocol_from_string' in
+ * https://github.com/openssl/openssl/blob/OpenSSL_1_1_0-stable/test/ssltest_old.c
+ *
+ * To further complicate matters, OpenSSL plans to remove support for older SSL versions over time.
+ * Fuzzball needs to provide a fallback to make sure existing setups specifying removed protocol
+ * versions will get a useful error message pointing to the problem, instead of entirely failing to
+ * compile.
+ *
+ * FB_PROTOCOL_VERSION  Copy OpenSSL's PROTOCOL_VERSION if defined, otherwise SSL_UNSUPPORTED_PROTOCOL
+ * FB_PROTOCOL_NAME     Friendly name for error messages, blank if not available
+ */
 #ifdef SSL3_VERSION
 # define FB_SSL3_VERSION SSL3_VERSION
 # define FB_SSL3_NAME "SSLv3 "
@@ -96,9 +98,10 @@ typedef enum {
 } ssl_logging_t;
 
 
-// Check if config.h specifies to log all SSL errors
-// TODO: This should be configurable at runtime, e.g. with an '@debug set ssl_logging'
-// command.
+/*
+ * Check if config.h specifies to log all SSL errors
+ * TODO: This should be configurable at runtime, e.g. with an '@debug set ssl_logging' command.
+ */
 #ifdef DEBUG_SSL_LOG_ALL
 /// SSL logging level for connection handling
 static const ssl_logging_t ssl_logging_connect = SSL_LOGGING_DEBUG;
@@ -117,15 +120,17 @@ int set_ssl_ctx_min_version(SSL_CTX *, const char *);
 
 int ssl_check_error(struct descriptor_data *, const int, const ssl_logging_t);
 
-// SSL_ERROR_WANT_ACCEPT is not defined in OpenSSL v0.9.6i and before. This
-// fix allows to compile fbmuck on systems with an 'old' OpenSSL library, and
-// yet have the server recognize the WANT_ACCEPT error when ran on systems with
-// a newer OpenSSL version installed... Of course, should the value of the
-// define change in ssl.h in the future (unlikely but not impossible), the
-// define below would have to be changed too...
+/*
+ * SSL_ERROR_WANT_ACCEPT is not defined in OpenSSL v0.9.6i and before. This
+ * fix allows to compile fbmuck on systems with an 'old' OpenSSL library, and
+ * yet have the server recognize the WANT_ACCEPT error when ran on systems with
+ * a newer OpenSSL version installed... Of course, should the value of the
+ * define change in ssl.h in the future (unlikely but not impossible), the
+ * define below would have to be changed too...
+ */
 #ifndef SSL_ERROR_WANT_ACCEPT
 #define SSL_ERROR_WANT_ACCEPT 8
 #endif
 
-#endif                                // USE_SSL
-#endif                                // _INTERFACE_SSL_H
+#endif /* USE_SSL */
+#endif /* !INTERFACE_SSL_H */

--- a/include/interp.h
+++ b/include/interp.h
@@ -1,5 +1,5 @@
-#ifndef _INTERP_H
-#define _INTERP_H
+#ifndef INTERP_H
+#define INTERP_H
 
 #include <stddef.h>
 #include <time.h>
@@ -381,4 +381,4 @@ int valid_player(struct inst *oper);
 #include "p_mcp.h"
 #include "p_strings.h"
 #include "p_regex.h"
-#endif				/* _INTERP_H */
+#endif /* !INTERP_H */

--- a/include/log.h
+++ b/include/log.h
@@ -1,5 +1,5 @@
-#ifndef _LOG_H
-#define _LOG_H
+#ifndef LOG_H
+#define LOG_H
 
 #include "config.h"
 #include "inst.h"
@@ -15,5 +15,4 @@ void log_status(char *format, ...);
 void log_user(dbref player, dbref program, char *logmessage);
 char *whowhere(dbref player);
 
-#endif				/* _LOG_H */
-
+#endif /* !LOG_H */

--- a/include/match.h
+++ b/include/match.h
@@ -1,5 +1,5 @@
-#ifndef _MATCH_H
-#define _MATCH_H
+#ifndef MATCH_H
+#define MATCH_H
 
 #include "config.h"
 
@@ -42,4 +42,4 @@ dbref match_result(struct match_data *md);
 void match_rmatch(dbref, struct match_data *md);
 dbref noisy_match_result(struct match_data *md);
 
-#endif				/* _MATCH_H */
+#endif /* !MATCH_H */

--- a/include/mcp.h
+++ b/include/mcp.h
@@ -1,8 +1,8 @@
 #include "config.h"
 
 #ifdef MCP_SUPPORT
-#ifndef _MCP_H
-#define _MCP_H
+#ifndef MCP_H
+#define MCP_H
 
 #define MCP_MESG_PREFIX		"#$#"
 #define MCP_QUOTE_PREFIX	"#$\""
@@ -114,5 +114,5 @@ void mcp_package_register(const char *pkgname, McpVer minver, McpVer maxver,
 int mcp_version_compare(McpVer v1, McpVer v2);
 McpVer mcp_version_select(McpVer min1, McpVer max1, McpVer min2, McpVer max2);
 
-#endif				/* _MCP_H */
-#endif
+#endif /* !MCP_H */
+#endif /* MCP_SUPPORT */

--- a/include/mcpgui.h
+++ b/include/mcpgui.h
@@ -1,8 +1,8 @@
 #include "config.h"
 
 #ifdef MCP_SUPPORT
-#ifndef _MCPGUI_H
-#define _MCPGUI_H
+#ifndef MCPGUI_H
+#define MCPGUI_H
 
 #include "interp.h"
 #include "mcp.h"
@@ -137,5 +137,5 @@ void muf_dlog_add(struct frame *fr, const char *dlogid);
 void muf_dlog_purge(struct frame *fr);
 void muf_dlog_remove(struct frame *fr, const char *dlogid);
 
-#endif				/* _MCPGUI_H */
-#endif
+#endif /* !MCPGUI_H */
+#endif /* MCP_SUPPORT */

--- a/include/mcppkg.h
+++ b/include/mcppkg.h
@@ -1,8 +1,8 @@
 #include "config.h"
 
 #ifdef MCP_SUPPORT
-#ifndef _MCPPKG_H
-#define _MCPPKG_H
+#ifndef MCPPKG_H
+#define MCPPKG_H
 
 #include "mcp.h"
 
@@ -11,5 +11,5 @@ void mcppkg_languages(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context);
 void mcppkg_help_request(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context);
 void show_mcp_error(McpFrame * mfr, char *topic, char *text);
 
-#endif				/* _MCPPKG_H */
-#endif
+#endif /* !MCPPKG_H */
+#endif /* MCP_SUPPORT */

--- a/include/mfun.h
+++ b/include/mfun.h
@@ -1,5 +1,5 @@
-#ifndef _MFUN_H
-#define _MFUN_H
+#ifndef MFUN_H
+#define MFUN_H
 
 #include <stddef.h>
 
@@ -301,4 +301,4 @@ static struct mfun_dat mfun_list[] = {
     {NULL, NULL, 0, 0, 0, 0, 0}	/* Ends the mfun list */
 };
 
-#endif				/* _MFUN_H */
+#endif /* !MFUN_H */

--- a/include/move.h
+++ b/include/move.h
@@ -1,5 +1,5 @@
-#ifndef _MOVE_H
-#define _MOVE_H
+#ifndef MOVE_H
+#define MOVE_H
 
 #include "config.h"
 
@@ -9,4 +9,4 @@ void send_contents(int descr, dbref loc, dbref dest);
 void send_home(int descr, dbref thing, int homepuppet);
 void recycle(int descr, dbref player, dbref thing);
 
-#endif				/* _MOVE_H */
+#endif /* !MOVE_H */

--- a/include/mpi.h
+++ b/include/mpi.h
@@ -1,5 +1,5 @@
-#ifndef _MPI_H
-#define _MPI_H
+#ifndef MPI_H
+#define MPI_H
 
 #include "config.h"
 
@@ -20,4 +20,4 @@ char *do_parse_mesg(int descr, dbref player, dbref what, const char *inbuf,
 char *do_parse_prop(int descr, dbref player, dbref what, const char *propname,
 			   const char *abuf, char *outbuf, int buflen, int mesgtyp);
 
-#endif				/* _MPI_H */
+#endif /* !MPI_H */

--- a/include/msgparse.h
+++ b/include/msgparse.h
@@ -1,5 +1,5 @@
-#ifndef _MSGPARSE_H
-#define _MSGPARSE_H
+#ifndef MSGPARSE_H
+#define MSGPARSE_H
 
 #include <time.h>
 #include "config.h"
@@ -64,4 +64,4 @@ const char *safegetprop(dbref player, dbref what, dbref perms, const char *inbuf
 const char *safegetprop_strict(dbref player, dbref what, dbref perms, const char *inbuf, int mesgtyp, int *blessed);
 int safeputprop(dbref obj, char *buf, char *val, int mesgtyp);
 
-#endif				/* _MSGPARSE_H */
+#endif /* !MSGPARSE_H */

--- a/include/mufevent.h
+++ b/include/mufevent.h
@@ -1,5 +1,5 @@
-#ifndef _MUFEVENT_H
-#define _MUFEVENT_H
+#ifndef MUFEVENT_H
+#define MUFEVENT_H
 
 #include <stddef.h>
 
@@ -24,4 +24,4 @@ int muf_event_read_notify(int descr, dbref player, const char *cmd);
 void muf_event_register_specific(dbref player, dbref prog, struct frame *fr, size_t eventcount,
 				 char **eventids);
 
-#endif				/* _MUFEVENT_H */
+#endif /* !MUFEVENT_H */

--- a/include/p_array.h
+++ b/include/p_array.h
@@ -1,5 +1,5 @@
-#ifndef _P_ARRAY_H
-#define _P_ARRAY_H
+#ifndef P_ARRAY_H
+#define P_ARRAY_H
 
 #include "interp.h"
 
@@ -104,4 +104,4 @@ void prim_array_notify_secure(PRIM_PROTOTYPE);
 	"ARRAY_FILTER_FLAGS", "ARRAY_INTERPRET", "ARRAY_NOTIFY_SECURE", \
 	"ARRAY_DEFAULT_PINNING", "ARRAY_FILTER_LOCK"
 
-#endif				/* _P_ARRAY_H */
+#endif /* !P_ARRAY_H */

--- a/include/p_connects.h
+++ b/include/p_connects.h
@@ -1,5 +1,5 @@
-#ifndef _P_CONNECTS_H
-#define _P_CONNECTS_H
+#ifndef P_CONNECTS_H
+#define P_CONNECTS_H
 
 #include "interp.h"
 
@@ -56,4 +56,4 @@ void prim_descr_bufsize(PRIM_PROTOTYPE);
 	"DESCRLEASTIDLE", "DESCRMOSTIDLE", "DESCRSECURE?",        \
 	"DESCRBUFSIZE"
 
-#endif				/* _P_CONNECTS_H */
+#endif /* !P_CONNECTS_H */

--- a/include/p_db.h
+++ b/include/p_db.h
@@ -1,5 +1,5 @@
-#ifndef _P_DB_H
-#define _P_DB_H
+#ifndef P_DB_H
+#define P_DB_H
 
 #include "interp.h"
 
@@ -103,4 +103,4 @@ void prim_toadplayer(PRIM_PROTOTYPE);
     "SETLINKS_ARRAY", "TOADPLAYER", "SUPPLICANT",	   \
     "PNAME_HISTORY"
 
-#endif				/* _P_DB_H */
+#endif /* !P_DB_H */

--- a/include/p_error.h
+++ b/include/p_error.h
@@ -1,5 +1,5 @@
-#ifndef _P_ERROR_H
-#define _P_ERROR_H
+#ifndef P_ERROR_H
+#define P_ERROR_H
 
 #include "interp.h"
 
@@ -20,4 +20,4 @@ void prim_error_num(PRIM_PROTOTYPE);
 #define PRIMS_ERROR_NAMES "CLEAR","CLEAR_ERROR","ERROR?","SET_ERROR",     \
         "IS_SET?","ERROR_STR","ERROR_NAME","ERROR_BIT","ERROR_NUM"
 
-#endif				/* _P_ERROR_H */
+#endif /* !P_ERROR_H */

--- a/include/p_float.h
+++ b/include/p_float.h
@@ -1,5 +1,5 @@
-#ifndef _P_FLOAT_H
-#define _P_FLOAT_H
+#ifndef P_FLOAT_H
+#define P_FLOAT_H
 
 #include "interp.h"
 
@@ -49,4 +49,4 @@ void prim_diff3(PRIM_PROTOTYPE);
 	"PI", "INF", "ROUND", "DIST3D", "XYZ_TO_POLAR",     \
 	"POLAR_TO_XYZ", "DIFF3", "EPSILON", "FTOSTRC", "**"
 
-#endif				/* _P_FLOAT_H */
+#endif /* !P_FLOAT_H */

--- a/include/p_math.h
+++ b/include/p_math.h
@@ -1,5 +1,5 @@
-#ifndef _P_MATH_H
-#define _P_MATH_H
+#ifndef P_MATH_H
+#define P_MATH_H
 
 #include "interp.h"
 
@@ -45,4 +45,4 @@ void prim_notequal(PRIM_PROTOTYPE);
      "SETSEED", "XOR", "GETSEED", "++", "--", "ABS", "SIGN",   \
      "!=", "&", "|", "^", "<<"
 
-#endif				/* _P_MATH_H */
+#endif /* !P_MATH_H */

--- a/include/p_mcp.h
+++ b/include/p_mcp.h
@@ -1,8 +1,8 @@
 #include "config.h"
 
 #ifdef MCP_SUPPORT
-#ifndef _P_MCP_H
-#define _P_MCP_H
+#ifndef P_MCP_H
+#define P_MCP_H
 
 #include "interp.h"
 
@@ -35,5 +35,5 @@ void prim_gui_ctrl_command(PRIM_PROTOTYPE);
 		"GUI_VALUE_SET", "GUI_CTRL_CREATE", "GUI_CTRL_COMMAND", \
 		"GUI_DLOG_CREATE", "MCP_REGISTER_EVENT"
 
-#endif				/* _P_MCP_H */
-#endif
+#endif /* !P_MCP_H */
+#endif /* MCP_SUPPORT */

--- a/include/p_misc.h
+++ b/include/p_misc.h
@@ -1,5 +1,5 @@
-#ifndef _P_MISC_H
-#define _P_MISC_H
+#ifndef P_MISC_H
+#define P_MISC_H
 
 #include "interp.h"
 
@@ -77,4 +77,4 @@ void prim_stats_array(PRIM_PROTOTYPE);
     "DEBUG_ON", "DEBUG_OFF", "DEBUG_LINE", "SYSTIME_PRECISE", \
     "READ_WANTS_NO_BLANKS", "STATS_ARRAY"
 
-#endif				/* _P_MISC_H */
+#endif /* !P_MISC_H */

--- a/include/p_props.h
+++ b/include/p_props.h
@@ -1,5 +1,5 @@
-#ifndef _P_PROPS_H
-#define _P_PROPS_H
+#ifndef P_PROPS_H
+#define P_PROPS_H
 
 #include "interp.h"
 
@@ -44,5 +44,4 @@ void prim_prop_name_okp(PRIM_PROTOTYPE);
 	"REFLIST_FIND", "REFLIST_ADD", "REFLIST_DEL", "BLESSED?", \
 	"PARSEPROPEX", "PARSEMPI", "PARSEMPIBLESSED", "PROP-NAME-OK?"
 
-#endif				/* _P_PROPS_H */
-
+#endif /* !P_PROPS_H */

--- a/include/p_regex.h
+++ b/include/p_regex.h
@@ -1,5 +1,5 @@
-#ifndef _P_REGEX_H
-#define _P_REGEX_H
+#ifndef P_REGEX_H
+#define P_REGEX_H
 
 #include "interp.h"
 
@@ -17,4 +17,4 @@ void prim_regsplit_noempty(PRIM_PROTOTYPE);
 
 #define PRIMS_REGEX_NAMES "REGEXP", "REGSUB", "REGSPLIT", "REGSPLIT_NOEMPTY"
 
-#endif				/* _P_REGEX_H */
+#endif /* !P_REGEX_H */

--- a/include/p_stack.h
+++ b/include/p_stack.h
@@ -1,5 +1,5 @@
-#ifndef _P_STACK_H
-#define _P_STACK_H
+#ifndef P_STACK_H
+#define P_STACK_H
 
 #include "interp.h"
 
@@ -83,4 +83,4 @@ void prim_trypop(PRIM_PROTOTYPE);	/* -- */
 
 #define PRIMS_INTERNAL_NAMES " FORITER", " FORPOP", " TRYPOP"
 
-#endif				/* _P_STACK_H */
+#endif /* !P_STACK_H */

--- a/include/p_strings.h
+++ b/include/p_strings.h
@@ -1,5 +1,5 @@
-#ifndef _P_STRINGS_H
-#define _P_STRINGS_H
+#ifndef P_STRINGS_H
+#define P_STRINGS_H
 
 #include "interp.h"
 
@@ -80,4 +80,4 @@ void prim_pose_separatorp(PRIM_PROTOTYPE);
 	"INSTRING", "RINSTRING", "MD5HASH", "SHA1HASH", "STRIP",   \
 	"TELL", "OTELL", "POSE-SEPARATOR?"
 
-#endif				/* _P_STRINGS_H */
+#endif /* !P_STRINGS_H */

--- a/include/player.h
+++ b/include/player.h
@@ -1,5 +1,5 @@
-#ifndef _PLAYER_H
-#define _PLAYER_H
+#ifndef PLAYER_H
+#define PLAYER_H
 
 #include "config.h"
 
@@ -17,4 +17,4 @@ void toad_player(int descr, dbref player, dbref victim, dbref recipient);
 void set_password(dbref player, const char *password);
 void set_password_raw(dbref player, const char *password);
 
-#endif				/* _PLAYER_H */
+#endif /* !PLAYER_H */

--- a/include/predicates.h
+++ b/include/predicates.h
@@ -1,5 +1,5 @@
-#ifndef _PREDICATES_H
-#define _PREDICATES_H
+#ifndef PREDICATES_H
+#define PREDICATES_H
 
 #include "config.h"
 #include "db.h"
@@ -12,4 +12,4 @@ int could_doit(int descr, dbref player, dbref thing);
 int exit_loop_check(dbref source, dbref dest);
 int parent_loop_check(dbref source, dbref dest);
 
-#endif				/* _PREDICATES_H */
+#endif /* !PREDICATES_H */

--- a/include/props.h
+++ b/include/props.h
@@ -6,8 +6,8 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
-#ifndef _PROPS_H
-#define _PROPS_H
+#ifndef PROPS_H
+#define PROPS_H
 
 #include <stdio.h>
 
@@ -1343,4 +1343,4 @@ void untouchprops_incremental(int limit);
  */
 int is_valid_propname(const char* pname);
 
-#endif				/* _PROPS_H */
+#endif /* !PROPS_H */

--- a/include/sha1.h
+++ b/include/sha1.h
@@ -1,5 +1,5 @@
-#ifndef _SHA1_H_
-#define _SHA1_H_
+#ifndef SHA1_H
+#define SHA1_H
 
 #include <stddef.h>
 /* Just in case the including file doesn't use stdint for uint8_t */
@@ -25,4 +25,4 @@ void sha1_write(sha1nfo * s, const char *data, size_t len);
 uint8_t *sha1_result(sha1nfo * s);
 void hash2hex(uint8_t * hash, char *buffer, size_t buflen);
 
-#endif
+#endif /* !SHA1_H */

--- a/include/timequeue.h
+++ b/include/timequeue.h
@@ -1,5 +1,5 @@
-#ifndef _TIMEQUEUE_H
-#define _TIMEQUEUE_H
+#ifndef TIMEQUEUE_H
+#define TIMEQUEUE_H
 
 #include <time.h>
 
@@ -45,4 +45,4 @@ int read_event_notify(int descr, dbref player, const char *cmd);
 int scan_instances(dbref program);
 struct frame *timequeue_pid_frame(int pid);
 
-#endif				/* _TIMEQUEUE_H */
+#endif /* !TIMEQUEUE_H */

--- a/include/tune.h
+++ b/include/tune.h
@@ -6,8 +6,8 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 
-#ifndef _TUNE_H
-#define _TUNE_H
+#ifndef TUNE_H
+#define TUNE_H
 
 #include <stdio.h>
 
@@ -469,4 +469,4 @@ void tune_save_parms_to_file(FILE * f);
  */
 int tune_setparm(dbref player, const char *parmname, const char *val, int security);
 
-#endif  /* _TUNE_H */
+#endif /* !TUNE_H */

--- a/include/tunelist.h
+++ b/include/tunelist.h
@@ -1,5 +1,5 @@
-#ifndef _TUNELIST_H
-#define _TUNELIST_H
+#ifndef TUNELIST_H
+#define TUNELIST_H
 
 #include <stddef.h>
 
@@ -506,4 +506,4 @@ struct tune_bool_entry tune_bool_list[] = {
     {NULL, NULL, NULL, 0, 0, NULL, 0, 0, 0}
 };
 
-#endif				/* _TUNELIST_H */
+#endif /* !TUNELIST_H */


### PR DESCRIPTION
They shouldn't start with an underscore _ and then an upper-case letter, as words like that are supposed to be reserved for the C implementation.

I also fix some major style issues in interface_ssl.h, and I also comment a couple extra endifs.