### PR TITLE
Fix DESCR_ARRAY crash

### DIFF
--- a/src/p_connects.c
+++ b/src/p_connects.c
@@ -1190,7 +1190,7 @@ prim_descr_array(PRIM_PROTOTYPE)
 
             array_setitem(&newarr, &temp1, &temp2);
         }
-
+	} else {
         darr = get_player_descrs(ref, &dcount);
         newarr = new_array_packed(dcount, fr->pinning);
 


### PR DESCRIPTION
An 'else' in prim_descr_array() was removed in b09e0064, causing segfaults on '#-1 DESCR_ARRAY'.