### PR TITLE
Fixed crasher bug introduced by 3b228ce

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -2103,7 +2103,7 @@ array_insertrange(stk_array ** harr, array_iter * start, stk_array * inarr)
             }
 
             /* Copy inarr into the space made. */
-            
+            idx.data.number = 0;
             do {
                     itm = array_getitem(inarr, &idx);
                     copyinst(itm, &arr->data.packed[start->data.number]);


### PR DESCRIPTION
It seems that 3b228ce introduced a crasher bug when the `array_insertrange` function was cleaned up. The `TODO` lines that said that something was impossible, didn't take into account the side effect that `array_first(inarr, &idx)` had on the `idx`. Coincidentally, it also reset the `idx.data.number` back to 0 as part of the call, resetting the loop for the next step of copying in `inarr`. 

This likely wouldn't have been a huge deal in some cases, but in the case that produced the crash, it happened when `run peak` is executed, where `peak` is an alias to `nexus,w,w`. The muf program eventually ends up with a call stack of `#0 'peak' 'nexus' [] 0 ['w', 'w']`. This ends up calling `array_insertrange([], 0, ['w', 'w'])`. The loop that copies over the first array is skipped because idx.data.number is set to `arr.items - 1`, where `arr = []` (and because it's empty). So, it gets `-1` which skips the loop. But the subsequent call to `array_getitem(inarr, &idx)` when `idx.data.number=-1`, causes it to return null, and `copyinst` crashes the muck when it tries to `*to = *from` when `*from` is 0.

This patch fixes it by resetting the index counter to 0, which is likely what is desired here, since you want to copy all of `inarr` from 0 to the end into `arr`. It also replicates the behavior of the previous call without the overhead of the call.