### PR TITLE
'NIL' probably should not be a valid object name

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -1611,6 +1611,7 @@ ok_object_name(const char *name, object_flag_type type)
         || !strcasecmp(name, "me")
         || !strcasecmp(name, "here")
         || !strcasecmp(name, "home")
+        || !strcasecmp(name, "nil")
         || (*tp_reserved_names && equalstr((char *) tp_reserved_names, (char *)name)
         ))
         return false;


### PR DESCRIPTION
Since fbmuck prevents 'me' 'here' and 'home' as object names because they are special matches, 'nil' should probably be added here as well.