### PR TITLE
Fix memory errors in prim_gui_value_set, GuiFree

### DIFF
--- a/src/mcpgui.c
+++ b/src/mcpgui.c
@@ -529,6 +529,7 @@ GuiFree(const char *id)
     while (valptr) {
         nextval = valptr->next;
         gui_value_free(valptr);
+        free(valptr);
         valptr = nextval;
     }
 

--- a/src/p_mcp.c
+++ b/src/p_mcp.c
@@ -1530,6 +1530,12 @@ prim_gui_value_set(PRIM_PROTOTYPE)
             temp2 = array_getitem(oper3->data.array, &temp1);
 
             if (!temp2) {
+                while (i-- > 0) {
+                    free(valarray[i]);
+                }
+
+                free(valarray);
+                abort_interp("Dictionary-style array where list value expected. (3)");
                 break;
             }
 

--- a/tests/command-cases/p_mcp.yml
+++ b/tests/command-cases/p_mcp.yml
@@ -1,0 +1,57 @@
+- name: gui-set-value-dict
+  setup: |
+    #$#mcp version: "2.1" to: "2.1" authentication-key: "1234"
+    #$#mcp-negotiate-can 1234 package: "org-fuzzball-gui" min-version: "1.0" max-version: "1.0"
+    #$#mcp-negotiate-can 1234 package: "mcp-negotiate" min-version: "1.0" max-version: "1.0"
+    #$#mcp-negotiate-end 1234
+    @program test.muf
+    1 i
+    : main
+      descr D_SIMPLE "testing dialog" { }list gui_dlog_create
+      dup C_SPINNER "example-id" { }list gui_ctrl_create
+      dup "example-id" { 1 2 }dict gui_value_set
+    ;
+    .
+    c
+    q
+    @act test=me
+    @link test=test.muf
+  commands:
+    test
+  expect:
+    - "#\\$#org-fuzzball-gui-dlog-create 1234"
+    - "#\\$#org-fuzzball-gui-ctrl-spinner 1234"
+    - "Program Error."
+    - "#\\$#org-fuzzball-gui-dlog-close 1234"
+
+- name: gui-set-value-list
+  setup: |
+    #$#mcp version: "2.1" to: "2.1" authentication-key: "1234"
+    #$#mcp-negotiate-can 1234 package: "org-fuzzball-gui" min-version: "1.0" max-version: "1.0"
+    #$#mcp-negotiate-can 1234 package: "mcp-negotiate" min-version: "1.0" max-version: "1.0"
+    #$#mcp-negotiate-end 1234
+    @program test.muf
+    1 i
+    : main
+      descr D_SIMPLE "testing dialog" { }list gui_dlog_create
+      dup C_SPINNER "example-id" { }list gui_ctrl_create
+      dup "example-id" { 1 2 3 }list gui_value_set
+      0 sleep
+      me @ "After set." notify
+    ;
+    .
+    c
+    q
+    @act test=me
+    @link test=test.muf
+  commands:
+    test
+  expect:
+    - "#\\$#org-fuzzball-gui-dlog-create 1234"
+    - "#\\$#org-fuzzball-gui-ctrl-spinner 1234"
+    - "#\\$#org-fuzzball-gui-ctrl-value 1234 .* id: \"example-id\""
+    - "value: 1"
+    - "value: 2"
+    - "value: 3"
+    - "After set."
+    - "#\\$#org-fuzzball-gui-dlog-close 1234"


### PR DESCRIPTION
Via some fuzzing, I discovered that prim_gui_value_set tries to call free() on an uninitialized pointer when it is passed a dictionary-like array instead of a list-like array. This fixes that, triggering an abort_interp() in that case.

In the process of testing this, I also noticed that GuiFree() failed to free dialog control tracking structs fully.

This patch also adds a couple tests for gui_value_set. This includes some hard-coded MCP messages to make the mcpgui code believe that it's talking to a client that supports the MCP GUI stuff.