### PR TITLE
avoid infinite loop in regsplit when regex matches empty string

### DIFF
--- a/src/p_regex.c
+++ b/src/p_regex.c
@@ -630,7 +630,18 @@ _prim_regsplit(PRIM_PROTOTYPE, int empty)
                 CLEAR(&val);
             }
 
-            text = &textstart[end];
+            if (end == pos) {
+                /* always advance where we match from by at least one char */
+                text = &textstart[end + 1];
+                if (!*text) {
+                    val.type = PROG_STRING;
+                    val.data.string = alloc_prog_string(&textstart[pos]);
+                    array_appenditem(&nu_val, &val);
+                    CLEAR(&val);
+                }
+            } else {
+                text = &textstart[end];
+            }
             pos = end;
         }
     }

--- a/tests/command-cases/p_regex.yml
+++ b/tests/command-cases/p_regex.yml
@@ -1,0 +1,145 @@
+- name: regsplit-normal
+  setup: |
+    @program test.muf
+    i
+    : main
+      "fooXbarYbazXquux" "X|Y" 0 regsplit
+      { me @ }list array_notify
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+    @set test.muf=D
+  commands: |
+    test
+  expect: |
+    foo
+    bar
+    baz
+    quux
+
+- name: regsplit-normal2
+  setup: |
+    @program test.muf
+    i
+    : main
+      "fooXXbXarYXbazXXquux" "XX|Y" 0 regsplit
+      { me @ }list array_notify
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+    @set test.muf=D
+  commands: |
+    test
+  expect: |
+    foo
+    bXar
+    Xbaz
+    quux
+
+- name: regsplit-normal-with-empty
+  setup: |
+    @program test.muf
+    i
+    : main
+      "fooXbarYbazXXYquux" "X|Y" 0 regsplit
+      foreach swap pop ":" swap strcat me @ swap notify repeat
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect: |
+    :foo
+    :bar
+    :baz
+    :
+    :
+    :quux
+
+- name: regsplit_noempty-normal-with-empty
+  setup: |
+    @program test.muf
+    i
+    : main
+      "fooXbarYbazXXYquux" "X|Y" 0 regsplit_noempty
+      foreach swap pop ":" swap strcat me @ swap notify repeat
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect: |
+    :foo
+    :bar
+    :baz
+    :quux
+
+- name: regsplit-noempty-match-every-char
+  setup: |
+    @program test.muf
+    i
+    : main
+      "abZcdZZef" "Z|" 0 regsplit_noempty
+      { me @ }list array_notify
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+    @set test.muf=D
+  commands: |
+    test
+  expect: |
+    a
+    b
+    c
+    d
+    e
+    f
+
+- name: regsplit-empty-match-every-char
+  setup: |
+    @program test.muf
+    i
+    : main
+      "abZcdZZef" "Z|" 0 regsplit
+      foreach
+        swap pop (remove index)
+        ":" swap strcat me @ swap notify
+      repeat
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect: |
+    :
+    :a
+    :
+    :b
+    :
+    :c
+    :
+    :d
+    :
+    :
+    :e
+    :
+    :f
+


### PR DESCRIPTION
The MUF primitives REGSPLIT and REGSPLIT_NOEMPTY do not advance their position in the input string when the supplied regular expression matches an empty string. This means that something like "FOO" "|" regsplit results in essentially an infinite loop.

This fixes this by making sure that REGSPLIT always advances their position in the string by at least one character, including a special case for when this is how the last character in the string is covered.

Also add some tests for REGSPLIT and REGSPLIT_NOEMPTY that exercise this functionality.