### PR TITLE
Fixed check for valid property name when registering objects

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -2152,6 +2152,11 @@ register_object(dbref player, dbref location, const char *propdir, char *name,
     char unparse_buf[BUFFER_LEN], unparse_buf2[BUFFER_LEN];
     char *strval;
 
+    if (!is_valid_propname(name)) {
+        notifyf_nolisten(player, "Registry name '%s' is not valid", name);
+        return;
+    }
+
     snprintf(buf, sizeof(buf), "%s/%s", propdir, name);
 
     if ((p = get_property(location, buf))) {


### PR DESCRIPTION
Fixes this:

```
> @create test=0=a::b
Object test(#190) created.
Now registered as _reg/a::b: test(#190) on Mercury(#164PWQBC)
> ex me=_reg/
- ref /_reg/a:test(#190)
1 property listed.
```