### PR TITLE
include strings.h in mkversion.c

### DIFF
--- a/src/mkversion.c
+++ b/src/mkversion.c
@@ -20,6 +20,7 @@
 
 #ifndef WIN32
 #include <dirent.h>
+#include <strings.h>
 #else
 #include "win32.h"
 #endif


### PR DESCRIPTION
Because it uses strcasecmp()