### PR TITLE
Remove TIME_MINUTE/HOUR/DAY macros

### DIFF
--- a/include/defaults.h
+++ b/include/defaults.h
@@ -26,8 +26,11 @@
 /*  Idleboot message.  */
 #define IDLEBOOT_MESSAGE "Autodisconnecting for inactivity."
 
-/*  How long someone can idle for.  */
-#define MAXIDLE TIME_HOUR(2)
+/*
+ * How long someone can idle for.
+ * 7200 seconds = 2 hours
+ */
+#define MAXIDLE 7200
 
 /*  Boot idle players?  */
 #define IDLEBOOT 1
@@ -58,11 +61,12 @@
 #define AUTOLOOK_CMD "look"
 
 /* various times */
-#define AGING_TIME TIME_DAY(90)	/* Unused time before obj shows as old. */
-#define DUMP_INTERVAL TIME_HOUR(4)	/* time between dumps */
-#define DUMP_WARNTIME TIME_MINUTE(2)	/* warning time before a dump */
-#define CLEAN_INTERVAL TIME_MINUTE(15)	/* time between unused obj purges */
-#define PNAME_HISTORY_THRESHOLD TIME_DAY(30) /* length of player name change history */
+#define AGING_TIME              7776000 /* Unused time before obj shows as old.  7776000 seconds = 90 days */
+#define DUMP_INTERVAL           14400   /* time between dumps: 14400 seconds = 4 hours */
+#define DUMP_WARNTIME           120     /* warning time before a dump: 120 seconds = 2 minutes */
+#define CLEAN_INTERVAL          900     /* time between unused obj purges: 900 seconds = 15 minutes */
+#define PNAME_HISTORY_THRESHOLD 2592000 /* length of player name change history: 2592000 seconds = 30 days */
+
 #define PNAME_HISTORY_REPORTING 1	/* Report player name change history */
 
 /* Information needed for SSL */

--- a/include/fbtime.h
+++ b/include/fbtime.h
@@ -13,10 +13,6 @@
 
 #include "config.h"
 
-#define TIME_MINUTE(x)  (60 * (x))                  /* 60 seconds */
-#define TIME_HOUR(x)    ((x) * (TIME_MINUTE(60)))   /* 60 minutes */
-#define TIME_DAY(x)     ((x) * (TIME_HOUR(24)))     /* 24 hours   */
-
 /**
  * Get the machine's offset from Greenwich Mean Time in seconds.
  *


### PR DESCRIPTION
They're only used in `defaults.h`.  I personally think the readability required is done better via good commenting than via macros.  It also reminds users that the final value genuinely is in seconds, and they can use any number of seconds they want.
We also save a few steps of multiplication, though that's not the impetus here.

If you think this is a bad idea, let me know!

I also chose to align everything. (with spaces, of course)
I also added a blank line to emphasise that PNAME_HISTORY_REPORTING is a boolean, not a time.