### PR TITLE
vlog2file: do not use NULL FILE*

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -49,7 +49,7 @@ vlog2file(int prepend_time, const char *filename, char *format, va_list args)
         if (prepend_time)
             strftime(buf, 32, "%Y-%m-%dT%H:%M:%S", localtime(&lt));
 
-        fprintf(fp, "%.32s: ", buf);
+        fprintf(stderr, "%.32s: ", buf);
         vfprintf(stderr, format, args);
     } else {
         if (prepend_time) {


### PR DESCRIPTION
If it's not possible to open the log file, then vlog2file() has code to log to stderr instead, but it still tries to use the NULL returned file pointer in that instead.