### PR TITLE
do not use notifyf for non-format-string message

### DIFF
--- a/src/match.c
+++ b/src/match.c
@@ -971,13 +971,15 @@ noisy_match_result(struct match_data * md)
 
     switch (match = match_result(md)) {
         case NOTHING:
-            notifyf_nolisten(md->match_who,
-                             match_msg_nomatch(md->match_name));
+            notify_nolisten(md->match_who,
+                            match_msg_nomatch(md->match_name),
+                            1);
             return NOTHING;
 
         case AMBIGUOUS:
-            notifyf_nolisten(md->match_who,
-                             match_msg_ambiguous(md->match_name));
+            notify_nolisten(md->match_who,
+                            match_msg_ambiguous(md->match_name),
+                            1);
             return NOTHING;
 
         default:


### PR DESCRIPTION
noisy_match_result uses notifyf when it doesn't pass a format string.

(This was probably a security vulnerability since, e.g., `@dig Bad=%n%n%n%n%n%n%n` caused a crash from it.)