### PR TITLE
add null pointer to checks to convtime, fmttime primitives

### DIFF
--- a/src/p_misc.c
+++ b/src/p_misc.c
@@ -333,7 +333,7 @@ prim_convtime(PRIM_PROTOTYPE)
     CHECKOP(1);
     oper1 = POP();
 
-    if (oper1->type != PROG_STRING)
+    if (oper1->type != PROG_STRING || !oper1->data.string)
         abort_interp("Invalid time string");
 
     time_t seconds = time_string_to_seconds(oper1->data.string->data, "%T%t%D",
@@ -377,10 +377,10 @@ prim_fmttime(PRIM_PROTOTYPE)
     oper1 = POP();
     oper2 = POP();
 
-    if (oper1->type != PROG_STRING)
+    if (oper1->type != PROG_STRING || !oper1->data.string)
         abort_interp("Invalid format string");
 
-    if (oper2->type != PROG_STRING)
+    if (oper2->type != PROG_STRING || !oper2->data.string)
         abort_interp("Invalid time string");
 
     time_t seconds = time_string_to_seconds(oper2->data.string->data,

--- a/tests/command-cases/p_misc.yml
+++ b/tests/command-cases/p_misc.yml
@@ -1,0 +1,44 @@
+- name: fmttime-crash-regression1
+  setup: |
+    @program test.muf
+    i
+    : main "" "Test." fmttime ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Program Error"
+
+- name: fmttime-crash-regression2
+  setup: |
+    @program test.muf
+    i
+    : main "Test." "" fmttime ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Program Error"
+
+- name: convtime-crash-regression
+  setup: |
+    @program test.muf
+    i
+    : main "" convtime ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Program Error"


### PR DESCRIPTION
Add null pointer to checks to convtime, fmttime primitives to prevent crashes when they are called with empty strings.

Also add some tests that would trigger the crashes.