### PR TITLE
Use appropriate types for ports/addresses (attempt 2)

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -10,6 +10,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/src/interface.c
+++ b/src/interface.c
@@ -1561,7 +1561,7 @@ make_socket_v6(int port)
 
 /* addrout_v6 -- Translate IPV6 address 'a' from addr struct to text. */
 static const char *
-addrout_v6(int lport, struct in6_addr *a, unsigned short prt)
+addrout_v6(in_port_t lport, struct in6_addr *a, in_port_t prt)
 {
     static char buf[128];
     char ip6addr[128];
@@ -1598,7 +1598,7 @@ addrout_v6(int lport, struct in6_addr *a, unsigned short prt)
 		secs_lost = lag;
 	    }
 	    if (he) {
-		snprintf(buf, sizeof(buf), "%s(%u)", he->h_name, prt);
+		snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", he->h_name, prt);
 		return buf;
 	    }
 	}
@@ -1607,18 +1607,18 @@ addrout_v6(int lport, struct in6_addr *a, unsigned short prt)
 
     inet_ntop(AF_INET6, a, ip6addr, 128);
 #ifdef SPAWN_HOST_RESOLVER
-    snprintf(buf, sizeof(buf), "%s(%u)%u\n", ip6addr, prt, lport);
+    snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")%" PRIu16 "\n", ip6addr, prt, lport);
     if (tp_hostnames) {
 	write(resolver_sock[1], buf, strlen(buf));
     }
 #endif
-    snprintf(buf, sizeof(buf), "%s(%u)\n", ip6addr, prt);
+    snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")\n", ip6addr, prt);
 
     return buf;
 }
 
 static struct descriptor_data *
-new_connection_v6(int port, int sock_, int is_ssl)
+new_connection_v6(in_port_t port, int sock_, int is_ssl)
 {
     int newsock;
 
@@ -1644,7 +1644,7 @@ new_connection_v6(int port, int sock_, int is_ssl)
 
 /* addrout -- Translate address 'a' from addr struct to text. */
 static const char *
-addrout(int lport, long a, unsigned short prt)
+addrout(in_port_t lport, in_addr_t a, in_port_t prt)
 {
     static char buf[128];
     struct in_addr addr;
@@ -1681,7 +1681,7 @@ addrout(int lport, long a, unsigned short prt)
 		secs_lost = lag;
 	    }
 	    if (he) {
-		snprintf(buf, sizeof(buf), "%s(%u)", he->h_name, prt);
+		snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", he->h_name, prt);
 		return buf;
 	    }
 	}
@@ -1691,14 +1691,14 @@ addrout(int lport, long a, unsigned short prt)
     a = ntohl(a);
 
 #ifdef SPAWN_HOST_RESOLVER
-    snprintf(buf, sizeof(buf), "%ld.%ld.%ld.%ld(%u)%u\n",
+    snprintf(buf, sizeof(buf), "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32 "(%" PRIu16 ")%" PRIu16 "\n",
 	     (a >> 24) & 0xff, (a >> 16) & 0xff, (a >> 8) & 0xff, a & 0xff, prt, lport);
     if (tp_hostnames) {
 	write(resolver_sock[1], buf, strlen(buf));
     }
 #endif
 
-    snprintf(buf, sizeof(buf), "%ld.%ld.%ld.%ld(%u)",
+    snprintf(buf, sizeof(buf), "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32 "(%" PRIu16 ")",
 	     (a >> 24) & 0xff, (a >> 16) & 0xff, (a >> 8) & 0xff, a & 0xff, prt);
     return buf;
 }
@@ -1780,7 +1780,7 @@ static void listen_bound_sockets()
 }
 
 static struct descriptor_data *
-new_connection(int port, int sock_, int is_ssl)
+new_connection(in_port_t port, int sock_, int is_ssl)
 {
     int newsock;
     struct sockaddr_in addr;

--- a/src/interface.c
+++ b/src/interface.c
@@ -57,6 +57,11 @@
 # endif
 #endif
 
+#ifdef WIN32
+typedef uint32_t in_addr_t;
+typedef uint16_t in_port_t;
+#endif
+
 static const char *connect_fail =
 	"Either that player does not exist, or has a different password.\r\n";
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -62,11 +62,9 @@ typedef uint32_t in_addr_t;
 typedef uint16_t in_port_t;
 #endif
 
-static const char *connect_fail =
-	"Either that player does not exist, or has a different password.\r\n";
+static const char *connect_fail = "Either that player does not exist, or has a different password.\r\n";
 
-static const char *create_fail =
-	"Either there is already a player with that name, or that name is illegal.\r\n";
+static const char *create_fail = "Either there is already a player with that name, or that name is illegal.\r\n";
 
 static const char *flushed_message = "<Output Flushed>\r\n";
 static const char *shutdown_message = "\r\nGoing down - Bye\r\n";
@@ -75,8 +73,8 @@ static int resolver_sock[2];
 
 struct descriptor_data *descriptor_list = NULL;
 
-static int con_players_max = 0;	/* one of Cynbe's good ideas. */
-static int con_players_curr = 0;	/* for playermax checks. */
+static int con_players_max = 0; /* one of Cynbe's good ideas. */
+static int con_players_curr = 0; /* for playermax checks. */
 
 #define MAX_LISTEN_SOCKS 16
 
@@ -1505,311 +1503,311 @@ initializesock(int s, const char *hostname, int is_ssl)
 static int
 make_socket_v6(int port)
 {
-    int s;
-    int opt;
-    struct sockaddr_in6 server;
+	int s;
+	int opt;
+	struct sockaddr_in6 server;
 
-    s = socket(AF_INET6, SOCK_STREAM, 0);
+	s = socket(AF_INET6, SOCK_STREAM, 0);
 
-    if (s < 0) {
-	perror("creating stream socket");
-	exit(3);
-    }
+	if (s < 0) {
+		perror("creating stream socket");
+		exit(3);
+	}
 
-    opt = 1;
-    if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *) &opt, sizeof(opt)) < 0) {
-	perror("setsockopt(SO_REUSEADDR)");
-	exit(1);
-    }
+	opt = 1;
+	if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *) &opt, sizeof(opt)) < 0) {
+		perror("setsockopt(SO_REUSEADDR)");
+		exit(1);
+	}
 
-    opt = 1;
-    if (setsockopt(s, SOL_SOCKET, SO_KEEPALIVE, (char *) &opt, sizeof(opt)) < 0) {
-	perror("setsockopt(SO_KEEPALIVE)");
-	exit(1);
-    }
+	opt = 1;
+	if (setsockopt(s, SOL_SOCKET, SO_KEEPALIVE, (char *) &opt, sizeof(opt)) < 0) {
+		perror("setsockopt(SO_KEEPALIVE)");
+		exit(1);
+	}
 
-    opt = 1;
-    if (setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, (char *) &opt, sizeof(opt)) < 0) {
-	perror("setsockopt(IPV6_V6ONLY");
-	exit(1);
-    }
+	opt = 1;
+	if (setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, (char *) &opt, sizeof(opt)) < 0) {
+		perror("setsockopt(IPV6_V6ONLY");
+		exit(1);
+	}
 
-    /*
-       opt = 240;
-       if (setsockopt(s, SOL_TCP, TCP_KEEPIDLE, (char *) &opt, sizeof(opt)) < 0) {
-       perror("setsockopt");
-       exit(1);
-       }
-     */
+	/*
+	opt = 240;
+	if (setsockopt(s, SOL_TCP, TCP_KEEPIDLE, (char *) &opt, sizeof(opt)) < 0) {
+		perror("setsockopt");
+		exit(1);
+	}
+	*/
 
-    memset((char *) &server, 0, sizeof(server));
-    /* server.sin6_len = sizeof(server); */
-    server.sin6_family = AF_INET6;
-    server.sin6_addr = bind_ipv6_address;
-    server.sin6_port = htons(port);
+	memset((char *) &server, 0, sizeof(server));
+	/* server.sin6_len = sizeof(server); */
+	server.sin6_family = AF_INET6;
+	server.sin6_addr = bind_ipv6_address;
+	server.sin6_port = htons(port);
 
-    if (bind(s, (struct sockaddr *) &server, sizeof(server))) {
-	perror("binding stream socket");
-	close(s);
-	exit(4);
-    }
+	if (bind(s, (struct sockaddr *) &server, sizeof(server))) {
+		perror("binding stream socket");
+		close(s);
+		exit(4);
+	}
 
-    make_cloexec(s);
+	make_cloexec(s);
 
-    /* We separate the binding of the socket and the listening on the socket */
-    /* to support binding to privileged ports, then dropping privileges */
-    /* before listening.  Listening now happens in listen_bound_sockets(), */
-    /* called during shovechars().  This function is now called before the */
-    /* checks for MUD_GID and MUD_ID in main(). */
-    /*    listen(s, 5);	*/
-    return s;
+	/*
+	 * We separate the binding of the socket and the listening on the socket
+	 * to support binding to privileged ports, then dropping privileges
+	 * before listening.  Listening now happens in listen_bound_sockets(),
+	 * called during shovechars().  This function is now called before the
+	 * checks for MUD_GID and MUD_ID in main().
+	 */
+	/* listen(s, 5); */
+	return s;
 }
 
 /* addrout_v6 -- Translate IPV6 address 'a' from addr struct to text. */
 static const char *
 addrout_v6(in_port_t lport, struct in6_addr *a, in_port_t prt)
 {
-    static char buf[128];
-    char ip6addr[128];
+	static char buf[128];
+	char ip6addr[128];
 
-    struct in6_addr addr;
-    memcpy(&addr.s6_addr, a, sizeof(struct in6_addr));
+	struct in6_addr addr;
+	memcpy(&addr.s6_addr, a, sizeof(struct in6_addr));
 
-    prt = ntohs(prt);
+	prt = ntohs(prt);
 
 #ifndef SPAWN_HOST_RESOLVER
-    if (tp_hostnames) {
-      /*
-       * One day the nameserver Qwest uses decided to start
-       * doing halfminute lags, locking up the entire muck
-       * that long on every connect.  This is intended to
-       * prevent that, reduces average lag due to nameserver
-       * to 1 sec/call, simply by not calling nameserver if
-       * it's in a slow mood *grin*. If the nameserver lags
-       * consistently, a hostname cache ala OJ's tinymuck2.3
-       * would make more sense:
-       */
-	static time_t secs_lost = 0;
+	if (tp_hostnames) {
+		/*
+		 * One day the nameserver Qwest uses decided to start
+		 * doing halfminute lags, locking up the entire muck
+		 * that long on every connect.  This is intended to
+		 * prevent that, reduces average lag due to nameserver
+		 * to 1 sec/call, simply by not calling nameserver if
+		 * it's in a slow mood *grin*. If the nameserver lags
+		 * consistently, a hostname cache ala OJ's tinymuck2.3
+		 * would make more sense:
+		 */
+		static time_t secs_lost = 0;
 
-	if (secs_lost) {
-	    secs_lost--;
-	} else {
-	    time_t gethost_start = time(NULL);
+		if (secs_lost) {
+			secs_lost--;
+		} else {
+			time_t gethost_start = time(NULL);
 
-	    struct hostent *he = gethostbyaddr(((char *) &addr), sizeof(addr), AF_INET6);
-	    time_t gethost_stop = time(NULL);
-	    time_t lag = gethost_stop - gethost_start;
+			struct hostent *he = gethostbyaddr(((char *) &addr), sizeof(addr), AF_INET6);
+			time_t gethost_stop = time(NULL);
+			time_t lag = gethost_stop - gethost_start;
 
-	    if (lag > 10) {
-		secs_lost = lag;
-	    }
-	    if (he) {
-		snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", he->h_name, prt);
-		return buf;
-	    }
+			if (lag > 10) {
+				secs_lost = lag;
+			}
+			if (he) {
+				snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", he->h_name, prt);
+				return buf;
+			}
+		}
 	}
-    }
-#endif			/* SPAWN_HOST_RESOLVER */
+#endif /* !SPAWN_HOST_RESOLVER */
 
-    inet_ntop(AF_INET6, a, ip6addr, 128);
+	inet_ntop(AF_INET6, a, ip6addr, 128);
 #ifdef SPAWN_HOST_RESOLVER
-    snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")%" PRIu16 "\n", ip6addr, prt, lport);
-    if (tp_hostnames) {
-	write(resolver_sock[1], buf, strlen(buf));
-    }
+	snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")%" PRIu16 "\n", ip6addr, prt, lport);
+	if (tp_hostnames) {
+		write(resolver_sock[1], buf, strlen(buf));
+	}
 #endif
-    snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")\n", ip6addr, prt);
+	snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")\n", ip6addr, prt);
 
-    return buf;
+	return buf;
 }
 
 static struct descriptor_data *
 new_connection_v6(in_port_t port, int sock_, int is_ssl)
 {
-    int newsock;
+	int newsock;
 
-    struct sockaddr_in6 addr;
-    socklen_t addr_len;
-    char hostname[128];
+	struct sockaddr_in6 addr;
+	socklen_t addr_len;
+	char hostname[128];
 
-    addr_len = (socklen_t) sizeof(addr);
-    newsock = accept(sock_, (struct sockaddr *) &addr, &addr_len);
-    if (newsock < 0) {
-	return 0;
-    } else {
-# ifdef F_SETFD
-	fcntl(newsock, F_SETFD, 1);
-# endif
-	strcpyn(hostname, sizeof(hostname),
-		addrout_v6(port, &(addr.sin6_addr), addr.sin6_port));
-	log_status("ACCEPT: %s on descriptor %d", hostname, newsock);
-	log_status("CONCOUNT: There are now %d open connections.", ++ndescriptors);
-	return initializesock(newsock, hostname, is_ssl);
-    }
+	addr_len = (socklen_t) sizeof(addr);
+	newsock = accept(sock_, (struct sockaddr *) &addr, &addr_len);
+	if (newsock < 0) {
+		return 0;
+	} else {
+#ifdef F_SETFD
+		fcntl(newsock, F_SETFD, 1);
+#endif
+		strcpyn(hostname, sizeof(hostname), addrout_v6(port, &(addr.sin6_addr), addr.sin6_port));
+		log_status("ACCEPT: %s on descriptor %d", hostname, newsock);
+		log_status("CONCOUNT: There are now %d open connections.", ++ndescriptors);
+		return initializesock(newsock, hostname, is_ssl);
+	}
 }
 
 /* addrout -- Translate address 'a' from addr struct to text. */
 static const char *
 addrout(in_port_t lport, in_addr_t a, in_port_t prt)
 {
-    static char buf[128];
-    struct in_addr addr;
+	static char buf[128];
+	struct in_addr addr;
 
-    memset(&addr, 0, sizeof(addr));
-    memcpy(&addr.s_addr, &a, sizeof(struct in_addr));
+	memset(&addr, 0, sizeof(addr));
+	memcpy(&addr.s_addr, &a, sizeof(struct in_addr));
 
-    prt = ntohs(prt);
+	prt = ntohs(prt);
 
 #ifndef SPAWN_HOST_RESOLVER
-    if (tp_hostnames) {
-      /*
-       * One day the nameserver Qwest uses decided to start
-       * doing halfminute lags, locking up the entire muck
-       * that long on every connect.  This is intended to
-       * prevent that, reduces average lag due to nameserver
-       * to 1 sec/call, simply by not calling nameserver if
-       * it's in a slow mood *grin*. If the nameserver lags
-       * consistently, a hostname cache ala OJ's tinymuck2.3
-       * would make more sense:
-       */
-	static time_t secs_lost = 0;
+	if (tp_hostnames) {
+		/*
+		 * One day the nameserver Qwest uses decided to start
+		 * doing halfminute lags, locking up the entire muck
+		 * that long on every connect.  This is intended to
+		 * prevent that, reduces average lag due to nameserver
+		 * to 1 sec/call, simply by not calling nameserver if
+		 * it's in a slow mood *grin*. If the nameserver lags
+		 * consistently, a hostname cache ala OJ's tinymuck2.3
+		 * would make more sense:
+		 */
+		static time_t secs_lost = 0;
 
-	if (secs_lost) {
-	    secs_lost--;
-	} else {
-	    time_t gethost_start = time(NULL);
+		if (secs_lost) {
+			secs_lost--;
+		} else {
+			time_t gethost_start = time(NULL);
 
-	    struct hostent *he = gethostbyaddr(((char *) &addr), sizeof(addr), AF_INET);
-	    time_t gethost_stop = time(NULL);
-	    time_t lag = gethost_stop - gethost_start;
+			struct hostent *he = gethostbyaddr(((char *) &addr), sizeof(addr), AF_INET);
+			time_t gethost_stop = time(NULL);
+			time_t lag = gethost_stop - gethost_start;
 
-	    if (lag > 10) {
-		secs_lost = lag;
-	    }
-	    if (he) {
-		snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", he->h_name, prt);
-		return buf;
-	    }
+			if (lag > 10) {
+				secs_lost = lag;
+			}
+			if (he) {
+				snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", he->h_name, prt);
+				return buf;
+			}
+		}
 	}
-    }
-#endif			/* SPAWN_HOST_RESOLVER */
+#endif /* !SPAWN_HOST_RESOLVER */
 
-    a = ntohl(a);
+	a = ntohl(a);
 
 #ifdef SPAWN_HOST_RESOLVER
-    snprintf(buf, sizeof(buf), "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32 "(%" PRIu16 ")%" PRIu16 "\n",
-	     (a >> 24) & 0xff, (a >> 16) & 0xff, (a >> 8) & 0xff, a & 0xff, prt, lport);
-    if (tp_hostnames) {
-	write(resolver_sock[1], buf, strlen(buf));
-    }
+	snprintf(buf, sizeof(buf), "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32 "(%" PRIu16 ")%" PRIu16 "\n", (a >> 24) & 0xff, (a >> 16) & 0xff, (a >> 8) & 0xff, a & 0xff, prt, lport);
+	if (tp_hostnames) {
+		write(resolver_sock[1], buf, strlen(buf));
+	}
 #endif
 
-    snprintf(buf, sizeof(buf), "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32 "(%" PRIu16 ")",
-	     (a >> 24) & 0xff, (a >> 16) & 0xff, (a >> 8) & 0xff, a & 0xff, prt);
-    return buf;
+	snprintf(buf, sizeof(buf), "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32 "(%" PRIu16 ")", (a >> 24) & 0xff, (a >> 16) & 0xff, (a >> 8) & 0xff, a & 0xff, prt);
+	return buf;
 }
 
 static int
 make_socket(int port)
 {
-    int s;
-    int opt;
-    struct sockaddr_in server;
+	int s;
+	int opt;
+	struct sockaddr_in server;
 
-    s = socket(AF_INET, SOCK_STREAM, 0);
+	s = socket(AF_INET, SOCK_STREAM, 0);
 
-    if (s < 0) {
-	perror("creating stream socket");
-	exit(3);
-    }
+	if (s < 0) {
+		perror("creating stream socket");
+		exit(3);
+	}
 
-    opt = 1;
-    if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *) &opt, sizeof(opt)) < 0) {
-	perror("setsockopt");
-	exit(1);
-    }
+	opt = 1;
+	if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *) &opt, sizeof(opt)) < 0) {
+		perror("setsockopt");
+		exit(1);
+	}
 
-    opt = 1;
-    if (setsockopt(s, SOL_SOCKET, SO_KEEPALIVE, (char *) &opt, sizeof(opt)) < 0) {
-	perror("setsockopt");
-	exit(1);
-    }
+	opt = 1;
+	if (setsockopt(s, SOL_SOCKET, SO_KEEPALIVE, (char *) &opt, sizeof(opt)) < 0) {
+		perror("setsockopt");
+		exit(1);
+	}
 
-    /*
-       opt = 240;
-       if (setsockopt(s, SOL_TCP, TCP_KEEPIDLE, (char *) &opt, sizeof(opt)) < 0) {
-       perror("setsockopt");
-       exit(1);
-       }
-     */
+	/*
+	opt = 240;
+	if (setsockopt(s, SOL_TCP, TCP_KEEPIDLE, (char *) &opt, sizeof(opt)) < 0) {
+		perror("setsockopt");
+		exit(1);
+	}
+	*/
 
-    server.sin_family = AF_INET;
-    server.sin_addr.s_addr = bind_ipv4_address;
-    server.sin_port = htons(port);
+	server.sin_family = AF_INET;
+	server.sin_addr.s_addr = bind_ipv4_address;
+	server.sin_port = htons(port);
 
-    if (bind(s, (struct sockaddr *) &server, sizeof(server))) {
-	perror("binding stream socket");
-	close(s);
-	exit(4);
-    }
+	if (bind(s, (struct sockaddr *) &server, sizeof(server))) {
+		perror("binding stream socket");
+		close(s);
+		exit(4);
+	}
 
-    make_cloexec(s);
+	make_cloexec(s);
 
-    /* We separate the binding of the socket and the listening on the socket */
-    /* to support binding to privileged ports, then dropping privileges */
-    /* before listening.  Listening now happens in listen_bound_sockets(), */
-    /* called during shovechars().  This function is now called before the */
-    /* checks for MUD_GID and MUD_ID in main(). */
-    /*    listen(s, 5);	*/
-    return s;
+	/*
+	 * We separate the binding of the socket and the listening on the socket
+	 * to support binding to privileged ports, then dropping privileges
+	 * before listening.  Listening now happens in listen_bound_sockets(),
+	 * called during shovechars().  This function is now called before the
+	 * checks for MUD_GID and MUD_ID in main().
+	 */
+	/* listen(s, 5); */
+	return s;
 }
 
 static void listen_bound_sockets()
 {
-    for (int i = 0; i < numsocks; i++) {
-	listen(sock[i], 5);
-    }
+	for (int i = 0; i < numsocks; i++) {
+		listen(sock[i], 5);
+	}
 
-    for (int i = 0; i< numsocks_v6; i++) {
-	listen(sock_v6[i],5);
-    }
+	for (int i = 0; i< numsocks_v6; i++) {
+		listen(sock_v6[i],5);
+	}
 
 #ifdef USE_SSL
-    for (int i = 0; i < ssl_numsocks; i++) {
-	listen(ssl_sock[i], 5);
-    }
+	for (int i = 0; i < ssl_numsocks; i++) {
+		listen(ssl_sock[i], 5);
+	}
 
-    for (int i = 0; i < ssl_numsocks_v6; i++) {
-	listen(ssl_sock_v6[i], 5);
-    }
+	for (int i = 0; i < ssl_numsocks_v6; i++) {
+		listen(ssl_sock_v6[i], 5);
+	}
 #endif
 }
 
 static struct descriptor_data *
 new_connection(in_port_t port, int sock_, int is_ssl)
 {
-    int newsock;
-    struct sockaddr_in addr;
-    socklen_t addr_len;
-    char hostname[128];
+	int newsock;
+	struct sockaddr_in addr;
+	socklen_t addr_len;
+	char hostname[128];
 
-    addr_len = (socklen_t) sizeof(addr);
-    newsock = accept(sock_, (struct sockaddr *) &addr, &addr_len);
-    if (newsock < 0) {
-	return 0;
-    } else {
+	addr_len = (socklen_t) sizeof(addr);
+	newsock = accept(sock_, (struct sockaddr *) &addr, &addr_len);
+	if (newsock < 0) {
+		return 0;
+	} else {
 #ifdef F_SETFD
-	fcntl(newsock, F_SETFD, 1);
+		fcntl(newsock, F_SETFD, 1);
 #endif
-	strcpyn(hostname, sizeof(hostname),
-		addrout(port, addr.sin_addr.s_addr, addr.sin_port));
-	log_status("ACCEPT: %s on descriptor %d", hostname, newsock);
-	log_status("CONCOUNT: There are now %d open connections.", ++ndescriptors);
-	return initializesock(newsock, hostname, is_ssl);
-    }
+		strcpyn(hostname, sizeof(hostname), addrout(port, addr.sin_addr.s_addr, addr.sin_port));
+		log_status("ACCEPT: %s on descriptor %d", hostname, newsock);
+		log_status("CONCOUNT: There are now %d open connections.", ++ndescriptors);
+		return initializesock(newsock, hostname, is_ssl);
+	}
 }
 
-/* sends keppalive; depends on process_output to set booted if connection is dead */
+/* sends keepalive; depends on process_output to set booted if connection is dead */
 static void 
 send_keepalive(struct descriptor_data *d)
 {

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -15,7 +15,7 @@
 /* number of hostnames cached in an LRU queue */
 #define HOST_CACHE_SIZE 8192
 
-/* Time before retrying to resolve a previously unresolved IP address. */ /* 1800 seconds == 30 minutes */
+/* Time before retrying to resolve a previously unresolved IP address.  1800 seconds == 30 minutes */
 #define EXPIRE_TIME 1800
 
 /* Time before the resolver gives up on a identd lookup.  Prevents hangs. */
@@ -167,156 +167,156 @@ static void hostadd_timestamp_v6(struct in6_addr *ip, const char *name) {
 }
 
 static const char * get_username_v6(struct in6_addr *a, in_port_t prt, in_port_t myprt) {
-    int fd, result;
-    socklen_t len;
-    char *ptr, *ptr2;
-    static char buf[1024];
-    int lasterr;
-    int timeout = IDENTD_TIMEOUT;
+	int fd, result;
+	socklen_t len;
+	char *ptr, *ptr2;
+	static char buf[1024];
+	int lasterr;
+	int timeout = IDENTD_TIMEOUT;
 
-    struct sockaddr_in6 addr;
+	struct sockaddr_in6 addr;
 
-    if ((fd = socket(AF_INET6, SOCK_STREAM, 0)) < 0) {
-	perror("resolver ident socket");
-	return (0);
-    }
-
-    make_nonblocking(fd);
-
-    len = sizeof(addr);
-    addr.sin6_family = AF_INET6;
-    memcpy(&addr.sin6_addr.s6_addr, a, sizeof(struct in6_addr));
-    addr.sin6_port = htons((short) 113);
-
-    do {
-	result = connect(fd, (struct sockaddr *) &addr, len);
-	lasterr = errno;
-	if (result < 0) {
-	    if (!timeout--)
-		break;
-	    sleep(1);
+	if ((fd = socket(AF_INET6, SOCK_STREAM, 0)) < 0) {
+		perror("resolver ident socket");
+		return (0);
 	}
-    } while (result < 0 && lasterr == EINPROGRESS);
-    if (result < 0 && lasterr != EISCONN) {
-	goto bad;
-    }
 
-    snprintf(buf, sizeof(buf), "%" PRIu16 ",%" PRIu16 "\n", prt, myprt);
-    do {
-	result = write(fd, buf, strlen(buf));
-	lasterr = errno;
-	if (result < 0) {
-	    if (!timeout--)
-		break;
-	    sleep(1);
+	make_nonblocking(fd);
+
+	len = sizeof(addr);
+	addr.sin6_family = AF_INET6;
+	memcpy(&addr.sin6_addr.s6_addr, a, sizeof(struct in6_addr));
+	addr.sin6_port = htons((short) 113);
+
+	do {
+		result = connect(fd, (struct sockaddr *) &addr, len);
+		lasterr = errno;
+		if (result < 0) {
+			if (!timeout--)
+				break;
+			sleep(1);
+		}
+	} while (result < 0 && lasterr == EINPROGRESS);
+	if (result < 0 && lasterr != EISCONN) {
+		goto bad;
 	}
-    } while (result < 0 && lasterr == EAGAIN);
-    if (result < 0)
-	goto bad2;
 
-    do {
-	result = read(fd, buf, sizeof(buf));
-	lasterr = errno;
-	if (result < 0) {
-	    if (!timeout--)
-		break;
-	    sleep(1);
-	}
-    } while (result < 0 && lasterr == EAGAIN);
-    if (result < 0)
-	goto bad2;
+	snprintf(buf, sizeof(buf), "%" PRIu16 ",%" PRIu16 "\n", prt, myprt);
+	do {
+		result = write(fd, buf, strlen(buf));
+		lasterr = errno;
+		if (result < 0) {
+			if (!timeout--)
+				break;
+			sleep(1);
+		}
+	} while (result < 0 && lasterr == EAGAIN);
+	if (result < 0)
+		goto bad2;
 
-    ptr = strchr(buf, ':');
-    if (!ptr)
-	goto bad2;
-    ptr++;
-    if (*ptr)
+	do {
+		result = read(fd, buf, sizeof(buf));
+		lasterr = errno;
+		if (result < 0) {
+			if (!timeout--)
+				break;
+			sleep(1);
+		}
+	} while (result < 0 && lasterr == EAGAIN);
+	if (result < 0)
+		goto bad2;
+
+	ptr = strchr(buf, ':');
+	if (!ptr)
+		goto bad2;
 	ptr++;
-    if (strncmp(ptr, "USERID", 6))
-	goto bad2;
+	if (*ptr)
+		ptr++;
+	if (strncmp(ptr, "USERID", 6))
+		goto bad2;
 
-    ptr = strchr(ptr, ':');
-    if (!ptr)
-	goto bad2;
-    ptr = strchr(ptr + 1, ':');
-    if (!ptr)
-	goto bad2;
-    ptr++;
-    /* if (*ptr) ptr++; */
+	ptr = strchr(ptr, ':');
+	if (!ptr)
+		goto bad2;
+	ptr = strchr(ptr + 1, ':');
+	if (!ptr)
+		goto bad2;
+	ptr++;
+	/* if (*ptr) ptr++; */
 
-    shutdown(fd, 2);
-    close(fd);
-    if ((ptr2 = strchr(ptr, '\r')))
-	*ptr2 = '\0';
-    if (!*ptr)
+	shutdown(fd, 2);
+	close(fd);
+	if ((ptr2 = strchr(ptr, '\r')))
+		*ptr2 = '\0';
+	if (!*ptr)
+		return (0);
+	return ptr;
+
+	bad2:
+	shutdown(fd, 2);
+
+	bad:
+	close(fd);
 	return (0);
-    return ptr;
-
-  bad2:
-    shutdown(fd, 2);
-
-  bad:
-    close(fd);
-    return (0);
 }
 
 /* addrout_v6 -- Translate address 'a' to text.  */
 static const char * addrout_v6(struct in6_addr *a, in_port_t prt, in_port_t myprt) {
-    static char buf[128];
-    char tmpbuf[128];
-    const char *ptr, *ptr2;
-    struct hostent *he;
+	static char buf[128];
+	char tmpbuf[128];
+	const char *ptr, *ptr2;
+	struct hostent *he;
 
-    struct in6_addr addr;
-    memcpy(&addr.s6_addr, a, sizeof(struct in6_addr));
+	struct in6_addr addr;
+	memcpy(&addr.s6_addr, a, sizeof(struct in6_addr));
 
-    ptr = hostfetch_v6(a);
+	ptr = hostfetch_v6(a);
 
-    if (ptr) {
-	ptr2 = get_username_v6(a, prt, myprt);
-	if (ptr2) {
-	    snprintf(buf, sizeof(buf), "%s(%s)", ptr, ptr2);
-	} else {
-	    snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", ptr, prt);
-	}
-	return buf;
-    }
-    he = gethostbyaddr(((char *) &addr), sizeof(addr), AF_INET6);
-
-    if (he) {
-	strcpyn(tmpbuf, sizeof(tmpbuf), he->h_name);
-	hostadd_v6(a, tmpbuf);
-	ptr = get_username_v6(a, prt, myprt);
 	if (ptr) {
-	    snprintf(buf, sizeof(buf), "%s(%s)", tmpbuf, ptr);
+		ptr2 = get_username_v6(a, prt, myprt);
+		if (ptr2) {
+			snprintf(buf, sizeof(buf), "%s(%s)", ptr, ptr2);
+		} else {
+			snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", ptr, prt);
+		}
+		return buf;
+	}
+	he = gethostbyaddr(((char *) &addr), sizeof(addr), AF_INET6);
+
+	if (he) {
+		strcpyn(tmpbuf, sizeof(tmpbuf), he->h_name);
+		hostadd_v6(a, tmpbuf);
+		ptr = get_username_v6(a, prt, myprt);
+		if (ptr) {
+			snprintf(buf, sizeof(buf), "%s(%s)", tmpbuf, ptr);
+		} else {
+			snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", tmpbuf, prt);
+		}
+		return buf;
+	}
+	inet_ntop(AF_INET6, a, tmpbuf, 128);
+	hostadd_timestamp_v6(a, tmpbuf);
+	ptr = get_username_v6(a, prt, myprt);
+
+	if (ptr) {
+		snprintf(buf, sizeof(buf), "%s(%s)", tmpbuf, ptr);
 	} else {
-	    snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", tmpbuf, prt);
+		snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", tmpbuf, prt);
 	}
 	return buf;
-    }
-    inet_ntop(AF_INET6, a, tmpbuf, 128);
-    hostadd_timestamp_v6(a, tmpbuf);
-    ptr = get_username_v6(a, prt, myprt);
-
-    if (ptr) {
-	snprintf(buf, sizeof(buf), "%s(%s)", tmpbuf, ptr);
-    } else {
-	snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", tmpbuf, prt);
-    }
-    return buf;
 }
 
 static void hostdel(long ip) {
-    for (struct hostcache *ptr = hostcache_list; ptr; ptr = ptr->next) {
-	if (ptr->ipnum == ip) {
-	    if (ptr->next) {
-		ptr->next->prev = ptr->prev;
-	    }
-	    *ptr->prev = ptr->next;
-	    free(ptr);
-	    return;
+	for (struct hostcache *ptr = hostcache_list; ptr; ptr = ptr->next) {
+		if (ptr->ipnum == ip) {
+			if (ptr->next) {
+				ptr->next->prev = ptr->prev;
+			}
+			*ptr->prev = ptr->next;
+			free(ptr);
+			return;
+		}
 	}
-    }
 }
 
 static const char * hostfetch(long ip) {
@@ -390,145 +390,144 @@ void set_signals(void) {
 }
 
 static const char * get_username(in_addr_t a, in_port_t prt, in_port_t myprt) {
-    int fd, result;
-    socklen_t len;
-    char *ptr, *ptr2;
-    static char buf[1024];
-    int lasterr;
-    int timeout = IDENTD_TIMEOUT;
+	int fd, result;
+	socklen_t len;
+	char *ptr, *ptr2;
+	static char buf[1024];
+	int lasterr;
+	int timeout = IDENTD_TIMEOUT;
 
-    struct sockaddr_in addr;
+	struct sockaddr_in addr;
 
-    if ((fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-	perror("resolver ident socket");
-	return (0);
-    }
-
-    make_nonblocking(fd);
-
-    len = sizeof(addr);
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = a;
-    addr.sin_port = htons((short) 113);
-
-    do {
-	result = connect(fd, (struct sockaddr *) &addr, len);
-	lasterr = errno;
-	if (result < 0) {
-	    if (!timeout--)
-		break;
-	    sleep(1);
+	if ((fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+		perror("resolver ident socket");
+		return (0);
 	}
-    } while (result < 0 && lasterr == EINPROGRESS);
-    if (result < 0 && lasterr != EISCONN) {
-	goto bad;
-    }
 
-    snprintf(buf, sizeof(buf), "%" PRIu16 ",%" PRIu16 "\n", prt, myprt);
-    do {
-	result = write(fd, buf, strlen(buf));
-	lasterr = errno;
-	if (result < 0) {
-	    if (!timeout--)
-		break;
-	    sleep(1);
+	make_nonblocking(fd);
+
+	len = sizeof(addr);
+	addr.sin_family = AF_INET;
+	addr.sin_addr.s_addr = a;
+	addr.sin_port = htons((short) 113);
+
+	do {
+		result = connect(fd, (struct sockaddr *) &addr, len);
+		lasterr = errno;
+		if (result < 0) {
+			if (!timeout--)
+				break;
+			sleep(1);
+		}
+	} while (result < 0 && lasterr == EINPROGRESS);
+	if (result < 0 && lasterr != EISCONN) {
+		goto bad;
 	}
-    } while (result < 0 && lasterr == EAGAIN);
-    if (result < 0)
-	goto bad2;
 
-    do {
-	result = read(fd, buf, sizeof(buf));
-	lasterr = errno;
-	if (result < 0) {
-	    if (!timeout--)
-		break;
-	    sleep(1);
-	}
-    } while (result < 0 && lasterr == EAGAIN);
-    if (result < 0)
-	goto bad2;
+	snprintf(buf, sizeof(buf), "%" PRIu16 ",%" PRIu16 "\n", prt, myprt);
+	do {
+		result = write(fd, buf, strlen(buf));
+		lasterr = errno;
+		if (result < 0) {
+			if (!timeout--)
+				break;
+			sleep(1);
+		}
+	} while (result < 0 && lasterr == EAGAIN);
+	if (result < 0)
+		goto bad2;
 
-    ptr = strchr(buf, ':');
-    if (!ptr)
-	goto bad2;
-    ptr++;
-    if (*ptr)
+	do {
+		result = read(fd, buf, sizeof(buf));
+		lasterr = errno;
+		if (result < 0) {
+			if (!timeout--)
+				break;
+			sleep(1);
+		}
+	} while (result < 0 && lasterr == EAGAIN);
+	if (result < 0)
+		goto bad2;
+
+	ptr = strchr(buf, ':');
+	if (!ptr)
+		goto bad2;
 	ptr++;
-    if (strncmp(ptr, "USERID", 6))
-	goto bad2;
+	if (*ptr)
+		ptr++;
+	if (strncmp(ptr, "USERID", 6))
+		goto bad2;
 
-    ptr = strchr(ptr, ':');
-    if (!ptr)
-	goto bad2;
-    ptr = strchr(ptr + 1, ':');
-    if (!ptr)
-	goto bad2;
-    ptr++;
-    /* if (*ptr) ptr++; */
+	ptr = strchr(ptr, ':');
+	if (!ptr)
+		goto bad2;
+	ptr = strchr(ptr + 1, ':');
+	if (!ptr)
+		goto bad2;
+	ptr++;
+	/* if (*ptr) ptr++; */
 
-    shutdown(fd, 2);
-    close(fd);
-    if ((ptr2 = strchr(ptr, '\r')))
-	*ptr2 = '\0';
-    if (!*ptr)
+	shutdown(fd, 2);
+	close(fd);
+	if ((ptr2 = strchr(ptr, '\r')))
+		*ptr2 = '\0';
+	if (!*ptr)
+		return (0);
+	return ptr;
+
+	bad2:
+	shutdown(fd, 2);
+	
+	bad:
+	close(fd);
 	return (0);
-    return ptr;
-
-  bad2:
-    shutdown(fd, 2);
-
-  bad:
-    close(fd);
-    return (0);
 }
 
 /* addrout -- Translate address 'a' to text.  */
 static const char * addrout(in_addr_t a, in_port_t prt, in_port_t myprt) {
-    static char buf[128];
-    char tmpbuf[128];
-    const char *ptr, *ptr2;
-    struct hostent *he;
-    struct in_addr addr;
+	static char buf[128];
+	char tmpbuf[128];
+	const char *ptr, *ptr2;
+	struct hostent *he;
+	struct in_addr addr;
 
-    addr.s_addr = a;
-    ptr = hostfetch(ntohl(a));
+	addr.s_addr = a;
+	ptr = hostfetch(ntohl(a));
 
-    if (ptr) {
-	ptr2 = get_username(a, prt, myprt);
-	if (ptr2) {
-	    snprintf(buf, sizeof(buf), "%s(%s)", ptr, ptr2);
-	} else {
-	    snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", ptr, prt);
-	}
-	return buf;
-    }
-    he = gethostbyaddr(((char *) &addr), sizeof(addr), AF_INET);
-
-    if (he) {
-	strcpyn(tmpbuf, sizeof(tmpbuf), he->h_name);
-	hostadd(ntohl(a), tmpbuf);
-	ptr = get_username(a, prt, myprt);
 	if (ptr) {
-	    snprintf(buf, sizeof(buf), "%s(%s)", tmpbuf, ptr);
+		ptr2 = get_username(a, prt, myprt);
+		if (ptr2) {
+			snprintf(buf, sizeof(buf), "%s(%s)", ptr, ptr2);
+		} else {
+			snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", ptr, prt);
+		}
+		return buf;
+	}
+	he = gethostbyaddr(((char *) &addr), sizeof(addr), AF_INET);
+
+	if (he) {
+		strcpyn(tmpbuf, sizeof(tmpbuf), he->h_name);
+		hostadd(ntohl(a), tmpbuf);
+		ptr = get_username(a, prt, myprt);
+		if (ptr) {
+			snprintf(buf, sizeof(buf), "%s(%s)", tmpbuf, ptr);
+		} else {
+			snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", tmpbuf, prt);
+		}
+		return buf;
+	}
+
+	a = ntohl(a);
+	snprintf(tmpbuf, sizeof(tmpbuf), "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32, (a >> 24) & 0xff, (a >> 16) & 0xff, (a >> 8) & 0xff, a & 0xff);
+	hostadd_timestamp(a, tmpbuf);
+	ptr = get_username(htonl(a), prt, myprt);
+
+	if (ptr) {
+		snprintf(buf, sizeof(buf), "%s(%s)", tmpbuf, ptr);
 	} else {
-	    snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", tmpbuf, prt);
+		snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", tmpbuf, prt);
 	}
 	return buf;
-    }
-
-    a = ntohl(a);
-    snprintf(tmpbuf, sizeof(tmpbuf), "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32,
-	     (a >> 24) & 0xff, (a >> 16) & 0xff, (a >> 8) & 0xff, a & 0xff);
-    hostadd_timestamp(a, tmpbuf);
-    ptr = get_username(htonl(a), prt, myprt);
-
-    if (ptr) {
-	snprintf(buf, sizeof(buf), "%s(%s)", tmpbuf, ptr);
-    } else {
-	snprintf(buf, sizeof(buf), "%s(%" PRIu16 ")", tmpbuf, prt);
-    }
-    return buf;
 }
 
 static volatile short shutdown_was_requested = 0;
@@ -536,145 +535,143 @@ static pthread_mutex_t input_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t output_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static int do_resolve(void) {
-    int ip1, ip2, ip3, ip4;
-    in_port_t prt, myprt;
-    int doagain;
-    char *result;
-    const char *ptr;
-    char buf[1024];
-    char outbuf[1024];
-    char *bufptr = NULL;
-    in_addr_t fullip;
+	int ip1, ip2, ip3, ip4;
+	in_port_t prt, myprt;
+	int doagain;
+	char *result;
+	const char *ptr;
+	char buf[1024];
+	char outbuf[1024];
+	char *bufptr = NULL;
+	in_addr_t fullip;
 
-    struct in6_addr fullip_v6;
+	struct in6_addr fullip_v6;
 
-    for (;;) {
-	ip1 = ip2 = ip3 = ip4 = prt = myprt = -1;
-	do {
-	    doagain = 0;
-	    *buf = '\0';
+	for (;;) {
+		ip1 = ip2 = ip3 = ip4 = prt = myprt = -1;
+		do {
+			doagain = 0;
+			*buf = '\0';
 
-	    /* lock input here. */
-	    if (pthread_mutex_lock(&input_mutex)) {
-		return 0;
-	    }
-	    if (shutdown_was_requested) {
-		/* unlock input here. */
-		pthread_mutex_unlock(&input_mutex);
-		return 0;
-	    }
+			/* lock input here. */
+			if (pthread_mutex_lock(&input_mutex)) {
+				return 0;
+			}
+			if (shutdown_was_requested) {
+				/* unlock input here. */
+				pthread_mutex_unlock(&input_mutex);
+				return 0;
+			}
 
-	    result = fgets(buf, sizeof(buf), stdin);
+			result = fgets(buf, sizeof(buf), stdin);
 
-            /* detect if QUIT was requested before letting
-               another thread start reading */
-	    if (!result) {
-		if (errno == EAGAIN) {
-		    doagain = 1;
-		} else {
-		    if (!feof(stdin)) {
-                        perror("fgets");
-                    }
-		    shutdown_was_requested = 1;
+			/* detect if QUIT was requested before letting another thread start reading */
+			if (!result) {
+				if (errno == EAGAIN) {
+					doagain = 1;
+				} else {
+					if (!feof(stdin)) {
+						perror("fgets");
+					}
+					shutdown_was_requested = 1;
+				}
+			} else if (!strncmp("QUIT", buf, 4)) {
+				shutdown_was_requested = 1;
+				fclose(stdin);
+			}
+
+			/* unlock input here. */
+			pthread_mutex_unlock(&input_mutex);
+
+			if (shutdown_was_requested) {
+				return 0;
+			} else if (doagain) {
+				sleep(1);
+			}
+		} while (doagain || !strcmp(buf, "\n"));
+
+		bufptr = strchr(buf, ':');
+		if (bufptr) {
+			/* Is an IPv6 addr. */
+			bufptr = strchr(buf, '(');
+			if (!bufptr) {
+				continue;
+			}
+			sscanf(bufptr, "(%" SCNu16 ")%" SCNu16, &prt, &myprt);
+			*bufptr = '\0';
+			if (myprt > 65535 || myprt < 0) {
+				continue;
+			}
+			if (inet_pton(AF_INET6, buf, &fullip_v6) <= 0) {
+				continue;
+			}
+			ptr = addrout_v6(&fullip_v6, prt, myprt);
+			snprintf(outbuf, sizeof(outbuf), "%s(%" PRIu16 ")|%s", buf, prt, ptr);
 		}
-	    } else if (!strncmp("QUIT", buf, 4)) {
-                shutdown_was_requested = 1;
-                fclose(stdin);
-            }
 
-	    /* unlock input here. */
-	    pthread_mutex_unlock(&input_mutex);
+		if (!bufptr) {
+			/* Is an IPv4 addr. */
+			sscanf(buf, "%d.%d.%d.%d(%" SCNu16 ")%" SCNu16, &ip1, &ip2, &ip3, &ip4, &prt, &myprt);
+			if (ip1 < 0 || ip2 < 0 || ip3 < 0 || ip4 < 0 || prt < 0) {
+				continue;
+			}
+			if (ip1 > 255 || ip2 > 255 || ip3 > 255 || ip4 > 255 || prt > 65535) {
+				continue;
+			}
+			if (myprt > 65535 || myprt < 0) {
+				continue;
+			}
 
-	    if (shutdown_was_requested) {
-		return 0;
-	    } else if (doagain) {
-                sleep(1);
-            }
-	} while (doagain || !strcmp(buf, "\n"));
+			fullip = (ip1 << 24) | (ip2 << 16) | (ip3 << 8) | ip4;
+			fullip = htonl(fullip);
 
-	bufptr = strchr(buf, ':');
-	if (bufptr) {
-	    /* Is an IPv6 addr. */
-	    bufptr = strchr(buf, '(');
-	    if (!bufptr) {
-		continue;
-	    }
-	    sscanf(bufptr, "(%" SCNu16 ")%" SCNu16, &prt, &myprt);
-	    *bufptr = '\0';
-	    if (myprt > 65535 || myprt < 0) {
-		continue;
-	    }
-	    if (inet_pton(AF_INET6, buf, &fullip_v6) <= 0) {
-		continue;
-	    }
-	    ptr = addrout_v6(&fullip_v6, prt, myprt);
-	    snprintf(outbuf, sizeof(outbuf), "%s(%" PRIu16 ")|%s", buf, prt, ptr);
+			ptr = addrout(fullip, prt, myprt);
+			snprintf(outbuf, sizeof(outbuf), "%d.%d.%d.%d(%" PRIu16 ")|%s", ip1, ip2, ip3, ip4, prt, ptr);
+		}
+
+		/* lock output here. */
+		if (pthread_mutex_lock(&output_mutex)) {
+			return 0;
+		}
+
+		fprintf(stdout, "%s\n", outbuf);
+		fflush(stdout);
+
+		/* unlock output here. */
+		pthread_mutex_unlock(&output_mutex);
 	}
-
-	if (!bufptr) {
-	    /* Is an IPv4 addr. */
-	    sscanf(buf, "%d.%d.%d.%d(%" SCNu16 ")%" SCNu16, &ip1, &ip2, &ip3, &ip4, &prt, &myprt);
-	    if (ip1 < 0 || ip2 < 0 || ip3 < 0 || ip4 < 0 || prt < 0) {
-		continue;
-	    }
-	    if (ip1 > 255 || ip2 > 255 || ip3 > 255 || ip4 > 255 || prt > 65535) {
-		continue;
-	    }
-	    if (myprt > 65535 || myprt < 0) {
-		continue;
-	    }
-
-	    fullip = (ip1 << 24) | (ip2 << 16) | (ip3 << 8) | ip4;
-	    fullip = htonl(fullip);
-
-	    ptr = addrout(fullip, prt, myprt);
-	    snprintf(outbuf, sizeof(outbuf), "%d.%d.%d.%d(%" PRIu16 ")|%s", ip1, ip2, ip3, ip4, prt,
-		     ptr);
-	}
-
-	/* lock output here. */
-	if (pthread_mutex_lock(&output_mutex)) {
-	    return 0;
-	}
-
-	fprintf(stdout, "%s\n", outbuf);
-	fflush(stdout);
-
-	/* unlock output here. */
-	pthread_mutex_unlock(&output_mutex);
-    }
 }
 
 static void * resolver_thread_root(void *threadid) {
-    do_resolve();
-    pthread_exit(NULL);
+	do_resolve();
+	pthread_exit(NULL);
 }
 
 int main(int argc, char **argv) {
-    pthread_t threads[NUM_THREADS];
+	pthread_t threads[NUM_THREADS];
 
-    if (argc > 1) {
-	fprintf(stderr, "Usage: %s\n", *argv);
-	exit(1);
-    }
-
-    /* remember to ignore certain signals */
-    set_signals();
-
-    /* go do it */
-    for (long i = 0; i < NUM_THREADS; i++) {
-	int rc = pthread_create(&threads[i], NULL, resolver_thread_root, (void *) i);
-	if (rc) {
-	    printf("ERROR; return code from pthread_create() is %d\n", rc);
-	    exit(-1);
+	if (argc > 1) {
+		fprintf(stderr, "Usage: %s\n", *argv);
+		exit(1);
 	}
-    }
-    for (long i = 0; i < NUM_THREADS; i++) {
-	void *retval;
-	pthread_join(threads[i], &retval);
-    }
 
-    fprintf(stderr, "Resolver exited.\n");
+	/* remember to ignore certain signals */
+	set_signals();
 
-    exit(0);
+	/* go do it */
+	for (long i = 0; i < NUM_THREADS; i++) {
+		int rc = pthread_create(&threads[i], NULL, resolver_thread_root, (void *) i);
+		if (rc) {
+			printf("ERROR; return code from pthread_create() is %d\n", rc);
+			exit(-1);
+		}
+	}
+	for (long i = 0; i < NUM_THREADS; i++) {
+		void *retval;
+		pthread_join(threads[i], &retval);
+	}
+
+	fprintf(stderr, "Resolver exited.\n");
+
+	exit(0);
 }

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -186,7 +186,7 @@ static const char * get_username_v6(struct in6_addr *a, in_port_t prt, in_port_t
 	len = sizeof(addr);
 	addr.sin6_family = AF_INET6;
 	memcpy(&addr.sin6_addr.s6_addr, a, sizeof(struct in6_addr));
-	addr.sin6_port = htons((short) 113);
+	addr.sin6_port = htons(113);
 
 	do {
 		result = connect(fd, (struct sockaddr *) &addr, len);
@@ -409,7 +409,7 @@ static const char * get_username(in_addr_t a, in_port_t prt, in_port_t myprt) {
 	len = sizeof(addr);
 	addr.sin_family = AF_INET;
 	addr.sin_addr.s_addr = a;
-	addr.sin_port = htons((short) 113);
+	addr.sin_port = htons(113);
 
 	do {
 		result = connect(fd, (struct sockaddr *) &addr, len);

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -389,7 +389,7 @@ void set_signals(void) {
     signal(SIGHUP, SIG_IGN);
 }
 
-static const char * get_username(long a, in_port_t prt, in_port_t myprt) {
+static const char * get_username(in_addr_t a, in_port_t prt, in_port_t myprt) {
     int fd, result;
     socklen_t len;
     char *ptr, *ptr2;
@@ -518,7 +518,7 @@ static const char * addrout(in_addr_t a, in_port_t prt, in_port_t myprt) {
     }
 
     a = ntohl(a);
-    snprintf(tmpbuf, sizeof(tmpbuf), "%ld.%ld.%ld.%ld",
+    snprintf(tmpbuf, sizeof(tmpbuf), "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32,
 	     (a >> 24) & 0xff, (a >> 16) & 0xff, (a >> 8) & 0xff, a & 0xff);
     hostadd_timestamp(a, tmpbuf);
     ptr = get_username(htonl(a), prt, myprt);


### PR DESCRIPTION
There are types meant for addresses and ports.  The IPv6 code was typically more correct than the IPv4 code, fixed both though.
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/inttypes.h.html

I also did some style fixes.  Not to the entire files, but to the portions I already touched.

I then removed an incorrect cast.