### PR TITLE
Modify deep_copyinst to fail when copying recursive arrays.

### DIFF
--- a/include/array.h
+++ b/include/array.h
@@ -605,4 +605,15 @@ void array_init_active_list(stk_array_list *list);
  */
 void array_free_all_on_list(stk_array_list *list);
 
+/**
+ * Make a deep copy of an array. Can fail if the array has a circular structure.
+ *
+ * @param in input array
+ * @param out pointer to the output array (will be allocated)
+ * @param pinned boolean, whether new arrays will be pinned. -1 will copy from existing arrays
+ * @return 1 if the copy was successful, 0 if not
+ */
+int
+array_deep_copy(stk_array *in, stk_array **out, int pinned);
+
 #endif /* !ARRAY_H */

--- a/include/interp.h
+++ b/include/interp.h
@@ -708,13 +708,20 @@ void copyinst(struct inst *from, struct inst *to);
  * fashion.  Otherwise it operates similar to copyinst, this really only
  * impacts arrays/dictionaries.
  *
+ * If the array contains cycles, then the copy can fail. If so, an error will be returned.
+ * (Probably the copy should also fail if some sort of memory limit is exceeded, but this
+ * is not implemented.)
+ *
+ * When a copy fails, the output instruction will be the value '0'.
+ *
  * @see copyinst
  *
  * @param from the source instruction
  * @param to the destination instruction
  * @param pinned boolean passed to any new arrays made.  -1 will use default
+ * @return 1 if successful, 0 otherwise
  */
-void deep_copyinst(struct inst *from, struct inst *to, int pinned);
+int deep_copyinst(struct inst *from, struct inst *to, int pinned);
 
 /**
  * Dump debugging data about an instruction

--- a/src/p_misc.c
+++ b/src/p_misc.c
@@ -1685,7 +1685,9 @@ prim_event_send(PRIM_PROTOTYPE)
         stk_array_active_list = &destfr->array_active_list;
         struct inst data_copy;
 
-        deep_copyinst(oper3, &data_copy, destfr->pinning);
+        if (!deep_copyinst(oper3, &data_copy, destfr->pinning)) {
+            abort_interp("Uncopyable data for event. (3)");
+        }
 
         arr = new_array_dictionary(destfr->pinning);
         array_set_strkey(&arr, "data", &data_copy);

--- a/src/p_stack.c
+++ b/src/p_stack.c
@@ -158,7 +158,9 @@ prim_deep_copy(PRIM_PROTOTYPE)
     EXPECT_READ_STACK(1);
     CHECKOFLOW(1);
 
-    deep_copyinst(&arg[*top - 1], &arg[*top], fr->pinning);
+    if (!deep_copyinst(&arg[*top - 1], &arg[*top], fr->pinning)) {
+        abort_interp("Could not make deep copy. (Probably cyclic array references.)");
+    }
     (*top)++;
 }
 

--- a/tests/command-cases/p_array.yml
+++ b/tests/command-cases/p_array.yml
@@ -67,3 +67,25 @@
     ex test.muf=.debug/errcount
   expect:
     - "int /.debug/errcount:1"
+
+- name: array-compare-cycle
+  setup: |
+    @program test.muf
+    i
+    : main
+        { 1 2 3 }list ARRAY_PIN var! x
+        { 4 5 6 }list ARRAY_PIN var! y
+        x @ y @ 0 ARRAY_SETITEM POP
+        y @ x @ 0 ARRAY_SETITEM POP
+        x @ y @ ARRAY_COMPARE
+        0 = intostr me @ swap notify
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "0"

--- a/tests/command-cases/p_stack.yml
+++ b/tests/command-cases/p_stack.yml
@@ -137,3 +137,57 @@
   timeout: 1
   expect:
     - "Complete"
+
+- name: deepcopy-pinned-array-nocycle
+  setup: |
+    @program test.muf
+    i
+    : main
+        { "x0" "x1" }list ARRAY_PIN var! x
+        { "y0" "y1" }list ARRAY_PIN var! y
+        y @ x @ 1 ARRAY_SETITEM POP
+        x @ DEEP_COPY ARRAY_PIN var! x_copy
+        "changed-in-orig" x @ { 1 1 }list ARRAY_NESTED_SET
+        "changed-in-copy" x_copy @ { 1 0 }list ARRAY_NESTED_SET
+        me @ "x->1->0=" x @ 1 ARRAY_GETITEM 0 ARRAY_GETITEM strcat notify
+        me @ "x->1->1=" x @ 1 ARRAY_GETITEM 1 ARRAY_GETITEM strcat notify
+        me @ "x_copy->1->0=" x_copy @ 1 ARRAY_GETITEM 0 ARRAY_GETITEM strcat notify
+        me @ "x_copy->1->1=" x_copy @ 1 ARRAY_GETITEM 1 ARRAY_GETITEM strcat notify
+        me @ "y->0=" y @ 0 ARRAY_GETITEM strcat notify
+        me @ "y->1=" y @ 1 ARRAY_GETITEM strcat notify
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "x->1->0=y0"
+    - "x->1->1=changed-in-orig"
+    - "x_copy->1->0=changed-in-copy"
+    - "x_copy->1->1=y1"
+    - "y->0=y0"
+    - "y->1=changed-in-orig"
+
+- name: deepcopy-array-cycle
+  setup: |
+    @program test.muf
+    i
+    : main
+        { 1 2 3 }list ARRAY_PIN var! x
+        { 4 5 6 }list ARRAY_PIN var! y
+        x @ y @ 0 ARRAY_SETITEM POP
+        y @ x @ 0 ARRAY_SETITEM POP
+        x @ DEEP_COPY
+    ;
+    .
+    c
+    q
+    @act test=here
+    @link test=test.muf
+  commands: |
+    test
+  expect:
+    - "Program Error"


### PR DESCRIPTION
By recursive arrays I mean arrays which contain pinned arrays that contain themselves
(directly or indirectly). Trying to copy these naively as deep_copyinst used to causes infinite recursion.

Previously deep_copyinst couldn't fail. This patch changes that and modifies prim_deep_copy
to expose the failure as a MUF error. deep_copyinst is also used by prim_fork. This patch
does not modify prim_fork.

When deep_copyinst fails it modifies the destination into the integer '0' to limit problems
from later use of this copy. (CLEAR() might be a better choice at least after prim_fork is
cleaned up to be aware of deep_copyinst failing.)

Also add basic tests for recursive array scenarios and normal usage of the deep_copy primitive.