### PR TITLE
use appropriate types for ports and addresses

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -10,6 +10,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/src/interface.c
+++ b/src/interface.c
@@ -1561,7 +1561,7 @@ make_socket_v6(int port)
 
 /* addrout_v6 -- Translate IPV6 address 'a' from addr struct to text. */
 static const char *
-addrout_v6(int lport, struct in6_addr *a, unsigned short prt)
+addrout_v6(in_port_t lport, struct in6_addr *a, in_port_t prt)
 {
     static char buf[128];
     char ip6addr[128];
@@ -1598,7 +1598,7 @@ addrout_v6(int lport, struct in6_addr *a, unsigned short prt)
 		secs_lost = lag;
 	    }
 	    if (he) {
-		snprintf(buf, sizeof(buf), "%s(%u)", he->h_name, prt);
+		snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", he->h_name, prt);
 		return buf;
 	    }
 	}
@@ -1607,18 +1607,18 @@ addrout_v6(int lport, struct in6_addr *a, unsigned short prt)
 
     inet_ntop(AF_INET6, a, ip6addr, 128);
 #ifdef SPAWN_HOST_RESOLVER
-    snprintf(buf, sizeof(buf), "%s(%u)%u\n", ip6addr, prt, lport);
+    snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")%" PRIu16 "\n", ip6addr, prt, lport);
     if (tp_hostnames) {
 	write(resolver_sock[1], buf, strlen(buf));
     }
 #endif
-    snprintf(buf, sizeof(buf), "%s(%u)\n", ip6addr, prt);
+    snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")\n", ip6addr, prt);
 
     return buf;
 }
 
 static struct descriptor_data *
-new_connection_v6(int port, int sock_, int is_ssl)
+new_connection_v6(in_port_t port, int sock_, int is_ssl)
 {
     int newsock;
 
@@ -1644,7 +1644,7 @@ new_connection_v6(int port, int sock_, int is_ssl)
 
 /* addrout -- Translate address 'a' from addr struct to text. */
 static const char *
-addrout(int lport, long a, unsigned short prt)
+addrout(in_port_t lport, in_addr_t a, in_port_t prt)
 {
     static char buf[128];
     struct in_addr addr;
@@ -1681,7 +1681,7 @@ addrout(int lport, long a, unsigned short prt)
 		secs_lost = lag;
 	    }
 	    if (he) {
-		snprintf(buf, sizeof(buf), "%s(%u)", he->h_name, prt);
+		snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", he->h_name, prt);
 		return buf;
 	    }
 	}
@@ -1691,14 +1691,14 @@ addrout(int lport, long a, unsigned short prt)
     a = ntohl(a);
 
 #ifdef SPAWN_HOST_RESOLVER
-    snprintf(buf, sizeof(buf), "%ld.%ld.%ld.%ld(%u)%u\n",
+    snprintf(buf, sizeof(buf), "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32 "(%" PRIu16 ")%" PRIu16 "\n",
 	     (a >> 24) & 0xff, (a >> 16) & 0xff, (a >> 8) & 0xff, a & 0xff, prt, lport);
     if (tp_hostnames) {
 	write(resolver_sock[1], buf, strlen(buf));
     }
 #endif
 
-    snprintf(buf, sizeof(buf), "%ld.%ld.%ld.%ld(%u)",
+    snprintf(buf, sizeof(buf), "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32 "(%" PRIu16 ")",
 	     (a >> 24) & 0xff, (a >> 16) & 0xff, (a >> 8) & 0xff, a & 0xff, prt);
     return buf;
 }
@@ -1780,7 +1780,7 @@ static void listen_bound_sockets()
 }
 
 static struct descriptor_data *
-new_connection(int port, int sock_, int is_ssl)
+new_connection(in_port_t port, int sock_, int is_ssl)
 {
     int newsock;
     struct sockaddr_in addr;

--- a/src/interface.c
+++ b/src/interface.c
@@ -57,6 +57,11 @@
 # endif
 #endif
 
+#ifdef WIN32
+typedef uint32_t in_addr_t;
+typedef uint16_t in_port_t;
+#endif
+
 static const char *connect_fail =
 	"Either that player does not exist, or has a different password.\r\n";
 

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -389,7 +389,7 @@ void set_signals(void) {
     signal(SIGHUP, SIG_IGN);
 }
 
-static const char * get_username(long a, in_port_t prt, in_port_t myprt) {
+static const char * get_username(in_addr_t a, in_port_t prt, in_port_t myprt) {
     int fd, result;
     socklen_t len;
     char *ptr, *ptr2;
@@ -518,7 +518,7 @@ static const char * addrout(in_addr_t a, in_port_t prt, in_port_t myprt) {
     }
 
     a = ntohl(a);
-    snprintf(tmpbuf, sizeof(tmpbuf), "%ld.%ld.%ld.%ld",
+    snprintf(tmpbuf, sizeof(tmpbuf), "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32,
 	     (a >> 24) & 0xff, (a >> 16) & 0xff, (a >> 8) & 0xff, a & 0xff);
     hostadd_timestamp(a, tmpbuf);
     ptr = get_username(htonl(a), prt, myprt);


### PR DESCRIPTION
There are types meant for addresses and ports.  The IPv6 code was typically more correct than the IPv4 code, fixed both though.
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/inttypes.h.html

TODO:
Use a function from here:
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/arpa_inet.h.html
to translate addresses back and forth between IPv4 dotted decimal notation strings and an integers.  Currently, Fuzzball does that itself by shifting bits.