### PR TITLE
Corrected some places where segfaults can occur if MCP is called via the login screen instead of being logged in.

### DIFF
--- a/src/mcppkgs.c
+++ b/src/mcppkgs.c
@@ -182,7 +182,7 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
             }
 
             if (Prop_System(reference)
-                || !OkRef(player)
+                || !ObjExists(player)
                 || (!Wizard(player) && (Prop_SeeOnly(reference)
                 || Prop_Hidden(reference)))) {
                 show_mcp_error(mfr, "simpleedit-set", "Permission denied.");
@@ -261,7 +261,7 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
             }
 
             if (Prop_System(reference)
-                || !OkRef(player)
+                || !ObjExists(player)
                 || (!Wizard(player) && (Prop_SeeOnly(reference)
                 || Prop_Hidden(reference)))) {
                 show_mcp_error(mfr, "simpleedit-set", "Permission denied.");
@@ -311,7 +311,7 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
                 return;
             }
 
-            if (!OkRef(player) || !Mucker(player)) {
+            if (!ObjExists(player) || !Mucker(player)) {
                 show_mcp_error(mfr, "simpleedit-set", "Permission denied.");
                 return;
             }
@@ -366,7 +366,7 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
             DBDIRTY(obj);
         } else if (!strcasecmp(category, "sysparm")) {
             /* Edit tune parameters */
-            if (!OkRef(player) || !Wizard(player)) {
+            if (!ObjExists(player) || !Wizard(player)) {
                 show_mcp_error(mfr, "simpleedit-set", "Permission denied.");
                 return;
             }

--- a/src/mcppkgs.c
+++ b/src/mcppkgs.c
@@ -182,6 +182,7 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
             }
 
             if (Prop_System(reference)
+                || !OkRef(player)
                 || (!Wizard(player) && (Prop_SeeOnly(reference)
                 || Prop_Hidden(reference)))) {
                 show_mcp_error(mfr, "simpleedit-set", "Permission denied.");
@@ -260,6 +261,7 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
             }
 
             if (Prop_System(reference)
+                || !OkRef(player)
                 || (!Wizard(player) && (Prop_SeeOnly(reference)
                 || Prop_Hidden(reference)))) {
                 show_mcp_error(mfr, "simpleedit-set", "Permission denied.");
@@ -309,7 +311,7 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
                 return;
             }
 
-            if (!Mucker(player)) {
+            if (!OkRef(player) || !Mucker(player)) {
                 show_mcp_error(mfr, "simpleedit-set", "Permission denied.");
                 return;
             }
@@ -345,6 +347,7 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
                 curr = new_line;
             }
 
+            /* Player ref should be fine by now */
             unparse_object(player, obj, unparse_buf, sizeof(unparse_buf));
             log_status("PROGRAM SAVED: %s by %s(%d)",
                        unparse_buf, NAME(player), player);
@@ -363,7 +366,7 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
             DBDIRTY(obj);
         } else if (!strcasecmp(category, "sysparm")) {
             /* Edit tune parameters */
-            if (!Wizard(player)) {
+            if (!OkRef(player) || !Wizard(player)) {
                 show_mcp_error(mfr, "simpleedit-set", "Permission denied.");
                 return;
             }

--- a/src/p_mcp.c
+++ b/src/p_mcp.c
@@ -120,6 +120,15 @@ muf_mcp_callback(McpFrame * mfr, McpMesg * mesg, McpVer version, void *context)
     descr = MCPFRAME_DESCR(mfr);
     user = MCPFRAME_PLAYER(mfr);
 
+    if (!OkRef(user)) {
+        /*
+         * I'm not sure if this is possible, but unchecked players have
+         * caused segfaults in the MCP system so we'll be safe.
+         */
+        log_status("MCP MUF Callback called with disconnected player.");
+        return;
+    }
+
     /* Let's see if we have an MCP bind that matches */
     for (ptr = PROGRAM_MCPBINDS(obj); ptr; ptr = ptr->next) {
         if (ptr->pkgname && ptr->msgname) {

--- a/src/p_mcp.c
+++ b/src/p_mcp.c
@@ -120,7 +120,7 @@ muf_mcp_callback(McpFrame * mfr, McpMesg * mesg, McpVer version, void *context)
     descr = MCPFRAME_DESCR(mfr);
     user = MCPFRAME_PLAYER(mfr);
 
-    if (!OkRef(user)) {
+    if (!ObjExists(user)) {
         /*
          * I'm not sure if this is possible, but unchecked players have
          * caused segfaults in the MCP system so we'll be safe.


### PR DESCRIPTION
For https://github.com/fuzzball-muck/fuzzball/issues/510