### PR TITLE
A @tune to prevent built-in commands (Except for wizards with !override)

### DIFF
--- a/docs/man.txt
+++ b/docs/man.txt
@@ -4442,6 +4442,7 @@ Parameters available:
  (str)  autolook_cmd              - Room entry look command
  (time) clean_interval            - Interval between memory/object cleanups
  (int)  cmd_log_threshold_msec    - Log commands that take longer than X millisecs
+ (bool) cmd_only_overrides        - Disable all built-in commands except wizard !overrides
  (int)  command_burst_size        - Max. commands per burst before limiter engages
  (int)  command_time_msec         - Millisecs per spam limiter time period
  (int)  commands_per_time         - Commands allowed per time period during limit

--- a/docs/mufman.html
+++ b/docs/mufman.html
@@ -7139,6 +7139,7 @@ Parameters available:
  (str)  autolook_cmd              - Room entry look command
  (time) clean_interval            - Interval between memory/object cleanups
  (int)  cmd_log_threshold_msec    - Log commands that take longer than X millisecs
+ (bool) cmd_only_overrides        - Disable all built-in commands except wizard !overrides
  (int)  command_burst_size        - Max. commands per burst before limiter engages
  (int)  command_time_msec         - Millisecs per spam limiter time period
  (int)  commands_per_time         - Commands allowed per time period during limit

--- a/include/tune.h
+++ b/include/tune.h
@@ -85,6 +85,7 @@ extern bool        tp_autolink_actions;
 extern const char *tp_autolook_cmd;
 extern int         tp_clean_interval;
 extern int         tp_cmd_log_threshold_msec;
+extern bool        tp_cmd_only_overrides;
 extern int         tp_command_burst_size;
 extern int         tp_command_time_msec;
 extern int         tp_commands_per_time;

--- a/include/tunelist.h
+++ b/include/tunelist.h
@@ -27,6 +27,7 @@ bool        tp_autolink_actions;
 const char *tp_autolook_cmd;
 int         tp_clean_interval;
 int         tp_cmd_log_threshold_msec;
+bool        tp_cmd_only_overrides;
 int         tp_command_burst_size;
 int         tp_command_time_msec;
 int         tp_commands_per_time;
@@ -208,6 +209,9 @@ struct tune_entry tune_list[] = {
     { "cmd_log_threshold_msec", "Log commands that take longer than X millisecs", "Logging", "", TP_TYPE_INTEGER,
         .defaultval.n=1000,
         .currentval.n=&tp_cmd_log_threshold_msec, 0, MLEV_WIZARD, true },
+    { "cmd_only_overrides", "Disable all built-in commands except wizard !overrides", "Commands", "", TP_TYPE_BOOLEAN,
+        .defaultval.b=false,
+        .currentval.b=&tp_cmd_only_overrides, 0, MLEV_WIZARD, true },
     { "command_burst_size", "Max. commands per burst before limiter engages", "Spam Limits", "", TP_TYPE_INTEGER,
         .defaultval.n=500,
         .currentval.n=&tp_command_burst_size, 0, MLEV_WIZARD, true },

--- a/src/game.c
+++ b/src/game.c
@@ -639,6 +639,8 @@ process_command(int descr, dbref player, const char *command)
 
         if (TrueWizard(OWNER(player)) && (*command == OVERRIDE_TOKEN))
             command++;
+        else if (tp_cmd_only_overrides)
+            goto bad;
 
         full_command = strcpyn(xbuf, sizeof(xbuf), command);
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -1886,7 +1886,8 @@ do_command(struct descriptor_data *d, char *command)
         return 0;
     } else if (tp_recognize_null_command && !strcasecmp(command, NULL_COMMAND)) {
         return 1;
-    } else if ((!strncmp(command, WHO_COMMAND, sizeof(WHO_COMMAND) - 1)) ||
+    } else if ((!tp_cmd_only_overrides &&
+               (!strncmp(command, WHO_COMMAND, sizeof(WHO_COMMAND) - 1))) ||
                (*command == OVERRIDE_TOKEN &&
                (!strncmp(command + 1, WHO_COMMAND, sizeof(WHO_COMMAND) - 1))
               )) {


### PR DESCRIPTION
I'd like to add this tune because I want to use it on my own MUCK for security and cosmetic reasons, and because it seems like a good intermediate step toward some day removing built-in commands entirely.

I've also created a repository (https://github.com/dbenoy/mercury-muf) where I'm working on MUF replacements for built-in commands, among other things. I've created copies of the logic for the object creation commands and followed the engine source fairly closely.

For various reasons the commands won't have precicely the same message output, but they try to follow the behavior of the built in commands in a quirk-for-quirk way.

It also adds a few features like object quotas, but I intend, once these programs are fairly well tested in the wild, to create a separate repository with vanilla copies of the built-in commands with no enhancements.