### PR TITLE
fix off by one error in prim_plusplus/minusminus; add related tests

### DIFF
--- a/src/p_math.c
+++ b/src/p_math.c
@@ -1175,9 +1175,8 @@ prim_plusplus(PRIM_PROTOTYPE)
     CHECKOP(1)
     temp1 = *(oper1 = POP());
 
-    if (oper1->type == PROG_VAR || oper1->type == PROG_SVAR
-        || oper1->type == PROG_LVAR)
-        if (oper1->data.number > MAX_VAR || oper1->data.number < 0)
+    if (oper1->type == PROG_VAR || oper1->type == PROG_LVAR)
+        if (oper1->data.number >= MAX_VAR || oper1->data.number < 0)
             abort_interp("Variable number out of range.");
 
     /* Load the correct type -- fetch from variable or from a steck item */
@@ -1188,6 +1187,8 @@ prim_plusplus(PRIM_PROTOTYPE)
 
         case PROG_SVAR:
             tmp = scopedvar_get(fr, 0, temp1.data.number);
+            if (!tmp)
+                abort_interp("Variable number out of range.");
             copyinst(tmp, &temp2);
             break;
 
@@ -1308,9 +1309,8 @@ prim_minusminus(PRIM_PROTOTYPE)
     CHECKOP(1)
     temp1 = *(oper1 = POP());
 
-    if (oper1->type == PROG_VAR || oper1->type == PROG_SVAR
-        || oper1->type == PROG_LVAR)
-        if (oper1->data.number > MAX_VAR || oper1->data.number < 0)
+    if (oper1->type == PROG_VAR || oper1->type == PROG_LVAR)
+        if (oper1->data.number >= MAX_VAR || oper1->data.number < 0)
             abort_interp("Variable number out of range.");
 
     /* Load the correct type -- fetch from variable or from a steck item */
@@ -1321,6 +1321,8 @@ prim_minusminus(PRIM_PROTOTYPE)
 
         case PROG_SVAR:
             tmp = scopedvar_get(fr, 0, temp1.data.number);
+            if (!tmp)
+                abort_interp("Variable number out of range");
             copyinst(tmp, &temp2);
             break;
 

--- a/tests/command-cases/p_math.yml
+++ b/tests/command-cases/p_math.yml
@@ -1,0 +1,28 @@
+- name: past-max-localvar-pp
+  setup: |
+    @program test.muf
+    1 i
+    : main max_variable_count localvar ++ ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Program Error"
+- name: past-max-var-pp
+  setup: |
+    @program test.muf
+    1 i
+    : main max_variable_count variable ++ ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Program Error"

--- a/tests/command-cases/p_math.yml
+++ b/tests/command-cases/p_math.yml
@@ -51,3 +51,28 @@
     test
   expect:
     - "43"
+- name: at-max-var-pp
+  setup: |
+    @program test.muf
+    1 i
+    : main
+        max_variable_count 1 - variable
+        (stack contains var#max)
+        42 over !
+        (set to 42)
+        dup ++
+        (increment to 43)
+        @
+        (retrieve value)
+        me @ swap intostr notify
+    ;
+    .
+    c
+    q
+    @set test.muf=D
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "43"

--- a/tests/command-cases/p_math.yml
+++ b/tests/command-cases/p_math.yml
@@ -44,7 +44,6 @@
     .
     c
     q
-    @set test.muf=D
     @act test=here
     @link test=test.muf
   commands: |
@@ -69,7 +68,6 @@
     .
     c
     q
-    @set test.muf=D
     @act test=here
     @link test=test.muf
   commands: |

--- a/tests/command-cases/p_math.yml
+++ b/tests/command-cases/p_math.yml
@@ -50,6 +50,30 @@
     test
   expect:
     - "43"
+- name: at-max-localvar-mm
+  setup: |
+    @program test.muf
+    1 i
+    : main
+        max_variable_count 1 - localvar
+        (stack contains localvar#max)
+        42 over !
+        (set to 42)
+        dup --
+        (decrement to 43)
+        @
+        (retrieve value)
+        me @ swap intostr notify
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "41"
 - name: at-max-var-pp
   setup: |
     @program test.muf
@@ -74,3 +98,27 @@
     test
   expect:
     - "43"
+- name: at-max-var-mm
+  setup: |
+    @program test.muf
+    1 i
+    : main
+        max_variable_count 1 - variable
+        (stack contains var#max)
+        42 over !
+        (set to 42)
+        dup --
+        (increment to 41)
+        @
+        (retrieve value)
+        me @ swap intostr notify
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "41"

--- a/tests/command-cases/p_math.yml
+++ b/tests/command-cases/p_math.yml
@@ -26,3 +26,28 @@
     test
   expect:
     - "Program Error"
+- name: at-max-localvar-pp
+  setup: |
+    @program test.muf
+    1 i
+    : main
+        max_variable_count 1 - localvar
+        (stack contains localvar#max)
+        42 over !
+        (set to 42)
+        dup ++
+        (increment to 43)
+        @
+        (retrieve value)
+        me @ swap intostr notify
+    ;
+    .
+    c
+    q
+    @set test.muf=D
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "43"

--- a/tests/command-cases/p_math.yml
+++ b/tests/command-cases/p_math.yml
@@ -12,11 +12,69 @@
     test
   expect:
     - "Program Error"
+- name: past-max-localvar-mm
+  setup: |
+    @program test.muf
+    1 i
+    : main max_variable_count localvar -- ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Program Error"
 - name: past-max-var-pp
   setup: |
     @program test.muf
     1 i
     : main max_variable_count variable ++ ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Program Error"
+- name: past-max-var-mm
+  setup: |
+    @program test.muf
+    1 i
+    : main max_variable_count variable -- ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Program Error"
+- name: past-max-svar-pp
+  setup: |
+    @program test.muf
+    1 i
+    : bad_scoped_var var my_scoped my_scoped ;
+    : main bad_scoped_var ++ ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Program Error"
+- name: past-max-svar-mm
+  setup: |
+    @program test.muf
+    1 i
+    : bad_scoped_var var my_scoped my_scoped ;
+    : main bad_scoped_var -- ;
     .
     c
     q
@@ -112,6 +170,44 @@
         @
         (retrieve value)
         me @ swap intostr notify
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "41"
+- name: scoped-var-pp
+  setup: |
+    @program test.muf
+    1 i
+    : main
+        var x
+        42 x !
+        x ++
+        me @ x @ intostr notify
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "43"
+- name: scoped-var-mm
+  setup: |
+    @program test.muf
+    1 i
+    : main
+        var x
+        42 x !
+        x --
+        me @ x @ intostr notify
     ;
     .
     c


### PR DESCRIPTION
prim_plusplus and prim_minusminus assumed MAX_VAR was the maximum index of a variable rather than the maximum number of variables, so they're check was off-by-one. This caused an out-of-bounds access into the variables/local-variables arrays.

I also notices that the scoped variable check was based on the variable number rather than whether scopedvar_get() returned a null pointer (though I'm not sure whether this could actually cause a NULL pointer dereference).

Also added some tests of this part of the ++/-- functionality (regressions for the out-of-bounds accesses and tests of normal behavior) and adjustments to the tests to be better at outputting stderr when the MUCK crashes.