### PR TITLE
Change default thing object value to 0

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -658,7 +658,7 @@ do_clone(int descr, dbref player, const char *name, const char *rname)
     /* copy all properties */
     copy_props(player, thing, clonedthing, "");
 
-    SETVALUE(clonedthing, MIN(GETVALUE(thing), tp_max_object_endowment));
+    SETVALUE(clonedthing, MAX(0,MIN(GETVALUE(thing), tp_max_object_endowment)));
 
     /* FIXME: should we clone attached actions? */
     EXITS(clonedthing) = NOTHING;
@@ -730,7 +730,7 @@ do_create(dbref player, char *name, char *acost)
     }
 
     thing = create_thing(player, name, player); 
-    SETVALUE(thing, MIN(OBJECT_ENDOWMENT(cost), tp_max_object_endowment));
+    SETVALUE(thing, MAX(0,MIN(OBJECT_ENDOWMENT(cost), tp_max_object_endowment)));
 
     unparse_object(player, thing, unparse_buf, sizeof(unparse_buf));
     notifyf(player, "Object %s created.", unparse_buf);

--- a/src/create.c
+++ b/src/create.c
@@ -198,7 +198,8 @@ do_link(int descr, dbref player, const char *thing_name, const char *dest_name)
 
             if (ndest == 0) {
                 notify(player, "No destinations linked.");
-                SETVALUE(player, GETVALUE(player) + tp_link_cost);
+                if(!Wizard(OWNER(thing)))
+                    SETVALUE(player, GETVALUE(player) + tp_link_cost);
                 DBDIRTY(player);
                 break;
             }

--- a/src/db.c
+++ b/src/db.c
@@ -325,7 +325,7 @@ create_thing(dbref player, const char *name, dbref location)
     PUSH(newthing, CONTENTS(location));
 
     EXITS(newthing) = NOTHING;
-    SETVALUE(newthing, 1);
+    SETVALUE(newthing, 0);
 
     ALLOC_THING_SP(newthing);
 

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -98,8 +98,8 @@ prim_addpennies(PRIM_PROTOTYPE)
 	if (mlev < 4)
 	    abort_interp("Permission denied.");
 	result = GETVALUE(ref) + oper1->data.number;
-	if (result < 1)
-	    abort_interp("Result must be positive.");
+	if (result < 0)
+	    abort_interp("Result must not be negative.");
 	SETVALUE(ref, (GETVALUE(ref) + oper1->data.number));
 	DBDIRTY(ref);
     } else {


### PR DESCRIPTION
This is my first pull request ever so I'm hoping I'm doing it right.

In addition to setting the default thing value to 0 instead of 1 as discussed in issue #459, there was a bug where if you are an unquelled wizard and you do: @link action= without specifying any destinations, it will increase your pennies.

Also I added a safety check to @create and @clone that prevents it from creating an object with a negative value.