### PR TITLE
SETLINKS_ARRAY can now link to NIL

### DIFF
--- a/src/p_db.c
+++ b/src/p_db.c
@@ -2410,7 +2410,7 @@ prim_setlinks_array(PRIM_PROTOTYPE)
 	    array_data *val = array_getitem(arr, &idx);
 	    dbref where = val->data.objref;
 
-	    if ((where != HOME) && !valid_object(val)) {
+	    if ((where != HOME) && (where != NIL) && !valid_object(val)) {
 		CLEAR(&idx);
 		abort_interp("Invalid object. (2)");
 	    }
@@ -2422,6 +2422,9 @@ prim_setlinks_array(PRIM_PROTOTYPE)
 
 	    switch (Typeof(what)) {
 	    case TYPE_EXIT:
+                if (where == NIL)
+                    break;
+
 		switch (Typeof(where)) {
 		case TYPE_PLAYER:
 		case TYPE_ROOM:


### PR DESCRIPTION
SETLINKS was able to link to NIL, but not SETLINKS_ARRAY. Fixed.

<hr>

\<rant\>
This looks like a bug caused by large blocks of nearly-identical code being in multiple places in the source, and when a modification happens, forgetting to replicate the same change to other bits of the code.

It actually seems pretty common for big chunks of code with very similar logic to be just copied with small modifications all over the source. Might be worth going through and fixing that up.

One nuclear option to fix a big class of this code duplication problem (which I would actually be in favor of) would be to eliminate the built-in commands entirely and replace them all with MUF programs (with the exception of `@program` and probably some limited emergency commands in case you mess up `@action` or `@link`)

As a bonus the code would get a lot leaner, and wizards will have full freedom to change pretty much every command name or add whatever colors they want, etc, and if they wanted to nuke or permission-restrict or tighten a command due to some special security consideration specific to their MUCK (Like if they don't want you setting your own HOME for example), they'd have full freedom to do that.

I'd be happy to write MUF versions of built-in commands if you need a volunteer.

It might be something to save for fb8, though?

Edit: Maybe this suggestion is too ambitious...
\</rant\>