### PR TITLE
Check validity of dbref array passed to array_noitfy

### DIFF
--- a/src/p_array.c
+++ b/src/p_array.c
@@ -1262,6 +1262,15 @@ prim_array_notify(PRIM_PROTOTYPE)
     strarr = oper1->data.array;
     refarr = oper2->data.array;
 
+    if (array_first(refarr, &temp1)) {
+        do {
+            oper3 = array_getitem(refarr, &temp1);
+            if (!valid_object(oper3))
+                abort_interp("Dbref array contains invalid object. (2)");
+            CHECKREMOTE(oper3->data.objref);
+        } while (array_next(refarr, &temp1));
+    }
+
     if (array_first(strarr, &temp2)) {
         do {
             oper4 = array_getitem(strarr, &temp2);

--- a/tests/command-cases/p_array.yml
+++ b/tests/command-cases/p_array.yml
@@ -1,0 +1,69 @@
+- name: simple-array-notify
+  setup: |
+    @program test.muf
+    i
+    : main { "Test 0" "Test 1" "Test 2" "Test 3" }list { me @ }list array_notify ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect: |
+    Test 0
+    Test 1
+    Test 2
+    Test 3
+
+- name: array-notify-nothing
+  setup: |
+    @program test.muf
+    i
+    : main { "Test 0" "Test 1" "Test 2" "Test 3" }list { #-1 }list array_notify ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Program Error"
+
+- name: array-notify-bad
+  setup: |
+    @program test.muf
+    i
+    : main { "Test 0" "Test 1" "Test 2" "Test 3" }list { #-1000 }list array_notify ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Program Error"
+
+- name: array-notify-remote
+  setup: |
+    @dig NewPlayerRoom==newplayerroom
+    @program test.muf
+    i
+    : main { "Test 0" "Test 1" "Test 2" "Test 3" }list { #1 }list array_notify ;
+    .
+    c
+    q
+    @act test=#0
+    @link test=test.muf
+    @pcreate OwnerPlayer=foo
+    @chown test.muf=OwnerPlayer
+    @set test.muf=1
+    @set *OwnerPlayer=1
+    @tel *OwnerPlayer=$newplayerroom
+    @force *OwnerPlayer=test
+  commands: |
+    ex test.muf=.debug/errcount
+  expect:
+    - "int /.debug/errcount:1"


### PR DESCRIPTION
Add a check that the array passed to array_notify has valid objects. Also include the M1 object-is-remote check. Previous code would access out-of-bounds when an invalid dbref like `#-1` was passed in the dbref array.

Also add corresponding tests.