### PR TITLE
Avoid very long loops in prim_checkargs; add tests for checkargs

### DIFF
--- a/src/p_stack.c
+++ b/src/p_stack.c
@@ -1232,6 +1232,18 @@ prim_checkargs(PRIM_PROTOTYPE)
             if (rngstktyp[rngstktop - 1] != itsarange)
                 abort_interp("Misformed argument expression.");
 
+            /* special case for "{}", "{ }", etc. (nothing inside the range)
+               override the count to 1 to avoid executing this loop potentially billions
+               of times causing a server hang.
+              */
+            if (buf[currpos + 1] == ' ' || buf[currpos + 1] == '}') {
+                int next_symbol_pos = currpos + 1;
+                while (buf[next_symbol_pos] == ' ') next_symbol_pos++;
+                if (buf[next_symbol_pos] == '}') {
+                    rngstkcnt[rngstktop - 1] = 1;
+                }
+            }
+
             if (--rngstkcnt[rngstktop - 1] > 0) {
                 currpos = rngstkpos[rngstktop - 1];
             } else {
@@ -1448,7 +1460,7 @@ prim_checkargs(PRIM_PROTOTYPE)
                     break;
 
                 default:
-                    abort_interp("Unkown argument type in expression.");
+                    abort_interp("Unknown argument type in expression.");
             }
 
             currpos--;          /* decrement string index */

--- a/tests/command-cases/p_stack.yml
+++ b/tests/command-cases/p_stack.yml
@@ -1,0 +1,118 @@
+- name: checkargs-multiple-okay
+  setup: |
+    @program test.muf
+    i
+    : main pop
+      "string" #0 #1 #-1 #-2 42
+      "sddddi" checkargs
+      "sd4i" checkargs
+      "sRPddi" checkargs
+      "RPddi" checkargs
+      me @ "Complete." notify
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Complete"
+
+- name: checkargs-single-ranges-okay
+  setup: |
+    @program test.muf
+    i
+    : main pop
+      { "X" }list 1 0 "xxx" "string" 2 #0 #1 #-1 #-2 4
+      "{y}{?}{s}{d}" checkargs
+      "yii{s}{d}" checkargs
+      "{y}{f}{s}{d}" checkargs
+      me @ "Complete." notify
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Complete"
+
+- name: checkargs-multi-ranges-okay
+  setup: |
+    @program test.muf
+    i
+    : main pop
+      "~" { "X" }list 1 0 42 "xxx" 43 "string" 2 #0 #1 #-1 #-2 4
+      "{sy}{?}{is}{d}" checkargs
+      "{sy}{FFFF}{is}{d}" checkargs
+      me @ "Complete." notify
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Complete"
+
+- name: checkargs-empty-range
+  setup: |
+    @program test.muf
+    i
+    : main pop
+      0 "{}" checkargs
+      1 "{}" checkargs
+      1000 "{}" checkargs
+      me @ "Complete." notify
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Complete"
+
+- name: checkargs-empty-range-negative
+  setup: |
+    @program test.muf
+    i
+    : main pop
+      -1 "{}" checkargs
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Program Error"
+
+- name: checkargs-huge-empty-range
+  setup: |
+    @program test.muf
+    i
+    : main pop
+      1000 1000 * 1000 * "{}" checkargs
+      me @ "Complete." notify
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  timeout: 1
+  expect:
+    - "Complete"

--- a/tests/command-cases/p_stack.yml
+++ b/tests/command-cases/p_stack.yml
@@ -29,6 +29,7 @@
       "{y}{?}{s}{d}" checkargs
       "yii{s}{d}" checkargs
       "{y}{f}{s}{d}" checkargs
+      "{ y }{ f }{ s }{ d }" checkargs
       me @ "Complete." notify
     ;
     .
@@ -49,6 +50,7 @@
       "~" { "X" }list 1 0 42 "xxx" 43 "string" 2 #0 #1 #-1 #-2 4
       "{sy}{?}{is}{d}" checkargs
       "{sy}{FFFF}{is}{d}" checkargs
+      "{ s y } { ? }{ i s } { d }" checkargs
       me @ "Complete." notify
     ;
     .
@@ -98,12 +100,31 @@
   expect:
     - "Program Error"
 
-- name: checkargs-huge-empty-range
+- name: checkargs-huge-empty-range1
   setup: |
     @program test.muf
     i
     : main pop
       1000 1000 * 1000 * "{}" checkargs
+      me @ "Complete." notify
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  timeout: 1
+  expect:
+    - "Complete"
+
+- name: checkargs-huge-empty-range2
+  setup: |
+    @program test.muf
+    i
+    : main pop
+      1000 1000 * 1000 * "{   }" checkargs
       me @ "Complete." notify
     ;
     .


### PR DESCRIPTION
When given a pattern like "{}", the CHECKARGS primitives will execute a loop in C for a number of iterations specified by the number at the top of the stack, allowing an unpriviliged MUF program with code like `1000 1000 * 1000 * "{}" checkargs` to make the server hang for a while. The code properly checks for a range of that number of copies of nothing on the stack.

This fixes that issue by special-casing "{}", "{ }", etc. in prim_checkargs. Other patterns should require at least one item to be examined on the stack in the range, limiting the number of iterations to the depth of the stack, which is bounded more reasonably.

This also adds a bunch of tests (but by no means tests sufficient for complete coverage) for CHECKARGS, and modifies the tests to support timeouts.