### PR TITLE
fix variables that shadow others

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -2072,9 +2072,9 @@ process_commands(void)
 static ssize_t
 socket_read(struct descriptor_data *d, void *buf, size_t count)
 {
+#ifdef USE_SSL
     int i;
 
-#ifdef USE_SSL
     if (!d->ssl_session) {
 #endif
         /* If no SSL, this is the only line in this function */
@@ -2138,7 +2138,9 @@ socket_read(struct descriptor_data *d, void *buf, size_t count)
 static ssize_t
 socket_write(struct descriptor_data * d, const void *buf, size_t count)
 {
+#ifdef USE_SSL
     int i;
+#endif
 
     d->last_pinged_at = time(NULL);
 

--- a/src/msgparse.c
+++ b/src/msgparse.c
@@ -1097,10 +1097,7 @@ msg_unparse_macro(dbref player, dbref what, dbref perms, char *name, int argc,
     const char *ptr;
     char *ptr2;
     char buf[BUFFER_LEN];
-    char buf2[BUFFER_LEN];
-    dbref obj;
     int i, p = 0;
-    int blessed;
 
     strcpyn(buf, sizeof(buf), rest);
 

--- a/src/prochelp.c
+++ b/src/prochelp.c
@@ -677,7 +677,7 @@ process_lines(FILE * infile, FILE * outfile, FILE * htmlfile)
     char buf3[4096];
     char buf4[4096];
     int nukenext = 0;
-    int topichead = 0;
+    int istopichead = 0;
     int codeblock = 0;
     char *ptr;
     char *ptr2;
@@ -812,7 +812,7 @@ process_lines(FILE * infile, FILE * outfile, FILE * htmlfile)
             }
         } else if (nukenext) {
             nukenext = 0;
-            topichead = 1;
+            istopichead = 1;
             fprintf(outfile, "%s", buf);
 
             for (ptr = buf; *ptr && *ptr != '|' && *ptr != '\n'; ptr++) {
@@ -825,8 +825,8 @@ process_lines(FILE * infile, FILE * outfile, FILE * htmlfile)
         } else if (buf[0] == ' ') {
             nukenext = 0;
 
-            if (topichead) {
-                topichead = 0;
+            if (istopichead) {
+                istopichead = 0;
                 fprintf(htmlfile, HTML_TOPICBODY);
             } else if (!codeblock) {
                 fprintf(htmlfile, HTML_PARAGRAPH);
@@ -839,12 +839,12 @@ process_lines(FILE * infile, FILE * outfile, FILE * htmlfile)
         } else {
             int found = 0;
 
-            for (replacement *temp = replacements; temp->token; temp++) {
-                if (strstr(buf, temp->token)) {
+            for (replacement *rtemp = replacements; rtemp->token; rtemp++) {
+                if (strstr(buf, rtemp->token)) {
                     found = 1;
-                    (temp->func)(outfile);
-                    (temp->func)(docsfile);
-                    (temp->func)(htmlfile);
+                    (rtemp->func)(outfile);
+                    (rtemp->func)(docsfile);
+                    (rtemp->func)(htmlfile);
                     break;
                 }
             }
@@ -856,7 +856,7 @@ process_lines(FILE * infile, FILE * outfile, FILE * htmlfile)
                 fprintf(htmlfile, "%s", buf3);
             }
 
-            if (topichead) {
+            if (istopichead) {
                 fprintf(htmlfile, HTML_TOPICHEAD_BREAK);
             }
         }
@@ -872,7 +872,6 @@ int
 main(int argc, char **argv)
 {
     FILE *infile, *outfile, *htmlfile;
-    int cols;
 
     if (argc != 4) {
         fprintf(stderr,


### PR DESCRIPTION
I renamed the inner variables to solve the conflict.

cc -O2 -pipe -W -Wall -Wshadow -Wno-unused-parameter -Wno-sign-compare -std=gnu99 -fwrapv -I../include  -I/usr/local/include -I/usr/local/include  -c prochelp.c
prochelp.c:680:9: warning: declaration shadows a variable in the global scope [-Wshadow]
    int topichead = 0;
        ^
prochelp.c:159:26: note: previous declaration is here
static struct topiclist *topichead;
                         ^
prochelp.c:842:31: warning: declaration shadows a local variable [-Wshadow]
            for (replacement *temp = replacements; temp->token; temp++) {
                              ^
prochelp.c:684:10: note: previous declaration is here
    char temp[BUFFER_LEN];
         ^
prochelp.c:875:9: warning: unused variable 'cols' [-Wunused-variable]
    int cols;
        ^
3 warnings generated.