### PR TITLE
Standards check 2 of 3 (CI check don'tmerge)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,6 +13,6 @@ task:
   script:
     - ./configure --prefix="$PWD/fuzzpre" $FLAG_SSL $FLAG_MEMPROF $FLAG_DEBUG
     # Speed up CI builds
-    - printf '/CFLAGS=/s/-g//\ns/-O2//\nw\nq\n' | ed -s src/Makefile
+    - printf '/CFLAGS=/s/-g//\ns/-O2//\ns/gnu99/c99/\nw\nq\n' | ed -s src/Makefile
     - make
     - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ script:
   # Set up configure flags
   - ./configure --prefix="$PWD/fuzzpre" $FLAG_SSL $FLAG_MEMPROF $FLAG_DEBUG
   # Speed up CI builds
-  - printf '/CFLAGS=/s/-g//\ns/-O2//\nw\nq\n' | ed -s src/Makefile
+  - printf '/CFLAGS=/s/-g//\ns/-O2//\ns/gnu99/c99/\nw\nq\n' | ed -s src/Makefile
   # Clean up build directory
   - make clean
   # Make Fuzzball and all related code


### PR DESCRIPTION
In the matrix of
gnu99 vs c99
nothing vs -D_XOPEN_SOURCE=700
there are four possibilities.
This one checks it with c99 and nothing

We could also check with -D_POSIX_C_SOURCE=200809L and without -D_XOPEN_SOURCE=700 for an additional matrix variable but I didn't choose to, yet.  _XOPEN_SOURCE is a superset of _POSIX_C_SOURCE, so some day the latter, smaller one alone should be checked.

We've done a lot of good changes since the last time we did standard checks, hence me doing some now. :3