### PR TITLE
Fixed YIELD not working when set on current room

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -819,7 +819,11 @@ match_all_exits(struct match_data *md)
     strcpyn(match_cmdname, sizeof(match_cmdname), "\0");
 
     if ((loc = LOCATION(md->match_from)) != NOTHING)
+    {
+        if (FLAGS(loc) & YIELD)
+            blocking = 1;
         match_room_exits(loc, md);
+    }
 
     if (md->exact_match != NOTHING)
         md->block_equals = 1;


### PR DESCRIPTION
YIELD was working for child rooms, but not working if you were standing directly inside the room with the flag set.