### PR TITLE
Fix for the dreaded #306 segfault

### DIFF
--- a/src/timequeue.c
+++ b/src/timequeue.c
@@ -952,7 +952,7 @@ int
 dequeue_prog_real(dbref program, int killmode, const char *file, const int line)
 {
     int count = 0;
-    timequeue ptr, prev
+    timequeue ptr, prev;
 
 #ifdef DEBUG
     fprintf(stderr, "[debug] dequeue_prog(#%d, %d) called from %s:%d\n", program, killmode,


### PR DESCRIPTION
@wyld-sw I know you're a merge-happy crazy-guy :)  so please read this first.

While I am .... 95% confident I've fixed this (I would be 100% if I understood the code a bit better), I may have introduced a (rare) memory leak.  I marked it with a big TODO ... There's a difference between dequeue_prog_real and dequeue_process (which underpins @ kill) that I don't really understand and I'd like your opinion on.

If you're just as clueless as me, I think we may need to do "something" to verify there's no leak.  Probably the easiest way to do this is to connect a bot to a test MUCK and have it enter @ edit on a event_wait MUF and just hit 'c' endlessly to see if the memory increases.

As I re-read this block, I'm thinking it may be something that won't be possible if we delete event queue before deleting processes, and this little if ocount < count business might just be a relic of bad logic.  It seems like something that should never happen to me, so maybe I'm stressing too much.  I just wish I understood a little better how this works, but I haven't gotten to mufevents or timequeue in the doc project yet :)

Anyway, it is probably okay to merge regardless, because a possible (extremely rare) memory leak is WAY better than a definite (extremely rare) segfault :)  And I'm about to do more MCP on Hope so having this fix will make my life better.