### PR TITLE
Mcp crash fix

### DIFF
--- a/include/mcp.h
+++ b/include/mcp.h
@@ -388,6 +388,28 @@ void mcp_package_register(const char *pkgname, McpVer minver, McpVer maxver,
                           ContextCleanup_CB cleanup);
 
 /**
+ * Send some text to a given MCP Frame
+ *
+ * The send is not immediate, it is queued to the descriptor with queue_write
+ *
+ * @see queue_write
+ * 
+ * @param mfr the frame we're transmitting to
+ * @param text the message to send
+ */
+void mcp_send_text(McpFrame *mfr, const char *text);
+
+
+/**
+ * Flushes the output queue associated with the frame mfr
+ *
+ * @param mfr the frame who's output queue we are flushing
+ */
+void mcp_flush_text(McpFrame *mfr);
+
+
+
+/**
  * Compares two McpVer structs.
  *
  * Results are similar to strcmp():

--- a/src/mcp.c
+++ b/src/mcp.c
@@ -393,6 +393,11 @@ mcp_intern_is_mesg_start(McpFrame *mfr, const char *in)
         /* It's incomplete.  Remember it to finish later. */
         const char *msgdt = mcp_mesg_arg_getline(newmsg, MCP_DATATAG, 0);
 
+        /* Avoid attack vector */
+        if (!msgdt) {
+            msgdt = "";
+        }
+
         newmsg->datatag = strdup(msgdt);
         mcp_mesg_arg_remove(newmsg, MCP_DATATAG);
         newmsg->next = mfr->messages;

--- a/src/mcp.c
+++ b/src/mcp.c
@@ -588,12 +588,11 @@ clean_mcpbinds(struct mcp_binding *mypub)
  *
  * @see queue_write
  *
- * @private
  * @param mfr the frame we're transmitting to
  * @param text the message to send
  */
-static void
-SendText(McpFrame *mfr, const char *text)
+void
+mcp_send_text(McpFrame *mfr, const char *text)
 {
     queue_write((struct descriptor_data *) mfr->descriptor, text, strlen(text));
 }
@@ -601,11 +600,10 @@ SendText(McpFrame *mfr, const char *text)
 /**
  * Flushes the output queue associated with the frame mfr
  *
- * @private
  * @param mfr the frame who's output queue we are flushing
  */
-static void
-FlushText(McpFrame *mfr)
+void
+mcp_flush_text(McpFrame *mfr)
 {
     struct descriptor_data *d = (struct descriptor_data *) mfr->descriptor;
 
@@ -1428,10 +1426,10 @@ mcp_frame_output_inband(McpFrame *mfr, const char *lineout)
     if (!mfr->enabled ||
         (strncmp(lineout, MCP_MESG_PREFIX, 3)
          && strncmp(lineout, MCP_QUOTE_PREFIX, 3))) {
-        SendText(mfr, lineout);
+        mcp_send_text(mfr, lineout);
     } else {
-        SendText(mfr, MCP_QUOTE_PREFIX);
-        SendText(mfr, lineout);
+        mcp_send_text(mfr, MCP_QUOTE_PREFIX);
+        mcp_send_text(mfr, lineout);
     }
 }
 
@@ -1569,8 +1567,8 @@ mcp_frame_output_mesg(McpFrame *mfr, McpMesg *msg)
     }
 
     /* Send the initial line. */
-    SendText(mfr, outbuf);
-    SendText(mfr, "\r\n");
+    mcp_send_text(mfr, outbuf);
+    mcp_send_text(mfr, "\r\n");
 
     if (mlineflag) {
         /*
@@ -1586,11 +1584,11 @@ mcp_frame_output_mesg(McpFrame *mfr, McpMesg *msg)
                     snprintf(outbuf, sizeof(outbuf), "%s* %s %s: %s",
                              MCP_MESG_PREFIX, datatag,
                              anarg->name, ap->value);
-                    SendText(mfr, outbuf);
-                    SendText(mfr, "\r\n");
+                    mcp_send_text(mfr, outbuf);
+                    mcp_send_text(mfr, "\r\n");
 
                     if (!--flushcount) {
-                        FlushText(mfr);
+                        mcp_flush_text(mfr);
                         flushcount = 8;
                     }
 
@@ -1601,8 +1599,8 @@ mcp_frame_output_mesg(McpFrame *mfr, McpMesg *msg)
 
         /* Let the other side know we're done sending multi-line arg vals. */
         snprintf(outbuf, sizeof(outbuf), "%s: %s", MCP_MESG_PREFIX, datatag);
-        SendText(mfr, outbuf);
-        SendText(mfr, "\r\n");
+        mcp_send_text(mfr, outbuf);
+        mcp_send_text(mfr, "\r\n");
     }
 
     return EMCP_SUCCESS;

--- a/src/mcppkgs.c
+++ b/src/mcppkgs.c
@@ -99,6 +99,15 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
         player = MCPFRAME_PLAYER(mfr);
         descr = MCPFRAME_DESCR(mfr);
 
+        /* Check for nulls to avoid attack vector */
+        if (!reference) {
+            reference = "";
+        }
+
+        if (!valtype) {
+            valtype = "";
+        }
+
         /* extract object number.  -1 for none.  */
         if (isdigit(*reference)) {
             obj = 0;
@@ -181,6 +190,11 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
                 for (int line = 0; line < lines; line++) {
                     content = mcp_mesg_arg_getline(msg, "content", line);
 
+                    /* Avoid attack vector */
+                    if (!content) {
+                        content = "";
+                    }
+
                     if (line > 0) {
                         if (left >= 1) {
                             strcatn(buf, sizeof(buf), "\r");
@@ -210,6 +224,12 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
                 }
 
                 content = mcp_mesg_arg_getline(msg, "content", 0);
+
+                /* Avoid attack vector */
+                if (!content) {
+                    content = "";
+                }
+
                 add_property(obj, reference, NULL, atoi(content));
             }
         } else if (!strcasecmp(category, "proplist")) {
@@ -346,6 +366,12 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
             }
 
             content = mcp_mesg_arg_getline(msg, "content", 0);
+
+            /* Avoid attack vector */
+            if (!content) {
+                content = " ";
+            }
+
             tune_setparm(player, reference, content, TUNE_MLEV(player));
         } else if (!strcasecmp(category, "user")) {
             /*
@@ -426,6 +452,15 @@ mcppkg_help_request(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
 
         onwhat = mcp_mesg_arg_getline(msg, "topic", 0);
         valtype = mcp_mesg_arg_getline(msg, "type", 0);
+
+        /* Avoid attack vector */
+        if (!onwhat) {
+            onwhat = "";
+        }
+
+        if (!valtype) {
+            valtype = "";
+        }
 
         *topic = '\0';
         strcpyn(topic, sizeof(topic), onwhat);

--- a/src/mcppkgs.c
+++ b/src/mcppkgs.c
@@ -46,7 +46,15 @@ show_mcp_error(McpFrame * mfr, char *topic, char *text)
         mcp_frame_output_mesg(mfr, &msg);
         mcp_mesg_clear(&msg);
     } else {
-        notify(MCPFRAME_PLAYER(mfr), text);
+        /*
+         * This used to be a notify which would cause segfaults when the
+         * error happens on the login screen.  I don't think changing
+         * this to SendText (which is what notify uses under the hood, and
+         * how MCP authenticate works) will hurt anything.
+         */
+        mcp_send_text(mfr, text);
+        mcp_send_text(mfr, "\r\n");
+        mcp_flush_text(mfr);
     }
 }
 
@@ -402,7 +410,7 @@ mcppkg_languages(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
     McpVer supp = mcp_frame_package_supported(mfr, "org-fuzzball-languages");
 
     if (supp.verminor == 0 && supp.vermajor == 0) {
-        notify(MCPFRAME_PLAYER(mfr), "MCP: org-fuzzball-languages not supported.");
+        mcp_send_text(mfr, "MCP: org-fuzzball-languages not supported.");
         return;
     }
 
@@ -442,7 +450,7 @@ mcppkg_help_request(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
     McpMesg omsg;
 
     if (supp.verminor == 0 && supp.vermajor == 0) {
-        notify(MCPFRAME_PLAYER(mfr), "MCP: org-fuzzball-help not supported.");
+        mcp_send_text(mfr, "MCP: org-fuzzball-help not supported.");
         return;
     }
 


### PR DESCRIPTION
@revarbat  seems to be finding a lot more of these bugs than I am -- there are some calling patterns like this:

```
lines = mcp_mesg_arg_linecount(msg, "data");

for (int i = 0; i < lines; i++) {
    /* Any mcp_mesg_arg_getline for "data" in this loop should be safe, right? */
}
```

So Revar may be adding checks in there which I am not sure are necessary.  However, I would appreciate additional sets of eyes on this.

Fix for: https://github.com/fuzzball-muck/fuzzball/issues/510