### PR TITLE
Fix several instances of notifyf being used without format string; mark notifyf functions for compilers

### DIFF
--- a/include/interface.h
+++ b/include/interface.h
@@ -591,7 +591,13 @@ int notify_nolisten(dbref player, const char *msg, int isprivate);
  * @param format the format string
  * @param ... as many arguments as necessary
  */
-void notifyf(dbref player, char *format, ...);
+void notifyf(dbref player, char *format, ...)
+#if defined(__GNUC__) || defined(__clang__)
+    /* let GCC and clang know that we use a printf-style format string
+       so they can give better warnings/errors */
+    __attribute__((format(printf, 2, 3)))
+#endif
+;
 
 /**
  * Notify the given player (or zombie) without triggering listen propqueue.
@@ -606,7 +612,13 @@ void notifyf(dbref player, char *format, ...);
  * @param format the format string
  * @param ... as many arguments as necessary.
  */
-void notifyf_nolisten(dbref player, char *format, ...);
+void notifyf_nolisten(dbref player, char *format, ...)
+#if defined(__GNUC__) || defined(__clang__)
+    /* let GCC and clang know that we use a printf-style format string
+       so they can give better warnings/errors */
+    __attribute__((format(printf, 2, 3)))
+#endif
+;
 
 /**
  * Partial pmatch searches for 'name' amongst the currently online players

--- a/src/create.c
+++ b/src/create.c
@@ -435,7 +435,7 @@ do_program(int descr, dbref player, const char *name, const char *rname)
             register_object(player, player, REGISTRATION_PROPDIR, (char *)rname, program);
         }
     } else if (program == AMBIGUOUS) {
-        notifyf_nolisten(player, match_msg_ambiguous(name));
+        notify_nolisten(player, match_msg_ambiguous(name), 1);
         return;
     }
 

--- a/src/look.c
+++ b/src/look.c
@@ -427,14 +427,14 @@ do_look_at(int descr, dbref player, const char *name, const char *detail)
                 exec_or_notify(descr, player, thing, PropDataStr(lastmatch), "(@detail)",
                                (PropFlags(lastmatch) & PROP_BLESSED) ? MPI_ISBLESSED : 0);
             } else if (ambig_flag) {
-                notifyf_nolisten(player, match_msg_ambiguous(buf));
+                notify_nolisten(player, match_msg_ambiguous(buf), 1);
             } else if (*detail) {
                 notify(player, tp_description_default);
             } else {
-                notifyf_nolisten(player, match_msg_nomatch(buf));
+                notify_nolisten(player, match_msg_nomatch(buf), 1);
             }
         } else {
-            notifyf_nolisten(player, match_msg_ambiguous(detail));
+            notify_nolisten(player, match_msg_ambiguous(detail), 1);
         }
     }
 }

--- a/tests/command-cases/create.yml
+++ b/tests/command-cases/create.yml
@@ -90,3 +90,25 @@
   expect:
     - "I don't understand '%n"
     - "Parent: Room Zero"
+
+- name: program-ambiguous
+  setup: |
+    @program Foo program 1.muf
+    q
+    @program Foo program 2.muf
+    q
+  commands: |
+    @program Foo
+  expect:
+    - "I don't know which 'Foo'"
+
+- name: program-ambiguous-fmtstring
+  setup: |
+    @program %n%n%n program 1.muf
+    q
+    @program %n%n%n program 2.muf
+    q
+  commands: |
+    @program %n%n%n
+  expect:
+    - "I don't know which '%n%n%n'"

--- a/tests/command-cases/look.yml
+++ b/tests/command-cases/look.yml
@@ -65,3 +65,66 @@
     - "Read Key: _readlocktest:1"
     - "Pecho: Foo pecho>>>"
     - "Oecho: Foo oecho>>>"
+
+- name: look-thing-desc
+  setup: |
+    @create Foo
+    @desc Foo=Example description.
+  commands: |
+    look Foo
+  expect:
+    - "Example description."
+
+- name: look-thing-nodesc
+  setup: |
+    @create Foo
+    @tune description_default=[DEFAULT]
+  commands: |
+    look Foo
+  expect:
+    - "[DEFAULT]"
+
+- name: look-thing-detail
+  setup: |
+    @create Foo
+    @set Foo=_details/Bar:Example detail.
+  commands: |
+    look Foo=Bar
+  expect:
+    - "Example detail."
+
+- name: look-thing-detail-nodesc
+  setup: |
+    @create Foo
+    @tune description_default=[DEFAULT]
+  commands: |
+    look Foo=Bar
+  expect:
+    - "[DEFAULT]"
+
+- name: look-thing-detail-ambig
+  setup: |
+    @create Foo
+    @set Foo=_details/Bar;x:Example 1.
+    @set Foo=_details/Bar;y:Example 2.
+  commands: |
+    look Foo=Bar
+  expect:
+    - "don't know which 'Bar' you mean"
+
+- name: look-thing-detail-ambig-fmtstring
+  setup: |
+    @create Foo
+    @set Foo=_details/%n;x:Example 1.
+    @set Foo=_details/%n;y:Example 2.
+  commands: |
+    look Foo=%n
+  expect:
+    - "don't know which '%n' you mean"
+
+- name: look-fail-fmtstring
+  commands: |
+    look %n%n%n%n%n%n%n%n%n%n
+  expect:
+    - "I don't understand '%n"
+


### PR DESCRIPTION
do_look_at and do_program both used notifyf_nolisten with the result of something like match_msg_ambiguous, which is not a format string and might contain %.

Also add tests to diagnose these cases.

Also modify interface.h's declarations of notifyf and notifyf_nolisten to add the "format" function attribute for GCC and clang, so they will give warnings about this issue with -Wformat-security.