### PR TITLE
Update log.c

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -91,9 +91,9 @@ strip_evil_characters(char *badstring)
 	return;
 
     for (; *s; ++s) {
-	*s &= 0x7f;		/* No high ascii */
+	*s &= '\177';		/* No high ascii */
 
-	if (*s == 0x1b)
+	if (*s == '\033')
 	    *s = '[';		/* No escape (Aieeee!) */
 
 	if (!isprint(*s))


### PR DESCRIPTION
This function only deals with chars, so may as well use char literals/constants for comparisons and ANDing.

My main intent here, actually, is to have escape be 033 so I can more easily search for it later.  This was the only case in the code where the escape character is written in hexadecimal rather than octal.
I easily could've used 33 instead of 033, but both work and I chose the latter.