### PR TITLE
Addressed a few compiler warnings:

### DIFF
--- a/include/commands.h
+++ b/include/commands.h
@@ -289,7 +289,7 @@ void do_doing(int descr, dbref player, const char *name, const char *mesg);
  * in play.
  *
  * For the put/throw logic, if the target object is not a room, it must
- * have a container lock.  The lock is "@conlock" or "_/clk".  If there is
+ * have a container lock.  The lock is "\@conlock" or "_/clk".  If there is
  * no lock it will default to false.
  *
  * This handles all the nuances of dropping things, such as drop/odrop

--- a/include/mufevent.h
+++ b/include/mufevent.h
@@ -254,3 +254,4 @@ void muf_event_register_specific(
                 char **eventids);
 
 #endif /* !MUFEVENT_H */
+

--- a/include/props.h
+++ b/include/props.h
@@ -513,7 +513,7 @@ const char *envpropstr(dbref * where, const char *propname);
  * @param thing - The DBREF of the thing emitting the message.
  * @param message - The message to emit
  * @param whatcalled - This is the caller context -- its the
- *                     MPI &how or the MUF command.  Such as "(@Desc)"
+ *                     MPI &how or the MUF command.  Such as "(\@Desc)"
  * @param mpiflags - What MPI flags to use - MPI_ISPRIVATE is added.
  */
 void exec_or_notify(int descr, dbref player, dbref thing, const char *message,
@@ -534,7 +534,7 @@ void exec_or_notify(int descr, dbref player, dbref thing, const char *message,
  * @param thing - The DBREF of the thing emitting the message.
  * @param propname - The property to load off 'thing'.
  * @param whatcalled - This is the caller context -- its the
- *                     MPI &how or the MUF command.  Such as "(@Desc)"
+ *                     MPI &how or the MUF command.  Such as "(\@Desc)"
  */
 void exec_or_notify_prop(int descr, dbref player, dbref thing,
                          const char *propname, const char *whatcalled);         

--- a/src/array.c
+++ b/src/array.c
@@ -2955,7 +2955,7 @@ array_deep_copy_internal(stk_array *in, stk_array **out, int pinned, visited_set
     }
 
     int failed = 0;
-    stk_array *nu;
+    stk_array *nu = NULL;
     switch (in->type) {
         case ARRAY_PACKED:{
             nu = new_array_packed(in->items, pinned == -1 ?

--- a/src/compile.c
+++ b/src/compile.c
@@ -879,7 +879,7 @@ uncompile_program(dbref i)
 }
 
 /**
- * Implementation of @uncompile command
+ * Implementation of \@uncompile command
  *
  * Removes all compiled programs from memory.  Does not do permission
  * checking.

--- a/src/create.c
+++ b/src/create.c
@@ -32,7 +32,7 @@
 #include "tune.h"
 
 /**
- * Implementation of @open command
+ * Implementation of \@open command
  *
  * This creates an exit in the current room and optionally links it
  * in one step.
@@ -116,7 +116,7 @@ do_open(int descr, dbref player, const char *direction, const char *linkto)
 }
 
 /**
- * Implementation of @link command.
+ * Implementation of \@link command
  *
  * Use this to link to a room that you own.  It also sets home for objects and
  * things, and drop-to's for rooms.  It seizes ownership of an unlinked exit,
@@ -287,7 +287,7 @@ do_link(int descr, dbref player, const char *thing_name, const char *dest_name)
 }
 
 /**
- * Implementation of @dig
+ * Implementation of \@dig
  *
  * Use this to create a room.  This does a lot of checks; rooms must pass
  * ok_object_name.  It handles finding the parent, if no parent is
@@ -389,7 +389,7 @@ do_dig(int descr, dbref player, const char *name, const char *pname)
 }
 
 /**
- * Implementation of @program
+ * Implementation of \@program
  *
  * First, find a program that matches that name.  If there's one, then we 
  * put the player into edit mode and do it.  Otherwise, we create a new object
@@ -444,7 +444,7 @@ do_program(int descr, dbref player, const char *name, const char *rname)
 
 
 /**
- * This is the implementation of @edit
+ * This is the implementation of \@edit
  *
  * This does not do any permission checking, however the underlying call
  * (edit_program) does do some minimal checking to make sure the player
@@ -675,7 +675,7 @@ do_clone(int descr, dbref player, const char *name, const char *rname)
 }
 
 /**
- * Implementation of @create
+ * Implementation of \@create
  *
  * Use this to create an object.  This does some checking; for instance,
  * the name must pass ok_object_name.  Does NOT check builder bit.
@@ -802,7 +802,7 @@ parse_source(int descr, dbref player, const char *source_name)
  * This routine attaches a new existing action to a source object, if possible.
  *
  * The action will not do anything until it is LINKed.  This is the 
- * implementation of @action.
+ * implementation of \@action.
  *
  * Action names must pass ok_object_name.
  *
@@ -875,7 +875,7 @@ do_action(int descr, dbref player, const char *action_name,
 /**
  * This routine attaches a previously existing action to a source object.
  * The action will not do anything unless it is LINKed.  This is the
- * implementation of @attach
+ * implementation of \@attach
  *
  * Does all the permission checking associated except for the builder bit.
  * Will reset the priority level if there is is a priority set.
@@ -931,7 +931,7 @@ do_attach(int descr, dbref player, const char *action_name, const char *source_n
 }
 
 /**
- * Implementation of @recycle command
+ * Implementation of \@recycle command
  *
  * This is a wrapper around 'recycle', but it does a lot of additional
  * permission checks.  For instance, in order to recycle an object or

--- a/src/db.c
+++ b/src/db.c
@@ -549,8 +549,8 @@ getref(FILE * f)
 /**
  * Get a string from the given file handle
  *
- * The string is read until a \n is encountered or until the buffer runs
- * out; anything over BUFFER_LEN -1 is discarded til the next \n is found.
+ * The string is read until a \\n is encountered or until the buffer runs
+ * out; anything over BUFFER_LEN -1 is discarded til the next \\n is found.
  *
  * Empty strings are supported and will be returned.  New memory is
  * allocated for the string that is returned.
@@ -1063,7 +1063,7 @@ db_read_object(FILE * f, dbref objno)
  * This autostarts by scanning the entire DB and compiling the ABODE
  * programs.  Compile will automatically queue up the programs.
  *
- * @static
+ * @private
  */
 static void
 autostart_progs(void)

--- a/src/edit.c
+++ b/src/edit.c
@@ -1363,7 +1363,7 @@ write_program(struct line *first, dbref i)
 }
 
 /**
- * Implementation of the @list command
+ * Implementation of the \@list command
  *
  * This includes all permission checking around whether someone can
  * list the program, and checking to make sure that 'name' is a program.
@@ -1556,7 +1556,7 @@ macrodump(struct macrotable *node, FILE * f)
 /**
  * Fetch the next line from a given file handle
  *
- * This cleans off trailing \n and \r if applicable.  Returns an allocated
+ * This cleans off trailing \\n and \\r if applicable.  Returns an allocated
  * string copy -- the caller must free the memory.
  *
  * @private

--- a/src/fbmath.c
+++ b/src/fbmath.c
@@ -28,7 +28,7 @@
 double
 _int_f_rand(void)
 {
-    return ((double)rand() / (double)RAND_MAX);
+    return (rand() / (double)RAND_MAX);
 }
 
 /**

--- a/src/fbsignal.c
+++ b/src/fbsignal.c
@@ -23,26 +23,26 @@
 #ifndef WIN32
 
 /*
- * Function prototypes
- *
- * @TODO remove set_signals(void) because it is declared in fbsignal.h
- *       I believe the rest of these are needed because they are signal
- *       callbacks?  Normally you don't need prototypes for local functions.
- *       That's probably why these aren't static as well.
+ * Function prototypes for signal callbacks
  *
  * See definitions for doc blocks.
  */
-void set_signals(void);
-void bailout(int);
-void sig_dump_status(int i);
-void sig_shutdown(int i);
-void sig_reconfigure(int i);
+#if defined(__GNUC__) || defined(__clang__)
+static void bailout(int) __attribute__((noreturn));
+#else
+static void bailout(int);
+#endif
+
+static void sig_dump_status(int i);
+static void sig_shutdown(int i);
+static void sig_reconfigure(int i);
+
 #ifdef SIGEMERG
-void sig_emerg(int i);
+static void sig_emerg(int i);
 #endif
 
 #ifdef SPAWN_HOST_RESOLVER
-void sig_reap(int i);
+static void sig_reap(int i);
 #endif
 
 #ifdef HAVE_PSELECT

--- a/src/game.c
+++ b/src/game.c
@@ -123,7 +123,7 @@ FILE *input_file;
 static char *in_filename = NULL;
 
 /**
- * Implementation of the @dump command
+ * Implementation of the \@dump command
  *
  * This does NOT do any permission checking, except for a GOD_PRIV check
  * if a newfile is provided.
@@ -166,7 +166,7 @@ do_dump(dbref player, const char *newfile)
 }
 
 /**
- * Implementation of @shutdown command
+ * Implementation of \@shutdown command
  *
  * Permissions are checked and non-wizard players are logged.  This will
  * trigger the MUCK to shut itself down  The implementation of this
@@ -192,7 +192,7 @@ do_shutdown(dbref player)
 
 #ifdef USE_SSL
 /**
- * Implementation of @reconfiguressl
+ * Implementation of \@reconfiguressl
  *
  * This is a simple wrapper around the reconfigure_ssl call.  This does
  * not do any permission checking.
@@ -213,7 +213,7 @@ do_reconfigure_ssl(dbref player)
 #endif
 
 /**
- * Implementation of the @restart command
+ * Implementation of the \@restart command
  *
  * Permissions are checked and non-wizard players are logged.  This will
  * trigger the MUCK to try and restart itself.  The implementation of this
@@ -496,7 +496,7 @@ cleanup_game()
 #endif
 
 /**
- * Implementation of @restrict command
+ * Implementation of \@restrict command
  *
  * This does not do any permission checking.  Arg can be either "on" to
  * turn on wiz-only mode, "off" to turn it off, or anything else (such
@@ -537,7 +537,7 @@ process_command(int descr, dbref player, const char *command)
 {
     char *arg1;
     char *arg2;
-    char *full_command;
+    char *full_command = NULL;
     char pbuf[BUFFER_LEN];
     char xbuf[BUFFER_LEN];
     char ybuf[BUFFER_LEN];

--- a/src/help.c
+++ b/src/help.c
@@ -500,7 +500,7 @@ do_info(dbref player, const char *topic, const char *seg)
 }
 
 /**
- * Implementation of @credits
+ * Implementation of \@credits
  *
  * Just spits a credits file (tp_file_credits) out to the player.
  *

--- a/src/interface.c
+++ b/src/interface.c
@@ -355,6 +355,10 @@ short wizonly_mode = 0;
  * @private
  * @param prog the string name of the program (argv[0] usually)
  */
+#if defined(__GNUC__) || defined(__clang__)
+static void show_program_usage(char *prog) __attribute((noreturn));
+#endif
+
 static void
 show_program_usage(char *prog)
 {
@@ -547,7 +551,7 @@ make_text_block(const char *s, size_t n)
  * @param b the message
  * @param n the number of bytes from message to allocate and copy
  */
-void
+static void
 add_to_queue(struct text_queue *q, const char *b, size_t n)
 {
     struct text_block *p;
@@ -1837,7 +1841,7 @@ check_connect(struct descriptor_data *d, const char *msg)
  *
  * @see mcp_frame_process_input
  *
- * This processes certain built-in 'special' commands; @Q (BREAK_COMMAND),
+ * This processes certain built-in 'special' commands; \@Q (BREAK_COMMAND),
  * QUIT, and WHO.  Then it hands off to process_command or check_connect
  * based on if you're connected or not.
  *
@@ -1923,7 +1927,7 @@ do_command(struct descriptor_data *d, char *command)
 /**
  * Check if 'cmd' is one of the special commands handled in interface.c
  *
- * This checks for certain built-in 'special' commands; @Q (BREAK_COMMAND),
+ * This checks for certain built-in 'special' commands; \@Q (BREAK_COMMAND),
  * QUIT (QUIT_COMMAND), and WHO (WHO_COMMAND).  Also checks for
  * MCP message prefix.
  *
@@ -3844,7 +3848,7 @@ spawn_resolver(void)
  * The resolver returns host information one per line.  The host information
  * looks like:
  *
- * hostip(port)|hostname(user)\n
+ * hostip(port)|hostname(user)\\n
  *
  * Once we get a line from the resolver, we iterate over the descriptor
  * list and use hostip + port to set the hostname + user on the descriptor
@@ -5347,7 +5351,6 @@ do_armageddon(dbref player, const char *msg)
     exit(ARMAGEDDON_EXIT_CODE);
 }
 
-
 /**
  * "Panic" the MUCK, which shuts it down with a message.
  *
@@ -5360,6 +5363,10 @@ do_armageddon(dbref player, const char *msg)
  *
  * @param message the message to show in the log
  */
+#if defined(__GNUC__) || defined(__clang__)
+void panic(const char *message) __attribute__((noreturn));
+#endif
+
 void
 panic(const char *message)
 {
@@ -6525,7 +6532,7 @@ ignore_is_ignoring_sub(dbref Player, dbref Who)
  * @param Who the player to check to see if being ignored.
  * @return boolean true if Player is ignoring Who
  */
-inline int
+int
 ignore_is_ignoring(dbref Player, dbref Who)
 {
     return ignore_is_ignoring_sub(Player, Who) || (tp_ignore_bidirectional

--- a/src/look.c
+++ b/src/look.c
@@ -1061,7 +1061,7 @@ do_inventory(dbref player)
 /**
  * Initialize the checkflags search system
  *
- * This is the underpinning of @find, @owned, @entrance, and a few
+ * This is the underpinning of \@find, \@owned, \@entrances, and a few
  * other similar calls.  It parses over a set of 'flags' to consider,
  * and loads the struct 'check' with the necessary filter paramters.
  *
@@ -1492,7 +1492,7 @@ checkflags(dbref what, struct flgchkdat check)
 /**
  * Display an object using output_type
  *
- * This is used as a helper for @find to output a found object to the
+ * This is used as a helper for \@find to output a found object to the
  * user using their output_type preference.  For output_types, see
  * init_checkflags
  *
@@ -1580,7 +1580,7 @@ display_objinfo(dbref player, dbref obj, int output_type)
 }
 
 /**
- * Implementation of @find command
+ * Implementation of \@find command
  *
  * This implements the find command, which is powered by
  * checkflags.  See that function for full details of how flags work.
@@ -1589,7 +1589,7 @@ display_objinfo(dbref player, dbref obj, int output_type)
  *
  * Takes a search string to look for, and iterates over the entire
  * database to find it.  There is an option to charge players for
- * @find's, probably since this is kind of nasty on the DB.
+ * \@find's, probably since this is kind of nasty on the DB.
  *
  * @param player the player doing the find
  * @param name the search criteria
@@ -1627,12 +1627,12 @@ do_find(dbref player, const char *name, const char *flags)
 }
 
 /**
- * Implementation of @owned command
+ * Implementation of \@owned command
  *
  * Like do_find, this is underpinned by the checkflags system.
  * For details of how the flags work, see init_checkflags
  *
- * This does do permission checks.  Like @find, it iterates over the
+ * This does do permission checks.  Like \@find, it iterates over the
  * entire database and supports a lookup cost.
  *
  * @see init_checkflags
@@ -1714,9 +1714,9 @@ do_trace(int descr, dbref player, const char *name, int depth)
 }
 
 /**
- * Implementation of the @entrances command
+ * Implementation of the \@entrances command
  *
- * This supports the same sort of flag searches that @find does,
+ * This supports the same sort of flag searches that \@find does,
  * except it searches for exits on the given object (which defaults to here)
  *
  * Under the hood, this uses the checkflags series of methods.
@@ -1810,7 +1810,7 @@ do_entrances(int descr, dbref player, const char *name, const char *flags)
 /**
  * Implementation of @contents
  *
- * This searches the contents of a given object, similar to the way @find
+ * This searches the contents of a given object, similar to the way \@find
  * works except confined to a certain object.  It supports a similar
  * syntax.  If 'name' is not provided, defaults to here.  'flags' can have
  * types and also an output type.

--- a/src/mcp.c
+++ b/src/mcp.c
@@ -2069,9 +2069,9 @@ mcpedit_program(int descr, dbref player, dbref program)
 }
 
 /**
- * Implementation of @mcpedit command
+ * Implementation of \@mcpedit command
  *
- * The MCP-enabled version of @edit.  The underlying call to the private
+ * The MCP-enabled version of \@edit.  The underlying call to the private
  * function mcpedit_program does check permissions.  This is a wrapper to
  * do object matching.  If MCP is not supported by the client, it enters
  * the regular editor.
@@ -2111,9 +2111,9 @@ do_mcpedit(int descr, dbref player, const char *name)
 }
 
 /**
- * Implementation of @mcpprogram command
+ * Implementation of \@mcpprogram command
  *
- * The MCP-enabled version of @program.  It creates the program and then
+ * The MCP-enabled version of \@program.  It creates the program and then
  * hands off to the private function mcpedit_program to start editing.
  * It does NOT check to see if the user has a MUCKER bit, so do not rely
  * on this for permission checking.
@@ -2169,7 +2169,7 @@ do_mcpprogram(int descr, dbref player, const char *name, const char *rname)
             register_object(player, player, REGISTRATION_PROPDIR, (char *)rname, program);
         }
     } else if (program == AMBIGUOUS) {
-        notifyf_nolisten(player, match_msg_ambiguous(name));
+        notify_nolisten(player, match_msg_ambiguous(name), 1);
         return;
     }
 

--- a/src/mfuns2.c
+++ b/src/mfuns2.c
@@ -734,7 +734,7 @@ mfn_fullname(MFUNARGS)
  *
  * @private
  * @param list the string to count items in
- * @param sep the separator to use (usually \r)
+ * @param sep the separator to use (usually \\r)
  * @return integer count of items or 0 if list is empty/NULL.
  */
 static int
@@ -776,7 +776,7 @@ countlitems(char *list, char *sep)
  * @param buf the buffer to put the result into
  * @param buflen the size of buf
  * @param list the list to search within
- * @param sep the separator, usually "\n"
+ * @param sep the separator, usually "\\n"
  * @param line the item number in the list.
  * @return a pointer to 'buf'
  */

--- a/src/p_mcp.c
+++ b/src/p_mcp.c
@@ -1536,7 +1536,6 @@ prim_gui_value_set(PRIM_PROTOTYPE)
 
                 free(valarray);
                 abort_interp("Dictionary-style array where list value expected. (3)");
-                break;
             }
 
             switch (temp2->type) {

--- a/src/player.c
+++ b/src/player.c
@@ -279,7 +279,7 @@ toad_player(int descr, dbref player, dbref victim, dbref recipient)
 }
 
 /**
- * Implementation of @password command
+ * Implementation of \@password command
  *
  * This changes the player's password after doing some validation checks.
  * Old password must be valid and new password must not have spaces in it.

--- a/src/property.c
+++ b/src/property.c
@@ -1817,7 +1817,7 @@ db_putprop(FILE * f, const char *dir, PropPtr p)
             ptr2 = intostr(PropDataVal(p));
             break;
         case PROP_FLTTYP:
-            if (!PropDataFVal(p))
+            if (PropDataFVal(p) == 0.0)
                 return;
             snprintf(tbuf, sizeof(tbuf), "%.17g", PropDataFVal(p));
             ptr2 = tbuf;

--- a/src/sanity.c
+++ b/src/sanity.c
@@ -172,7 +172,7 @@ SanPrintObject(dbref player, const char *prefix, dbref ref)
 }
 
 /**
- * This is the implementation of the @examine command
+ * This is the implementation of the \@examine command
  *
  * Specifically, this command examines the "sanity" or data integrity of
  * the given object or "here" if no object is provided.  There is NO
@@ -783,7 +783,7 @@ check_object(dbref player, dbref obj)
 }
 
 /**
- * Implementation of the @sanity command
+ * Implementation of the \@sanity command
  *
  * This does sanity checks on the entire database.  This is pretty compute
  * intensive as it crawls through everything.  No permission checks are done
@@ -1519,7 +1519,7 @@ clean_global_environment(void)
 }
 
 /**
- * Implementation of @sanfix command
+ * Implementation of \@sanfix command
  *
  * This does a sanity check, and tries to repair any problems it finds.
  * Theoretically there are problems this can't fix.  do_sanity does sort
@@ -1596,7 +1596,7 @@ static char cbuf[1000];
 static char buf2[1000];
 
 /**
- * Implementation of @sanchange command
+ * Implementation of \@sanchange command
  *
  * This enables the manual editing of database object fields in a very
  * raw fashion.  It is truly a bad idea to mess with as this can cause

--- a/src/set.c
+++ b/src/set.c
@@ -28,7 +28,7 @@
 #include "tune.h"
 
 /**
- * Implementation of the @name command
+ * Implementation of the \@name command
  *
  * This performs a name change for a given 'name' to 'newname'
  *
@@ -117,7 +117,7 @@ do_name(int descr, dbref player, const char *name, char *newname)
  * to its owner.  If this is a player, its home will be reset to player start.
  *
  * If quiet is true, only errors will be displayed and no other messaging.
- * Otherwise, full messaging as expected with @unlink will be used.
+ * Otherwise, full messaging as expected with \@unlink will be used.
  *
  * This does do permission checking.
  *
@@ -207,7 +207,7 @@ _do_unlink(int descr, dbref player, const char *name, bool quiet)
 }
 
 /**
- * Implementation of @unlink command
+ * Implementation of \@unlink command
  *
  * This is a thin wrapper around _do_unlink (a private function) that does
  * all the logic.  As it is a private function, the documentation will
@@ -233,7 +233,7 @@ do_unlink(int descr, dbref player, const char *name)
 }
 
 /**
- * Implementation of @relink command
+ * Implementation of \@relink command
  *
  * This is basically the same as doing an @unlink followed by an @link.
  * Thus the details of what that entails is best described in those functions.
@@ -375,7 +375,7 @@ do_relink(int descr, dbref player, const char *thing_name,
 }
 
 /**
- * Implementation of the @chown command
+ * Implementation of the \@chown command
  *
  * This handles all the security aspects of the @chown command, including
  * the various weird details.  Such as THINGs must be held by the person
@@ -663,7 +663,7 @@ restricted(dbref player, dbref thing, object_flag_type flag)
 }
 
 /**
- * Implementation of @set command
+ * Implementation of \@set command
  *
  * This can set flags or props.  The determining factor is if there is
  * a PROP_DELIMITER (:) character in the 'flag' string.  The special
@@ -988,7 +988,7 @@ do_set(int descr, dbref player, const char *name, const char *flag)
 }
 
 /**
- * Implementation of @propset
+ * Implementation of \@propset
  *
  * Propset can set props along with types.  'prop' can be of the
  * format: <type>:<property>:<value> or erase:<property>
@@ -1123,7 +1123,7 @@ do_propset(int descr, dbref player, const char *name, const char *prop)
 }
 
 /**
- * Implementation of @register command
+ * Implementation of \@register command
  *
  * Does property registration similar to the 'classic' MUF @register
  * command.  Thus, the parameters are a little complex.
@@ -1338,7 +1338,7 @@ do_register(int descr, dbref player, char *arg1, const char *arg2)
 }
 
 /**
- * Implemenation of @doing command
+ * Implemenation of \@doing command
  *
  * This, at present, only allows you to to set a doing message on
  * 'me' or you can leave 'name' as an empty string.
@@ -1365,7 +1365,7 @@ do_doing(int descr, dbref player, const char *name, const char *mesg)
 
 
 /**
- * Implementation of @unlock command
+ * Implementation of \@unlock command
  *
  * Unlocks a given object.  This does do permission checks.
  *

--- a/src/speech.c
+++ b/src/speech.c
@@ -104,7 +104,7 @@ do_pose(dbref player, const char *message)
 }
 
 /**
- * Implementation of @wall command
+ * Implementation of \@wall command
  *
  * This broadcasts a message to everyone on the MUCK, as a "shout"
  * using a format similar to "say".  This does NOT do permission

--- a/src/timequeue.c
+++ b/src/timequeue.c
@@ -1130,7 +1130,7 @@ has_refs(dbref program, timequeue ptr)
 }
 
 /**
- * Implementation of the @ps command
+ * Implementation of the \@ps command
  *
  * Shows running timequeue / process information to the given player.
  * Permission checking is done; wizards can see all processes, but players
@@ -1728,7 +1728,7 @@ dequeue_timers(int pid, char *id)
 }
 
 /**
- * Implementation of @kill command
+ * Implementation of \@kill command
  *
  * Kills a process or set of processes off the time queue.  "arg1" can
  * be either a process ID, a player name to kill all of a player's processs,

--- a/src/tune.c
+++ b/src/tune.c
@@ -1,6 +1,6 @@
 /** @file tune.c
  *
- * Source defining the functions that support the @tune function and
+ * Source defining the functions that support the \@tune function and
  * dealing with tunable configuration parameters.
  *
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
@@ -640,7 +640,7 @@ tune_load_parms_from_file(FILE * f, dbref player, int cnt)
 }
 
 /**
- * Implementation of @tune command
+ * Implementation of \@tune command
  *
  * This does a lot of different things based on if 'parmname' and
  * 'parmval' are set and to what.
@@ -658,7 +658,7 @@ tune_load_parms_from_file(FILE * f, dbref player, int cnt)
  * If the parmname is "save" or "load", it will save or load parameters
  * from file accordingly.
  *
- * Otherwise, parmname should be either "" to list all @tunes or
+ * Otherwise, parmname should be either "" to list all \@tunes or
  * a simple regex can be used to show only certain parameters.
  *
  * The parmname "info" will display more detained tune information.

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -33,9 +33,9 @@
 #include "tune.h"
 
 /**
- * Implementation of the @teleport command
+ * Implementation of the \@teleport command
  *
- * This is the MUCK's @teleport command.  It does do permission checking
+ * This is the MUCK's \@teleport command.  It does do permission checking
  * and sometimes that gets pretty detailed -- the rules for teleporting
  * different things vary slightly.  However, in general, the player must
  * control both the object to be teleported and the destination -- or
@@ -301,7 +301,7 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
 }
 
 /**
- * The wildcard implementation that underpins @bless (do_bless) and @unbless
+ * The wildcard implementation that underpins \@bless and \@unbless
  *
  * @see do_bless
  * @see do_unbless
@@ -410,7 +410,7 @@ blessprops_wildcard(dbref player, dbref thing, const char *dir,
 }
 
 /**
- * Implementation of the @unbless command
+ * Implementation of the \@unbless command
  *
  * This does not handle basic permission checking.  The propname can have
  * wildcards in it.
@@ -448,7 +448,7 @@ do_unbless(int descr, dbref player, const char *what, const char *propname)
 }
 
 /**
- * Implementation of the @bless command
+ * Implementation of the \@bless command
  *
  * This does not handle basic permission checking.  The propname can have
  * wildcards in it.
@@ -494,7 +494,7 @@ do_bless(int descr, dbref player, const char *what, const char *propname)
 }
 
 /**
- * The implementation of the @force command
+ * The implementation of the \@force command
  *
  * This uses the global 'force_level' to keep track of how many
  * layers of force calls are in play.  That makes this not threadsafe,
@@ -624,7 +624,7 @@ do_force(int descr, dbref player, const char *what, char *command)
 }
 
 /**
- * Implementation of the @stats command
+ * Implementation of the \@stats command
  *
  * This displays stats on what is in the database, optionally showing
  * stats on what a given player owns.
@@ -805,7 +805,7 @@ do_stats(dbref player, const char *name)
 }
 
 /**
- * Implementation of the @boot command
+ * Implementation of the \@boot command
  *
  * WARNING: This call does NOT check to see if 'player' is a wizard.
  *
@@ -862,7 +862,7 @@ do_boot(dbref player, const char *name)
 }
 
 /**
- * Implementation of the @toad command
+ * Implementation of the \@toad command
  *
  * Toading is the deletion of a player.  This is a wrapper around
  * toad_player, so the mechanics of toading are in that call.
@@ -948,7 +948,7 @@ do_toad(int descr, dbref player, const char *name, const char *recip)
 }
 
 /**
- * Implements the @newpassword command
+ * Implements the \@newpassword command
  *
  * Changes the password to 'password' on a given player 'name'.
  *
@@ -993,7 +993,7 @@ do_newpassword(dbref player, const char *name, const char *password)
 }
 
 /**
- * Implements the @pcreate command
+ * Implements the \@pcreate command
  *
  * Creates a player.  This is an incredibly thin wrapper around create_player;
  * in fact, this does no permission checks or any other kind of check.
@@ -1021,7 +1021,7 @@ do_pcreate(dbref player, const char *user, const char *password)
 
 #ifndef NO_USAGE_COMMAND
 /**
- * Implementation of the @usage command
+ * Implementation of the \@usage command
  *
  * This gives a bunch of information about the FuzzBall MUCK process.
  * Back in "the day" a lot of this information was not available on
@@ -1076,7 +1076,7 @@ do_usage(dbref player)
  */
 
 /**
- * Implementation of the @muftops command
+ * Implementation of the \@muftops command
  *
  * This shows statistics about programs that have been running.  These
  * statistics are shown for top 'arg1' number of programs.  The default
@@ -1209,7 +1209,7 @@ do_muf_topprofs(dbref player, char *arg1)
 }
 
 /**
- * Implementation of the @mpitops command
+ * Implementation of the \@mpitops command
  *
  * This shows statistics about programs that have been running.  These
  * statistics are shown for top 'arg1' number of programs.  The default
@@ -1332,7 +1332,7 @@ do_mpi_topprofs(dbref player, char *arg1)
 }
 
 /**
- * Implementation of the @tops command
+ * Implementation of the \@tops command
  *
  * This shows statistics about programs that have been running.  These
  * statistics are shown for top 'arg1' number of programs.  The default
@@ -1526,7 +1526,7 @@ do_topprofs(dbref player, char *arg1)
 
 #ifndef NO_MEMORY_COMMAND
 /**
- * Implementation of @memory command
+ * Implementation of \@memory command
  *
  * This displays memory information to the calling user.  Note that it
  * does not do any permission checkings.
@@ -1583,7 +1583,7 @@ do_memory(dbref who)
 #endif      /* NO_MEMORY_COMMAND */
 
 /**
- * Implementation of @debug command
+ * Implementation of \@debug command
  *
  * This only applies to DISKBASE (at the moment), and only works if
  * the argument "display propcache" is displayed.  Under the hood,
@@ -1763,16 +1763,16 @@ base64_send(struct descriptor_data* descr, FILE* in)
 }
 
 /**
- * Implementation of @teledump command
+ * Implementation of \@teledump command
  *
- * @teledump does a base64 encoded dump of the entire database and the
+ * \@teledump does a base64 encoded dump of the entire database and the
  * associated macros and MUF in a fashion that can be consumed by an unpacker
  * script (a python unpacker will be provided as part of this).
  *
  * It is a way to preserve the vital data of a MUCK but it does not
  * send over irrelevant files.
  *
- * For simplicity sake, it dumps the DB on disk, so @dump before running
+ * For simplicity sake, it dumps the DB on disk, so \@dump before running
  * this command to get the latest.
  *
  * @param descr the player's descriptor


### PR DESCRIPTION
- bad-function-cast
- conditional-uninitialized
- documentation-unknown-command (*)
- float-conversion
- format-security
- missing-noreturn
- missing-prototypes
- newline-eof
- static-in-inline
- unreachable-code-break

(*) Warnings addressed were related to @-commands in docblocks.