### PR TITLE
Attempted some -Wdocumentation warnings cleanup.

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -252,7 +252,7 @@ void do_debug(dbref player, const char *args);
  * It supports registrtration if pname has an = in it.
  *
  * @param descr the descriptor of the person making the call
- * c@param player the player doing the call
+ * @param player the player doing the call
  * @param name the name of the room to make
  * @param pname the parent room and possibly registration info
  */

--- a/include/commands.h
+++ b/include/commands.h
@@ -252,7 +252,7 @@ void do_debug(dbref player, const char *args);
  * It supports registrtration if pname has an = in it.
  *
  * @param descr the descriptor of the person making the call
- * @param player the player doing the call
+ * c@param player the player doing the call
  * @param name the name of the room to make
  * @param pname the parent room and possibly registration info
  */
@@ -1605,7 +1605,7 @@ void do_usage(dbref player);
  *
  * Displays version information to player.
  *
- * @param player
+ * @param player the player doing the command
  */
 void do_version(dbref player);
 

--- a/include/compile.h
+++ b/include/compile.h
@@ -125,12 +125,10 @@ void init_primitives(void);
 /**
  * See if 'token' is a primitive
  *
- * @private
- * @param cstat the compile state structure
  * @param token the token to check
  * @return boolean true if 'token' is a primitive, false otherwise
  */
-int primitive(const char *s);
+int primitive(const char *token);
 
 /**
  * Calculate the in-memory size of a program

--- a/include/interface.h
+++ b/include/interface.h
@@ -574,7 +574,7 @@ void notify_listeners(dbref who, dbref xprog, dbref obj, dbref room, const char 
  *
  * @param player the player (or zombie) to deliver the message to
  * @param msg the message to send as a character string
- * @param isprivate
+ * @param isprivate zombie message filter -- see the notes above. 
  * @return boolean true if message received, false if nothing was queued.
  */
 int notify_nolisten(dbref player, const char *msg, int isprivate);

--- a/include/props.h
+++ b/include/props.h
@@ -1144,7 +1144,7 @@ void remove_property_list(dbref player, int all);
  *
  * @internal
  * @param player The object to operate on.
- * @param pname the property name to delete
+ * @param type the property name to delete
  * @param sync Do not sync gender props?  See description above.
  */
 void remove_property_nofetch(dbref player, const char *type, int sync);

--- a/src/array.c
+++ b/src/array.c
@@ -471,7 +471,7 @@ array_tree_find(array_tree * avl, array_iter * key)
  * This has 'friendly' node handling, returning 0 on a NULL
  *
  * @private
- * @param the node to be computed
+ * @param node the node to be computed
  * @return the height of the given node
  */
 static short
@@ -840,7 +840,7 @@ array_tree_remove_node(array_iter * key, array_tree ** root)
  *
  * @private
  * @param key the key to delete
- * @param root the root node to start from.
+ * @param avl the root node to start from.
  * @return the node to delete (it's removed from the tree)
  */
 static array_tree *

--- a/src/boolexp.c
+++ b/src/boolexp.c
@@ -301,8 +301,8 @@ static struct boolexp *parse_boolprop(char *buf);
  *
  * @private
  * @param descr the descriptor belonging to the person compiling the lock
+ * @param parsebuf the lock string
  * @param player the person or thing compiling the lock
- * @param buf the lock string
  * @param dbloadp 1 if being called by the property disk loader, 0 otherwise
  * @return struct boolexp whatever node was created or TRUE_BOOLEXP on failure
  */
@@ -452,8 +452,8 @@ parse_boolexp_F(int descr, const char **parsebuf, dbref player, int dbloadp)
  *
  * @private
  * @param descr the descriptor belonging to the person compiling the lock
+ * @param parsebuf the lock string
  * @param player the person or thing compiling the lock
- * @param buf the lock string
  * @param dbloadp 1 if being called by the property disk loader, 0 otherwise
  * @return struct boolexp whatever node was created or TRUE_BOOLEXP on failure
  */
@@ -515,8 +515,8 @@ parse_boolexp_T(int descr, const char **parsebuf, dbref player, int dbloadp)
  *
  * @private
  * @param descr the descriptor belonging to the person compiling the lock
+ * @param parsebuf the lock string
  * @param player the person or thing compiling the lock
- * @param buf the lock string
  * @param dbloadp 1 if being called by the property disk loader, 0 otherwise
  * @return struct boolexp whatever node was created or TRUE_BOOLEXP on failure
  */
@@ -573,8 +573,8 @@ parse_boolexp_E(int descr, const char **parsebuf, dbref player, int dbloadp)
  *   It is just used by the property disk loader.
  *
  * @param descr the descriptor belonging to the person compiling the lock
+ * @param parsebuf the lock string
  * @param player the person or thing compiling the lock
- * @param buf the lock string
  * @param dbloadp 1 if being called by the property disk loader, 0 otherwise
  * @return struct boolexp - the "head" of the boolean expression node tree.
  *         or TRUE_BOOLEXP on failure.
@@ -758,8 +758,6 @@ static char *buftop;
  * @param b the boolean expression to process
  * @param outer_type the type of the parent node
  * @param fullname Show names instead of DBREFs?  True or false.
- *
- * @return pointer to static buffer containing string for display.
  */ 
 static void
 unparse_boolexp1(dbref player, struct boolexp *b, short outer_type, int fullname)

--- a/src/compile.c
+++ b/src/compile.c
@@ -2510,7 +2510,6 @@ quoted(COMPSTATE * cstat, const char *token)
  * Check to see if 'token' is a #dbref
  *
  * @private
- * @param cstat the compile state structure
  * @param token the token to check
  * @return boolean true if 'token' is a #dbref, false otherwise
  */
@@ -2524,7 +2523,6 @@ object(const char *token)
  * See if 'token' starts a new string
  *
  * @private
- * @param cstat the compile state structure
  * @param token the token to check
  * @return boolean true if 'token' starts with a '"', false otherwise
  */
@@ -2592,8 +2590,6 @@ localvar(COMPSTATE * cstat, const char *token)
 /**
  * See if 'token' is a primitive
  *
- * @private
- * @param cstat the compile state structure
  * @param token the token to check
  * @return boolean true if 'token' is a primitive, false otherwise
  */

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -1060,8 +1060,6 @@ muf_debugger(int descr, dbref player, dbref program, const char *text, struct fr
         primset[2].line = 0;
         primset[2].data.number = IN_RET;
 
-        /* primset[3].data.number = primitive("EXIT"); */
-
         fr->system.st[fr->system.top].progref = program;
         fr->system.st[fr->system.top++].offset = fr->pc;
         fr->pc = &primset[1];

--- a/src/edit.c
+++ b/src/edit.c
@@ -286,7 +286,7 @@ do_list_tree(struct macrotable *node, const char *first, const char *last,
  * @param word the array of words - see description above
  * @param k the size of 'word' array
  * @param player the player to notify
- * @param length a boolean value, true for full mode, false for abridged
+ * @param full a boolean value, true for full mode, false for abridged
  */
 static void
 list_macros(char *word[], int k, dbref player, int full)

--- a/src/interp.c
+++ b/src/interp.c
@@ -46,7 +46,13 @@
  * they have an instruction number, etc.
  *
  * @private
- * @param PRIM_PROTOTYPE the standard primitive parameters
+ * @param player the player running the MUF program
+ * @param program the program being run
+ * @param mlev the effective MUCKER level
+ * @param pc the program counter pointer
+ * @param arg the argument stack
+ * @param top the top-most item of the stack
+ * @param fr the program frame
  */
 static void
 p_null(PRIM_PROTOTYPE)

--- a/src/mufevent.c
+++ b/src/mufevent.c
@@ -908,7 +908,7 @@ muf_event_add(struct frame *fr, char *event, struct inst *val, int exclusive)
  *
  * @private
  * @param fr the frame to find events for
- * @param count the number of events in 'events'
+ * @param eventcount the number of events in 'events'
  * @param events an array of strings with event names
  * @return either NULL or the found (and removed from list) mufevent
  */

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -76,7 +76,7 @@ static char buf[BUFFER_LEN];
  * @private
  * @param player the player to receive the new thing
  * @param old the dbref of the object being copied
- * @param new the dbref of the new object
+ * @param nu the dbref of the new object
  */
 static void
 copyobj(dbref player, dbref old, dbref nu)

--- a/src/p_mcp.c
+++ b/src/p_mcp.c
@@ -967,10 +967,9 @@ fbgui_muf_event_cb(GUI_EVENT_CB_ARGS)
  * @private
  * @param descr the descriptor source/target of event.
  * @param dlogid the string dialog ID
- * @param id strind ID
- * @param event string event
- * @param msg McpMesg object source of event
- * @param did_dismiss boolean
+ * @param id string ID
+ * @param errcode error code
+ * @param errtext error description
  * @param context void* pointer to arbitrary object (struct frame in this case)
  */
 static void

--- a/src/property.c
+++ b/src/property.c
@@ -410,7 +410,7 @@ add_property(dbref player, const char *pname, const char *strval, int value)
  * @param player The object to clear properties on.
  * @param p The propdir / property structure we are currently working
  *        on.
- * @param all Clear all properties? boolean -- see description above.
+ * @param allp Clear all properties? boolean -- see description above.
  */
 static void
 remove_proplist_item(dbref player, PropPtr p, int allp)
@@ -707,6 +707,13 @@ has_property(int descr, dbref player, dbref what, const char *pname, const char 
 }
 
 /**
+ * @private
+ * @var has_prop_recursion_limit
+ *      prevents too much MPI execution.  Should this be a config parameter?
+ */
+static int has_prop_recursion_limit = 2;
+
+/**
  * has_property_strict is the call that underpins has_property, and
  * unlike has_property, it checks property values for a *single*
  * object and not the object, all its contents, etc.
@@ -726,7 +733,6 @@ has_property(int descr, dbref player, dbref what, const char *pname, const char 
  *
  * @return boolean - true if property exists with value, false otherwise.
  */
-static int has_prop_recursion_limit = 2;
 int
 has_property_strict(int descr, dbref player, dbref what, const char *pname, const char *strval,
                     int value)
@@ -1963,6 +1969,12 @@ untouchprop_rec(PropPtr p)
     untouchprop_rec(PropDir(p));
 }
 
+/**
+ * @private
+ * @var untouch_lastdone
+ *      The last dbref that has been untouched in this process
+ */
+static dbref untouch_lastdone = 0;
 
 /**
  * This function is a progressive iteration over the entire database,
@@ -1980,7 +1992,6 @@ untouchprop_rec(PropPtr p)
  * @internal
  * @param limit The number of database objects to process before returning.
  */
-static dbref untouch_lastdone = 0;
 void
 untouchprops_incremental(int limit)
 {

--- a/src/props.c
+++ b/src/props.c
@@ -46,7 +46,7 @@ height_of(PropPtr node)
  * right node.
  *
  * @private
- * @param the node to check
+ * @param node the node to check
  *
  * @return the difference in height between left and right.
  *         Positive numbers mean right is 'heigher', negative


### PR DESCRIPTION
Was randomly looking through the bazillions of warnings we have with `-Weverything`, and `-Wdocumentation` caught my eye. I'm relatively new to doxygen, so let me know if there are things I've done that are silly or make things worse!

I have not addressed any`-Wdocumentation-deprecated-sync` warnings - and like this update, it's probably very far from urgent.