### PR TITLE
COPYOBJ was setting the penny value of _both_ thing objects to 1

### DIFF
--- a/src/p_db.c
+++ b/src/p_db.c
@@ -572,6 +572,8 @@ prim_copyobj(PRIM_PROTOTYPE)
 	newobj = new_object();
 	*DBFETCH(newobj) = *DBFETCH(ref);
 	copyobj(player, ref, newobj);
+        if (mlev < 3)
+          SETVALUE(newobj, 0);
 	CLEAR(oper1);
 	PushObject(newobj);
     }

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -41,7 +41,7 @@ copyobj(dbref player, dbref old, dbref nu)
     NAME(nu) = alloc_string(NAME(old));
     if (Typeof(old) == TYPE_THING) {
 	ALLOC_THING_SP(nu);
-	THING_SET_HOME(nu, player);
+	THING_SET_HOME(nu, THING_HOME(old));
     }
     newp->properties = copy_prop(old);
     newp->exits = NOTHING;

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -42,7 +42,6 @@ copyobj(dbref player, dbref old, dbref nu)
     if (Typeof(old) == TYPE_THING) {
 	ALLOC_THING_SP(nu);
 	THING_SET_HOME(nu, player);
-	SETVALUE(nu, 1);
     }
     newp->properties = copy_prop(old);
     newp->exits = NOTHING;


### PR DESCRIPTION
The COPYOBJ primitive duplicates the contents of the database object, but leaving a pointer to the previous properties tree in tact. Then it calls copy_prop which (I believe) makes a new property tree structure for the object and copies the previous one.

However, in the meantime, while the pointer for the property tree for both objects is still set to the original object, it does `SETVALUE(nu, 1)` which acts on the shared pointer (because the object's penny value is inside the property tree... I'm guessing it wasn't always this way) and sets the value of both objects to 1.

I don't know if I've addressed this correctly, though. Before merging this change... should I still be setting the object's penny value?

This pull request as written will copy the penny value exactly. Whatever the source object had the destination object will have. Theoretically, this could be part of the same class of problems I discussed in #459, though. Somebody with a low MUCKER level could use it combined with the RECYCLE primitive to generate pennies.

Maybe I should have it do a SETVALUE(nu, 0) after the copy_prop line? Or maybe this primitive should be changed to require a higher MUCKER level? Let me know if you want me to revise it.

Edit: Also the COPYOBJ primitive behavior is not in line with the `@clone` command. COPYOBJ will set the home to the player, `@clone` will leave the home alone. Maybe I should modify the THING_SET_HOME(nu, player); line as well, so it copies instead?