### PR TITLE
Fix exit code for fb-resolver

### DIFF
--- a/src/resolver.c
+++ b/src/resolver.c
@@ -663,7 +663,7 @@ int main(int argc, char **argv) {
 		int rc = pthread_create(&threads[i], NULL, resolver_thread_root, (void *) i);
 		if (rc) {
 			printf("ERROR; return code from pthread_create() is %d\n", rc);
-			exit(-1);
+			exit(2);
 		}
 	}
 	for (long i = 0; i < NUM_THREADS; i++) {


### PR DESCRIPTION
When fb-resolver tries to return -1 to the shell, my shell interprets/receives it as 255.  We can't expect any particular number in a portable way, though, when returning a negative number to the shell.
I change it to 2, which the shell receives as 2.  I did this because exit(1) is already used in main(), and I wanted to keep the exit numbers for these two situations different for now, as they were already different.

I've also checked prochelp (prochelp.c) and fbmuck (interface.c) and didn't spot any cases where they might attempt to return a negative number to the shell.  (though the win32 restart program does, but I'm not touching it)
I've also already checked for this in all our shell scripts, in the past.