### PR TITLE
Switch from getpagesize to sysconf

### DIFF
--- a/src/wiz.c
+++ b/src/wiz.c
@@ -1039,8 +1039,8 @@ do_pcreate(dbref player, const char *user, const char *password)
 void
 do_usage(dbref player)
 {
-    long psize;
 #ifdef HAVE_GETRUSAGE
+    long psize;
     struct rusage usage;
 #endif
 
@@ -1068,9 +1068,9 @@ do_usage(dbref player)
             (long) (usage.ru_maxrss * (psize / 1024)));
     notifyf(player, "Integral resident memory: %ldk",
             (long) (usage.ru_idrss * (psize / 1024)));
-#endif      /* HAVE_GETRUSAGE */
+#endif /* HAVE_GETRUSAGE */
 }
-#endif      /* NO_USAGE_COMMAND */
+#endif /* !NO_USAGE_COMMAND */
 
 /**
  * @TODO: These "topprofs" calls are almost all copy/paste.  I've noted in

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -1061,8 +1061,8 @@ do_usage(dbref player)
     notifyf(player, "Swapped out of main memory %d times.", usage.ru_nswap);
     notifyf(player, "Voluntarily context switched %d times.", usage.ru_nvcsw);
     notifyf(player, "Involuntarily context switched %d times.", usage.ru_nivcsw);
-    notifyf(player, "User time used: %d sec.", usage.ru_utime.tv_sec);
-    notifyf(player, "System time used: %d sec.", usage.ru_stime.tv_sec);
+    notifyf(player, "User time used: %ld sec.", usage.ru_utime.tv_sec);
+    notifyf(player, "System time used: %ld sec.", usage.ru_stime.tv_sec);
     notifyf(player, "Pagesize for this machine: %ld", psize);
     notifyf(player, "Maximum resident memory: %ldk",
             (long) (usage.ru_maxrss * (psize / 1024)));

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -1039,7 +1039,7 @@ do_pcreate(dbref player, const char *user, const char *password)
 void
 do_usage(dbref player)
 {
-    int psize;
+    long psize;
 #ifdef HAVE_GETRUSAGE
     struct rusage usage;
 #endif
@@ -1048,7 +1048,7 @@ do_usage(dbref player)
     notifyf(player, "Max descriptors/process: %ld", max_open_files());
 
 #ifdef HAVE_GETRUSAGE
-    psize = getpagesize();
+    psize = sysconf(_SC_PAGESIZE);
     getrusage(RUSAGE_SELF, &usage);
 
     notifyf(player, "Performed %d input servicings.", usage.ru_inblock);
@@ -1063,7 +1063,7 @@ do_usage(dbref player)
     notifyf(player, "Involuntarily context switched %d times.", usage.ru_nivcsw);
     notifyf(player, "User time used: %d sec.", usage.ru_utime.tv_sec);
     notifyf(player, "System time used: %d sec.", usage.ru_stime.tv_sec);
-    notifyf(player, "Pagesize for this machine: %d", psize);
+    notifyf(player, "Pagesize for this machine: %ld", psize);
     notifyf(player, "Maximum resident memory: %ldk",
             (long) (usage.ru_maxrss * (psize / 1024)));
     notifyf(player, "Integral resident memory: %ldk",

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -1061,8 +1061,8 @@ do_usage(dbref player)
     notifyf(player, "Swapped out of main memory %d times.", usage.ru_nswap);
     notifyf(player, "Voluntarily context switched %d times.", usage.ru_nvcsw);
     notifyf(player, "Involuntarily context switched %d times.", usage.ru_nivcsw);
-    notifyf(player, "User time used: %ld sec.", usage.ru_utime.tv_sec);
-    notifyf(player, "System time used: %ld sec.", usage.ru_stime.tv_sec);
+    notifyf(player, "User time used: %ld sec and %ld usec.", usage.ru_utime.tv_sec, usage.ru_utime.tv_usec);
+    notifyf(player, "System time used: %ld sec and %ld usec.", usage.ru_stime.tv_sec, usage.ru_stime.tv_usec);
     notifyf(player, "Pagesize for this machine: %ld", psize);
     notifyf(player, "Maximum resident memory: %ldk",
             (long) (usage.ru_maxrss * (psize / 1024)));


### PR DESCRIPTION
POSIX labeled getpagesize() as legacy a long time ago, and later removed it.  But while it was still there, but labeled as legacy, it defined it as identical to sysconf(_SC_PAGESIZE), other than for the result being a long rather than an int.

I need help with this one.  This can't be merged yet, but I don't know why things are differing.

Before:
```
Process ID: 2237
Max descriptors/process: 233379
Performed 0 input servicings.
Performed 0 output servicings.
Sent 24 messages over a socket.
Received 3 messages over a socket.
Received 0 signals.
Page faults NOT requiring physical I/O: 183
Page faults REQUIRING physical I/O: 0
Swapped out of main memory 0 times.
Voluntarily context switched 10 times.
Involuntarily context switched 0 times.
User time used: 0 sec.
System time used: 0 sec.
Pagesize for this machine: 4096
Maximum resident memory: 18064k
Integral resident memory: 1472k
```
After:
```
Process ID: 3211
Max descriptors/process: 233379
Performed 0 input servicings.
Performed 0 output servicings.
Sent 41 messages over a socket.
Received 6 messages over a socket.
Received 0 signals.
Page faults NOT requiring physical I/O: 183
Page faults REQUIRING physical I/O: 0
Swapped out of main memory 0 times.
Voluntarily context switched 15 times.
Involuntarily context switched 0 times.
User time used: 0 sec.
System time used: 0 sec.
Pagesize for this machine: 4096
Maximum resident memory: 0k
Integral resident memory: 0k
```
Despite the page size showing up correctly both times, the last two numbers turn to zero...