### PR TITLE
CrT_free: ignore free(NULL)

### DIFF
--- a/src/crt_malloc.c
+++ b/src/crt_malloc.c
@@ -1005,6 +1005,9 @@ CrT_realloc(void *p, size_t size, const char *file, int line)
 void
 CrT_free(void *p, const char *file, int line)
 {
+    if (!p)
+        return;
+
     Header m = ((Header) p) - 1;
     Block b = m->b;
 


### PR DESCRIPTION
Some code can call free(NULL), which is not an error (it's defined to do nothing), but CrT_free (used when memory profiling is enabled) may try to dereference the NULL pointer in this case.