### PR TITLE
Pennies related fixes to @chown and @link when dealing with unlinked exits

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -175,21 +175,21 @@ do_link(int descr, dbref player, const char *thing_name, const char *dest_name)
                     return;
                 }
             } else {
+                if (!Builder(player)) {
+                    notify(player, "Only authorized builders may seize exits.");
+                    return;
+                }
                 if (!payfor(player, tp_link_cost + tp_exit_cost)) {
                     notifyf(player, "It costs %d %s to link this exit.",
                             (tp_link_cost + tp_exit_cost),
                             (tp_link_cost + tp_exit_cost == 1) ? tp_penny : tp_pennies);
                     return;
-                } else if (!Builder(player)) {
-                    notify(player, "Only authorized builders may seize exits.");
-                    return;
-                } else {
-                    /* pay the owner for his loss */
-                    dbref owner = OWNER(thing);
-
-                    SETVALUE(owner, GETVALUE(owner) + tp_exit_cost);
-                    DBDIRTY(owner);
                 }
+                /* pay the owner for his loss */
+                dbref owner = OWNER(thing);
+
+                SETVALUE(owner, GETVALUE(owner) + tp_exit_cost);
+                DBDIRTY(owner);
             }
 
             /* link has been validated and paid for; do it */

--- a/src/set.c
+++ b/src/set.c
@@ -441,6 +441,23 @@ do_chown(int descr, dbref player, const char *name, const char *newowner)
         }
     }
 
+    /* handle costs */
+    if (owner == player && Typeof(thing) == TYPE_EXIT && OWNER(thing) != OWNER(player)) {
+	if (!Builder(player)) {
+	    notify(player, "Only authorized builders may seize exits.");
+	    return;
+	}
+	if (!payfor(player, tp_link_cost + tp_exit_cost)) {
+	    notifyf(player, "It costs %d %s to seize this exit.",
+		    tp_exit_cost,
+		    (tp_exit_cost == 1) ? tp_penny : tp_pennies);
+	    return;
+	}
+	/* pay the owner for his loss */
+	SETVALUE(OWNER(thing), GETVALUE(OWNER(thing)) + tp_exit_cost);
+	DBDIRTY(OWNER(thing));
+    }
+
     if (tp_realms_control && !Wizard(OWNER(player)) && TrueWizard(thing) &&
         Typeof(thing) == TYPE_ROOM) {
         notify(player, "You can't take possession of that.");


### PR DESCRIPTION
Fixes two things:
- `@link unclaimedexit=room` when you don't have a BUILDER does not work, but it was charging you the pennies /before/ rejecting the attempt. I reversed this, checking first before charging.

- You have to pay tp_exit_cost pennies when you do `@link unclaimedexit=room`, but you could cheat and get around this by doing `@chown` unclaimed exit. I copied the logic for charging you pennies from `@link` into `@chown`.

IMHO though, I think that long term, the entire 'anybody can seize an unclaimed exit' thing should be eliminated from fbmuck entirely.
- I can't imagine any MUCK out there using this functionality. (Correct me if I'm wrong?)
- It can easily be replaced in a more robust and intuitive way by creating a MUF program to claim/create exits.
- It's a security risk, in case you accidentally leave an unclaimed exit in `#0`, for example. It could be claimed, renamed to 'say' and then given an MPI program to beam all your communication off to a malicious party, or otherwise wreak havoc.