### PR TITLE
Promote some variables to const, reduce instances of casting.

### DIFF
--- a/include/array.h
+++ b/include/array.h
@@ -206,7 +206,7 @@ void array_free(stk_array *arr);
  * @param key the key to fetch
  * @return string value or NULL if not a string value (or not found)
  */
-char *array_get_intkey_strval(stk_array *arr, int key);
+const char *array_get_intkey_strval(stk_array *arr, int key);
 
 /**
  * Fetch an item from the given array.
@@ -266,7 +266,7 @@ stk_array *array_getrange(stk_array *arr, array_iter *start, array_iter *end, in
  * @param case_sens Case sensitive compare for strings?
  * @return similar to strcmp; 0 is equal, negative is A < B, positive is A > B
  */
-int array_tree_compare(array_iter * a, array_iter * b, int case_sens);
+int array_tree_compare(const array_iter * a, const array_iter * b, int case_sens);
 
 /**
  * Insert an item into the given array at the given index.

--- a/include/commands.h
+++ b/include/commands.h
@@ -539,7 +539,7 @@ void do_gripe(dbref player, const char *message);
  * @param topic the topic the player is looking up or ""
  * @param segment the range of lines to view - only works for subfiles
  */
-void do_helpfile(dbref player, const char *dir, const char *file, char *topic, char *segment);
+void do_helpfile(dbref player, const char *dir, const char *file, const char *topic, const char *segment);
 
 /*
  * I
@@ -969,10 +969,10 @@ void do_password(dbref player, const char *old, const char *newobj);
  * @see create_player
  *
  * @param player the player running the command
- * @param arg1 the user to create
- * @param arg2 the password to set on the new user.
+ * @param user the user to create
+ * @param pass the password to set on the new user.
  */
-void do_pcreate(dbref player, const char *arg1, const char *arg2);
+void do_pcreate(dbref player, const char *user, const char *pass);
 
 /**
  * Implementation of pose command

--- a/include/db.h
+++ b/include/db.h
@@ -836,8 +836,7 @@ struct program_specific {
  * @param x the program to initialize a program specific structure for
  */
 #define ALLOC_PROGRAM_SP(x)     { \
-    PROGRAM_SP(x) = \
-        (struct program_specific *)malloc(sizeof(struct program_specific)); \
+    PROGRAM_SP(x) = malloc(sizeof(struct program_specific)); \
 }
 
 /**
@@ -1321,8 +1320,7 @@ struct player_specific {
  * @param x the thing to initialize a thing specific structure for
  */
 #define ALLOC_THING_SP(x)       { \
-    PLAYER_SP(x) = \
-        (struct player_specific *)malloc(sizeof(struct player_specific)); \
+    PLAYER_SP(x) = malloc(sizeof(struct player_specific)); \
 }
 
 /**
@@ -1392,8 +1390,7 @@ struct player_specific {
  * @param x the thing to initialize a player specific structure for
  */
 #define ALLOC_PLAYER_SP(x)      { \
-    PLAYER_SP(x) = \
-        (struct player_specific *)malloc(sizeof(struct player_specific)); \
+    PLAYER_SP(x) = malloc(sizeof(struct player_specific)); \
     memset(PLAYER_SP(x),0,sizeof(struct player_specific)); \
 }
 

--- a/include/fbstrings.h
+++ b/include/fbstrings.h
@@ -113,8 +113,7 @@ char *cr2slash(char *buf, int buflen, const char *in);
  *
  * @return See description - string or NULL
  */
-const char *exit_prefix(register const char *string,
-                        register const char *prefix);
+const char *exit_prefix(const char *string, const char *prefix);
 
 /**
  * This is a POSIX-style regex implementation.  I'm not sure why a standard
@@ -171,7 +170,7 @@ const char *exit_prefix(register const char *string,
  * @param t The string to match to the pattern
  * @return 1 if matched, 0 if not.
  */
-int equalstr(char *s, char *t);
+int equalstr(char *s, const char *t);
 
 /**
  * Checks to see if string s contains a float of format:
@@ -389,7 +388,7 @@ char *ref2str(dbref obj, char *buf, size_t buflen);
 void remove_ending_whitespace(char **s);
 
 /**
- * Skip over starting whitespaces in a string
+ * Skip over starting whitespaces in a constant string
  *
  * Note that this does not technically "trim" spaces; instead, it advances
  * the provided pointer to the first non-space (or to the end of the string
@@ -398,6 +397,17 @@ void remove_ending_whitespace(char **s);
  * @param parsebuf pointer to a string pointer.
  */
 void skip_whitespace(const char **parsebuf);
+
+/**
+ * Skip over starting whitespaces in a variable string
+ *
+ * Note that this does not technically "trim" spaces; instead, it advances
+ * the provided pointer to the first non-space (or to the end of the string
+ * as the case may be).
+ *
+ * @param parsebuf pointer to a string pointer.
+ */
+void skip_whitespace_var(char **parsebuf);
 
 /**
  * This is an implementation of strncat that takes the buffer size instead

--- a/include/fbtime.h
+++ b/include/fbtime.h
@@ -172,7 +172,7 @@ void ts_useobject(dbref thing);
  * @param error the error message, if any
  * @return the time in seconds
  */
-time_t time_string_to_seconds(char *string, char *format, char **error);
+time_t time_string_to_seconds(char *string, const char *format, const char **error);
 #endif
 
 /**

--- a/include/interface.h
+++ b/include/interface.h
@@ -591,7 +591,7 @@ int notify_nolisten(dbref player, const char *msg, int isprivate);
  * @param format the format string
  * @param ... as many arguments as necessary
  */
-void notifyf(dbref player, char *format, ...)
+void notifyf(dbref player, const char *format, ...)
 #if defined(__GNUC__) || defined(__clang__)
     /* let GCC and clang know that we use a printf-style format string
        so they can give better warnings/errors */
@@ -612,7 +612,7 @@ void notifyf(dbref player, char *format, ...)
  * @param format the format string
  * @param ... as many arguments as necessary.
  */
-void notifyf_nolisten(dbref player, char *format, ...)
+void notifyf_nolisten(dbref player, const char *format, ...)
 #if defined(__GNUC__) || defined(__clang__)
     /* let GCC and clang know that we use a printf-style format string
        so they can give better warnings/errors */

--- a/include/interp.h
+++ b/include/interp.h
@@ -34,7 +34,7 @@
  * @param file the file from which this function was called.
  * @param line the line in the file from which this function was called.
  */
-void RCLEAR(struct inst *oper, char *file, int line);
+void RCLEAR(struct inst *oper, const char *file, int line);
 
 /**
  * This is a wrapper around RCLEAR to automatically inject file and line
@@ -772,8 +772,8 @@ char *debug_inst(struct frame * fr, int lev, struct inst * pc, int pid,
 void do_abort_interp(dbref player, const char *msg, struct inst *pc,
                      struct inst *arg, int atop, struct frame *fr,
                      struct inst *oper1, struct inst *oper2, struct inst *oper3,
-                     struct inst *oper4, int nargs, dbref program, char *file,
-                     int line);
+                     struct inst *oper4, int nargs, dbref program,
+                     const char *file, int line);
 
 /**
  * Silently abort the interpreter loop.

--- a/include/log.h
+++ b/include/log.h
@@ -19,7 +19,7 @@
  * @param format the format string with sprinf-style replacements
  * @param ... whatever sprintf replacement variables
  */
-void log2file(const char *myfilename, char *format, ...);
+void log2file(const char *myfilename, const char *format, ...);
 
 /**
  * Log to the commands file
@@ -32,7 +32,7 @@ void log2file(const char *myfilename, char *format, ...);
  * @param format the log line to submit
  * @param ... the arguments
  */
-void log_command(char *format, ...);
+void log_command(const char *format, ...);
 
 /**
  * Log to the gripes file
@@ -45,7 +45,7 @@ void log_command(char *format, ...);
  * @param format the log line to submit
  * @param ... the arguments
  */
-void log_gripe(char *format, ...);
+void log_gripe(const char *format, ...);
 
 /**
  * Log to the muf errors file
@@ -58,7 +58,7 @@ void log_gripe(char *format, ...);
  * @param format the log line to submit
  * @param ... the arguments
  */
-void log_muf(char *format, ...);
+void log_muf(const char *format, ...);
 
 /**
  * Log a program's text to the program log file
@@ -85,7 +85,7 @@ void log_program_text(struct line *first, dbref player, dbref i);
  * @param format the log line to submit
  * @param ... the arguments
  */
-void log_sanfix(char *format, ...);
+void log_sanfix(const char *format, ...);
 
 /**
  * Log to the sanity file
@@ -98,7 +98,7 @@ void log_sanfix(char *format, ...);
  * @param format the log line to submit
  * @param ... the arguments
  */
-void log_sanity(char *format, ...);
+void log_sanity(const char *format, ...);
 
 /**
  * Log to the status file
@@ -111,7 +111,7 @@ void log_sanity(char *format, ...);
  * @param format the log line to submit
  * @param ... the arguments
  */
-void log_status(char *format, ...);
+void log_status(const char *format, ...);
 
 /**
  * Log something to the user log file used by USERLOG primitive

--- a/include/mcppkg.h
+++ b/include/mcppkg.h
@@ -74,6 +74,6 @@ void mcppkg_help_request(McpFrame * mfr, McpMesg * msg, McpVer ver, void *contex
  * @param topic the topic to use
  * @param text the text to send
  */
-void show_mcp_error(McpFrame * mfr, char *topic, char *text);
+void show_mcp_error(McpFrame * mfr, const char *topic, const char *text);
 
 #endif /* !MCPPKG_H */

--- a/include/mfun.h
+++ b/include/mfun.h
@@ -2893,7 +2893,7 @@ const char *mfn_xor(MFUNARGS);
  * the return value of the function.
  */
 struct mfun_dat {
-    char *name;                     /**< Function name, all upper case */
+    const char *name;               /**< Function name, all upper case */
     const char *(*mfn) (MFUNARGS);  /**< Function implementation */
     short parsep;                   /**< If true, the arguments will be parsed */
     short postp;                    /**< If true, auto-parse the return value */

--- a/include/mufevent.h
+++ b/include/mufevent.h
@@ -80,7 +80,7 @@ stk_array *get_mufevent_pidinfo(stk_array * nw, int pid, int pinned);
  * @param val the data associated with the event
  * @param exclusive boolean as described above
  */
-void muf_event_add(struct frame *fr, char *event, struct inst *val,
+void muf_event_add(struct frame *fr, const char *event, struct inst *val,
                    int exclusive);
 
 /**
@@ -251,7 +251,6 @@ int muf_event_read_notify(int descr, dbref player, const char *cmd);
  */
 void muf_event_register_specific(
                 dbref player, dbref prog, struct frame *fr, size_t eventcount,
-                char **eventids);
+                const char **eventids);
 
 #endif /* !MUFEVENT_H */
-

--- a/src/array.c
+++ b/src/array.c
@@ -30,9 +30,6 @@
  */
 stk_array_list *stk_array_active_list;
 
-/* See the definition for full comment */
-int array_tree_compare(array_iter * a, array_iter * b, int case_sens);
-
 /* The buckets themselves */
 typedef struct visited_set_bucket_t {
     stk_array *value;                       /* The value in the bucket      */
@@ -251,9 +248,9 @@ static void visited_set_free(visited_set* set) {
     free(set->buckets);
 }
 
-/* See the definition for details about this function */
+/* See the definition for full comment */
 static int
-array_tree_compare_internal(array_iter * a, array_iter * b, int case_sens, visited_set *visited_a, visited_set *visited_b);
+array_tree_compare_internal(const array_iter * a, const array_iter * b, int case_sens, visited_set *visited_a, visited_set *visited_b);
 
 /**
  * Compares two arrays
@@ -274,7 +271,7 @@ array_tree_compare_internal(array_iter * a, array_iter * b, int case_sens, visit
  * @return similar to strcmp; 0 is equal, negative is A < B, positive is A > B
  */
 static int
-array_tree_compare_arrays(array_iter * a, array_iter * b, int case_sens, visited_set *visited_a, visited_set *visited_b)
+array_tree_compare_arrays(const array_iter * a, const array_iter * b, int case_sens, visited_set *visited_a, visited_set *visited_b)
 {
     int more1, more2, res;
     array_iter idx1;
@@ -360,7 +357,7 @@ array_tree_compare_arrays(array_iter * a, array_iter * b, int case_sens, visited
  * @return similar to strcmp; 0 is equal, negative is A < B, positive is A > B
  */
 int
-array_tree_compare(array_iter * a, array_iter * b, int case_sens) {
+array_tree_compare(const array_iter * a, const array_iter * b, int case_sens) {
     visited_set visited_a, visited_b;
     visited_set_empty(&visited_a);
     visited_set_empty(&visited_b);
@@ -395,7 +392,7 @@ array_tree_compare(array_iter * a, array_iter * b, int case_sens) {
  * @return similar to strcmp; 0 is equal, negative is A < B, positive is A > B
  */
 static int
-array_tree_compare_internal(array_iter * a, array_iter * b, int case_sens, visited_set *visited_a, visited_set *visited_b)
+array_tree_compare_internal(const array_iter * a, const array_iter * b, int case_sens, visited_set *visited_a, visited_set *visited_b)
 {
     assert(a != NULL);
     assert(b != NULL);
@@ -435,8 +432,8 @@ array_tree_compare_internal(array_iter * a, array_iter * b, int case_sens, visit
             return -1;
         }
     } else if (a->type == PROG_STRING) {
-        char *astr = DoNullInd(a->data.string);
-        char *bstr = DoNullInd(b->data.string);
+        const char *astr = DoNullInd(a->data.string);
+        const char *bstr = DoNullInd(b->data.string);
 
         if (0 != case_sens) {
             return strcmp(astr, bstr);
@@ -745,8 +742,8 @@ static array_tree *
 array_tree_insert(array_tree ** avl, array_iter * key)
 {
     array_tree *ret;
-    register array_tree *p = *avl;
-    register int cmp;
+    array_tree *p = *avl;
+    int cmp;
     static short balancep;
 
     assert(avl != NULL);
@@ -1620,8 +1617,8 @@ array_setitem(stk_array ** harr, array_iter * idx, array_data * item)
                 /* @TODO : This code looks pretty similar to array_insertitem
                  *         We should probably converge the two.
                  */
-                arr->data.packed = (array_data *)
-                realloc(arr->data.packed, sizeof(array_data) * (size_t)(arr->items + 1));
+                arr->data.packed =
+                        realloc(arr->data.packed, sizeof(array_data) * (size_t)(arr->items + 1));
 
                 if (arr->data.packed == NULL) {
                     fprintf(stderr, "array_setitem(): Out of Memory!");
@@ -1710,8 +1707,8 @@ array_insertitem(stk_array ** harr, array_iter * idx, array_data * item)
                 arr = *harr = array_decouple(arr);
             }
 
-            arr->data.packed = (array_data *)
-            realloc(arr->data.packed, sizeof(array_data) * (size_t)(arr->items + 1));
+            arr->data.packed =
+                    realloc(arr->data.packed, sizeof(array_data) * (size_t)(arr->items + 1));
 
             if (arr->data.packed == NULL) {
                 fprintf(stderr, "array_insertitem(): Out of Memory!");
@@ -2116,8 +2113,7 @@ array_insertrange(stk_array ** harr, array_iter * start, stk_array * inarr)
                 arr = *harr = array_decouple(arr);
             }
 
-            arr->data.packed =
-                (struct inst *)realloc(arr->data.packed,
+            arr->data.packed = realloc(arr->data.packed,
                     sizeof(array_data) * (size_t)(arr->items + inarr->items));
 
             if (arr->data.packed == NULL) {
@@ -2276,8 +2272,8 @@ array_delrange(stk_array ** harr, array_iter * start, array_iter * end)
             totsize = (size_t)((arr->items) ? arr->items : 1);
 
             /* Shrink the packed data area */
-            arr->data.packed = (array_data *)
-            realloc(arr->data.packed, sizeof(array_data) * totsize);
+            arr->data.packed =
+                    realloc(arr->data.packed, sizeof(array_data) * totsize);
 
             if (arr->data.packed == NULL) {
                 fprintf(stderr, "array_delrange(): Out of Memory!");
@@ -2816,7 +2812,7 @@ array_set_intkey_strval(stk_array ** harr, int key, const char *val)
  * @param key the key to fetch
  * @return string value or NULL if not a string value (or not found)
  */
-char *
+const char *
 array_get_intkey_strval(stk_array * arr, int key)
 {
     struct inst ikey;

--- a/src/boolexp.c
+++ b/src/boolexp.c
@@ -619,7 +619,7 @@ parse_boolprop(char *buf)
     char *temp;
 
     x = type;
-    skip_whitespace((const char **)&type);
+    skip_whitespace_var(&type);
 
     /* This means there was no propname */
     if (*type == PROP_DELIMITER) {
@@ -632,10 +632,10 @@ parse_boolprop(char *buf)
      */
     *strval = '\0';
 
-    remove_ending_whitespace((char **)&type);
+    remove_ending_whitespace(&type);
 
     strval++;
-    skip_whitespace((const char **)&strval);
+    skip_whitespace_var(&strval);
 
     /* If there is no value, then we can't make a property node */
     if (!*strval) {
@@ -646,7 +646,7 @@ parse_boolprop(char *buf)
     /* find the end of our prop value.  Note that it is impossible
      * to lock a prop to a value with spaces using this code.
      */
-    for (temp = (char *)strval; !isspace(*temp) && *temp; temp++) ;
+    for (temp = strval; !isspace(*temp) && *temp; temp++) ;
     *temp = '\0';
 
     /* Set up our propnode and boolnode, and then clean up our memory. */

--- a/src/compile.c
+++ b/src/compile.c
@@ -471,11 +471,10 @@ get_address(COMPSTATE * cstat, struct INTERMEDIATE *dest, int offset)
 
     if (cstat->addrcount >= cstat->addrmax) {
         cstat->addrmax += ADDRLIST_ALLOC_CHUNK_SIZE;
-        cstat->addrlist = (struct INTERMEDIATE **)
-                        realloc(cstat->addrlist,
-                                cstat->addrmax * sizeof(struct INTERMEDIATE *));
-        cstat->addroffsets = (int *)
-                    realloc(cstat->addroffsets, cstat->addrmax * sizeof(int));
+        cstat->addrlist = realloc(cstat->addrlist,
+                cstat->addrmax * sizeof(struct INTERMEDIATE *));
+        cstat->addroffsets =
+                realloc(cstat->addroffsets, cstat->addrmax * sizeof(int));
     }
 
     cstat->addrlist[cstat->addrcount] = dest;
@@ -595,7 +594,7 @@ expand_def(COMPSTATE * cstat, const char *defname)
         }
     }
 
-    return (strdup((char *) exp->pval));
+    return (strdup(exp->pval));
 }
 
 /**
@@ -687,7 +686,7 @@ include_defs(COMPSTATE * cstat, dbref i)
         tmpptr = get_property_class(i, dirname);
 
         if (tmpptr && *tmpptr)
-            insert_def(cstat, temp, (char *) tmpptr);
+            insert_def(cstat, temp, tmpptr);
 
         j = next_prop(pptr, j, temp, sizeof(temp));
     }
@@ -3266,10 +3265,10 @@ next_token_raw(COMPSTATE * cstat)
     int i;
 
     if (!cstat->curr_line)
-        return (char *) 0;
+        return NULL;
 
     if (!cstat->next_char)
-        return (char *) 0;
+        return NULL;
 
     skip_whitespace(&cstat->next_char);
 
@@ -3819,7 +3818,7 @@ do_directive(COMPSTATE * cstat, char *direct)
                 struct line *tmpline;
 
                 tmpline = PROGRAM_FIRST(i);
-                PROGRAM_SET_FIRST(i, ((struct line *) read_program(i)));
+                PROGRAM_SET_FIRST(i, read_program(i));
                 do_compile(cstat->descr, OWNER(i), i, 0);
                 free_prog_text(PROGRAM_FIRST(i));
                 PROGRAM_SET_FIRST(i, tmpline);

--- a/src/create.c
+++ b/src/create.c
@@ -70,7 +70,7 @@ do_open(int descr, dbref player, const char *direction, const char *linkto)
     qname = buf2;
     remove_ending_whitespace(&qname);
 
-    skip_whitespace((const char **)&rname);
+    skip_whitespace_var(&rname);
 
     loc = LOCATION(player);
 
@@ -359,7 +359,7 @@ do_dig(int descr, dbref player, const char *name, const char *pname)
     qname = buf;
     remove_ending_whitespace(&qname);
 
-    skip_whitespace((const char **)&rname);
+    skip_whitespace_var(&rname);
     rname = strcpyn(rbuf, sizeof(rbuf), rname);
     qname = strcpyn(qbuf, sizeof(qbuf), qname);
 
@@ -708,7 +708,7 @@ do_create(dbref player, char *name, char *acost)
     qname = buf2;
     remove_ending_whitespace(&qname);
 
-    skip_whitespace((const char **)&rname);
+    skip_whitespace_var(&rname);
 
     cost = atoi(qname);
 
@@ -839,7 +839,7 @@ do_action(int descr, dbref player, const char *action_name,
     qname = buf2;
     remove_ending_whitespace(&qname);
 
-    skip_whitespace((const char **)&rname);
+    skip_whitespace_var(&rname);
 
     if (!ok_object_name(action_name, TYPE_EXIT)) {
         notify(player, "Please specify a valid name for this action.");

--- a/src/db.c
+++ b/src/db.c
@@ -1083,7 +1083,7 @@ autostart_progs(void)
                  * finish compiling.
                  */
                 tmp = PROGRAM_FIRST(i);
-                PROGRAM_SET_FIRST(i, (struct line *) read_program(i));
+                PROGRAM_SET_FIRST(i, read_program(i));
                 do_compile(-1, OWNER(i), i, 0);
                 free_prog_text(PROGRAM_FIRST(i));
                 PROGRAM_SET_FIRST(i, tmp);
@@ -1980,7 +1980,7 @@ _link_exit(int descr, dbref player, dbref exit, char *dest_name,
      * Each iteration of this loop will be a single potential destination.
      */
     while (*dest_name) {
-        skip_whitespace((const char **)&dest_name);
+        skip_whitespace_var(&dest_name);
         p = dest_name;
 
         while (*dest_name && (*dest_name != EXIT_DELIMITER))
@@ -1991,7 +1991,7 @@ _link_exit(int descr, dbref player, dbref exit, char *dest_name,
 
         if (*dest_name) {
             dest_name++;
-            skip_whitespace((const char **)&dest_name);
+            skip_whitespace_var(&dest_name);
         }
 
         /*

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -104,7 +104,7 @@ list_proglines(dbref player, dbref program, struct frame *fr, int start,
     /* Make sure we have the lines of code loaded for display */
     if (!fr->brkpt.proglines || program != fr->brkpt.lastproglisted) {
         free_prog_text(fr->brkpt.proglines);
-        fr->brkpt.proglines = (struct line *) read_program(program);
+        fr->brkpt.proglines = read_program(program);
         fr->brkpt.lastproglisted = program;
     }
 
@@ -302,7 +302,7 @@ unparse_sysreturn(dbref * program, struct inst *pc)
 {
     static char buf[BUFFER_LEN];
     struct inst *ptr;
-    char *fname;
+    const char *fname;
 
     buf[0] = '\0';
     for (ptr = pc; ptr >= PROGRAM_CODE(*program); ptr--) {

--- a/src/edit.c
+++ b/src/edit.c
@@ -79,7 +79,7 @@ macro_expansion(const char *match)
     struct macrotable *node = macrotop;
 
     while (node) {
-        register int value = strcasecmp(match, node->name);
+        int value = strcasecmp(match, node->name);
 
         if (value < 0)
             node = node->left;
@@ -135,7 +135,7 @@ static int
 grow_macro_tree(struct macrotable *node, struct macrotable *newmacro)
 {
     while (node) {
-        register int value = strcasecmp(newmacro->name, node->name);
+        int value = strcasecmp(newmacro->name, node->name);
 
         if (!value)
             return 0;
@@ -932,7 +932,7 @@ list_publics(int descr, dbref player, int arg[], int argc)
             struct line *tmpline;
 
             tmpline = PROGRAM_FIRST(program);
-            PROGRAM_SET_FIRST(program, (struct line *) read_program(program));
+            PROGRAM_SET_FIRST(program, read_program(program));
             do_compile(descr, OWNER(program), program, 0);
             free_prog_text(PROGRAM_FIRST(program));
             PROGRAM_SET_FIRST(program, tmpline);

--- a/src/fbmath.c
+++ b/src/fbmath.c
@@ -139,7 +139,7 @@ struct xMD5Context {
 static void
 xMD5Transform(uint32_t buf[4], uint32_t const in[16])
 {
-    register uint32_t a, b, c, d;
+    uint32_t a, b, c, d;
 
     a = buf[0];
     b = buf[1];
@@ -389,7 +389,7 @@ static void
 Base64Encode(char *outbuf, const void *inbuf, size_t inlen)
 {
     const unsigned char b64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    const unsigned char *inb = (unsigned char *) inbuf;
+    const unsigned char *inb = inbuf;
     unsigned char *out = NULL;
     size_t numb;
     size_t endcnt;

--- a/src/fbsignal.c
+++ b/src/fbsignal.c
@@ -290,7 +290,7 @@ sig_emerg(int i)
  * @param s the message to send
  */
 static void
-wall_status(char *s)
+wall_status(const char *s)
 {
     char buf[BUFFER_LEN];
 

--- a/src/fbstrings.c
+++ b/src/fbstrings.c
@@ -42,7 +42,7 @@ alphanum_compare(const char *t1, const char *s2)
 {
     int n1, n2, cnt1, cnt2;
     const char *u1, *u2;
-    register const char *s1 = t1;
+    const char *s1 = t1;
 
     while (*s1 && tolower(*s1) == tolower(*s2)) {
         s1++;
@@ -117,7 +117,7 @@ alphanum_compare(const char *t1, const char *s2)
  * @return See description - string or NULL
  */
 const char *
-exit_prefix(register const char *string, register const char *prefix)
+exit_prefix(const char *string, const char *prefix)
 {
     const char *p;
     const char *s = string;
@@ -146,7 +146,7 @@ exit_prefix(register const char *string, register const char *prefix)
         skip_whitespace(&s);
     }
 
-    return 0;
+    return NULL;
 }
 
 /**
@@ -160,7 +160,7 @@ exit_prefix(register const char *string, register const char *prefix)
  * @return boolean - true if string starts with prefix.
  */
 int
-string_prefix(register const char *string, register const char *prefix)
+string_prefix(const char *string, const char *prefix)
 {
     while (*string && *prefix && tolower(*string) == tolower(*prefix)) {
         string++;
@@ -189,7 +189,7 @@ string_prefix(register const char *string, register const char *prefix)
  *         location in 'src' where 'sub' starts.
  */
 const char *
-string_match(register const char *src, register const char *sub)
+string_match(const char *src, const char *sub)
 {
     if (*sub != '\0') {
         while (*src) {
@@ -204,7 +204,7 @@ string_match(register const char *src, register const char *sub)
                 src++;
         }
     }
-    return 0;
+    return NULL;
 }
 
 #define GENDER_UNASSIGNED   0x0    /* unassigned - the default */
@@ -557,7 +557,7 @@ char *
 alloc_string(const char *string)
 {
     if (!string || !*string)
-        return 0;
+        return NULL;
 
     return strdup(string);
 }
@@ -585,8 +585,7 @@ alloc_prog_string(const char *s)
         return (NULL);
 
     length = strlen(s);
-    if ((ss = (struct shared_string *)
-        malloc(sizeof(struct shared_string) + length)) == NULL)
+    if ((ss = malloc(sizeof(struct shared_string) + length)) == NULL)
         abort();
 
     ss->links = 1;
@@ -1036,7 +1035,7 @@ prepend_string(char **before, char *start, const char *what)
     if (ptr < start)
         return 0;
 
-    memcpy((void *) ptr, (const void *) what, len);
+    memcpy(ptr, what, len);
     *before = ptr;
     return len;
 }
@@ -1368,8 +1367,8 @@ ifloat(const char *s)
  * @param c the character to find
  * @return a pointer to the position of c in s, or NULL if not found.
  */
-static char *
-cstrchr(char *s, char c)
+static const char *
+cstrchr(const char *s, char c)
 {
     c = tolower(c);
     while (*s && tolower(*s) != c)
@@ -1430,7 +1429,7 @@ estrchr(char *s, char c, char e)
  */
 #define test(x) if (tolower(x) == c1) return truthval
 static int
-cmatch(char *s1, char c1)
+cmatch(const char *s1, char c1)
 {
     int truthval = 0;
 
@@ -1472,7 +1471,7 @@ cmatch(char *s1, char c1)
  * See the definition for smatch for all the details.  It is a rather
  * lengthly comment so I don't want to repeat it here :)
  */
-static int smatch(char *s1, char *s2);
+static int smatch(char *s1, const char *s2);
 
 /**
  * Does a word match as part of the smatch implementation
@@ -1485,13 +1484,13 @@ static int smatch(char *s1, char *s2);
  * @return 0 if matched, 1 if not matched.
  */
 static int
-wmatch(char *wlist, char **s2)
+wmatch(char *wlist, const char **s2)
 {
-    char *matchstr,     /* which word to find             */
-    *strend,            /* end of current word from wlist */
-    *matchbuf,          /* where to find from             */
-    *bufend;            /* end of match buffer            */
-    int result = 1;     /* intermediate result            */
+    char *matchstr;        /* which word to find             */
+    char *strend;          /* end of current word from wlist */
+    const char *matchbuf;  /* where to find from             */
+    char *bufend;          /* end of match buffer            */
+    int result = 1;        /* intermediate result            */
 
     if (!wlist || !*s2)
         return 1;
@@ -1581,9 +1580,10 @@ wmatch(char *wlist, char **s2)
  * @return 0 if matched; otherwise it returns a non-0 number.
  */
 static int
-smatch(char *s1, char *s2)
+smatch(char *s1, const char *s2)
 {
-    char ch, *start = s2;
+    char ch;
+    const char *start = s2;
 
     while (*s1) {
         switch (*s1) {
@@ -1754,7 +1754,7 @@ smatch(char *s1, char *s2)
  * @return 1 if matched, 0 if not.
  */
 int
-equalstr(char *pattern, char *str)
+equalstr(char *pattern, const char *str)
 {
     return !smatch(pattern, str);
 }
@@ -1822,7 +1822,7 @@ char *
 stripspaces(char *s)
 {
     char *ptr = s;
-    skip_whitespace((const char **)&ptr);
+    skip_whitespace_var(&ptr);
     remove_ending_whitespace(&ptr);
     return ptr;
 }
@@ -1937,7 +1937,7 @@ truestr(const char *buf)
 }
 
 /**
- * Skip over starting whitespaces in a string
+ * Skip over starting whitespaces in a constant string
  *
  * Note that this does not technically "trim" spaces; instead, it advances
  * the provided pointer to the first non-space (or to the end of the string
@@ -1947,6 +1947,22 @@ truestr(const char *buf)
  */
 void
 skip_whitespace(const char **parsebuf)
+{
+    while (**parsebuf && isspace(**parsebuf))
+        (*parsebuf)++;
+}
+
+/**
+ * Skip over starting whitespaces in a variable string
+ *
+ * Note that this does not technically "trim" spaces; instead, it advances
+ * the provided pointer to the first non-space (or to the end of the string
+ * as the case may be).
+ *
+ * @param parsebuf pointer to a string pointer.
+ */
+void
+skip_whitespace_var(char **parsebuf)
 {
     while (**parsebuf && isspace(**parsebuf))
         (*parsebuf)++;

--- a/src/fbtime.c
+++ b/src/fbtime.c
@@ -152,7 +152,7 @@ get_tz_offset(void)
 char *
 time_format_1(time_t dt)
 {
-    register struct tm *delta;
+    struct tm *delta;
     static char buf[64];
 
     delta = gmtime((time_t *) & dt);
@@ -184,7 +184,7 @@ time_format_1(time_t dt)
 char *
 time_format_2(time_t dt)
 {
-    register struct tm *delta;
+    struct tm *delta;
     static char buf[64];
 
     delta = gmtime((time_t *) & dt);
@@ -348,7 +348,7 @@ timestr_long(long dtime)
  */
 #ifndef WIN32
 time_t
-time_string_to_seconds(char *string, char *format, char **error)
+time_string_to_seconds(char *string, const char *format, const char **error)
 {
     struct tm otm;
 

--- a/src/game.c
+++ b/src/game.c
@@ -681,7 +681,7 @@ process_command(int descr, dbref player, const char *command)
         strcpyn(match_args, sizeof(match_args), full_command);
         strcpyn(match_cmdname, sizeof(match_cmdname), command);
 
-        skip_whitespace((const char **)&arg1);
+        skip_whitespace_var(&arg1);
 
         /* find end of arg1, start of arg2 */
         for (arg2 = arg1; *arg2 && *arg2 != ARG_DELIMITER; arg2++) ;
@@ -692,7 +692,7 @@ process_command(int descr, dbref player, const char *command)
         char *p = arg1;
         remove_ending_whitespace(&p);
 
-        skip_whitespace((const char **)&arg2);
+        skip_whitespace_var(&arg2);
 
         switch (command[0]) {
             case '@':

--- a/src/hashtab.c
+++ b/src/hashtab.c
@@ -30,7 +30,7 @@
  * @return the hash value as an unsigned integer
  */
 unsigned int
-hash(register const char *s, unsigned int hash_size)
+hash(const char *s, unsigned int hash_size)
 {
     unsigned int hashval;
 
@@ -53,9 +53,9 @@ hash(register const char *s, unsigned int hash_size)
  * @return NULL if not found, otherwise a pointer to the data union
  */
 hash_data *
-find_hash(register const char *s, hash_tab * table, unsigned int size)
+find_hash(const char *s, hash_tab * table, unsigned int size)
 {
-    for (register hash_entry *hp = table[hash(s, size)]; hp != NULL;
+    for (hash_entry *hp = table[hash(s, size)]; hp != NULL;
          hp = hp->next) {
         if (strcasecmp(s, hp->name) == 0) {
             return &(hp->dat); /* found */
@@ -79,10 +79,10 @@ find_hash(register const char *s, hash_tab * table, unsigned int size)
  * @param size the page size of the hash table 
  */
 hash_entry *
-add_hash(register const char *name, hash_data data, hash_tab * table,
+add_hash(const char *name, hash_data data, hash_tab * table,
          unsigned int size)
 {
-    register hash_entry *hp;
+    hash_entry *hp;
     unsigned int hashval;
 
     hashval = hash(name, size);
@@ -144,13 +144,13 @@ add_hash(register const char *name, hash_data data, hash_tab * table,
  * @return 0 on success, -1 if 'name' was not found.
  */
 int
-free_hash(register const char *name, hash_tab * table, unsigned int size)
+free_hash(const char *name, hash_tab * table, unsigned int size)
 {
-    register hash_entry **lp;
+    hash_entry **lp;
 
     lp = &table[hash(name, size)];
 
-    for (register hash_entry *hp = *lp;
+    for (hash_entry *hp = *lp;
          hp != NULL; lp = &(hp->next), hp = hp->next) {
         if (strcasecmp(name, hp->name) == 0) {
             *lp = hp->next; /* got it.  fix the pointers */
@@ -176,10 +176,10 @@ free_hash(register const char *name, hash_tab * table, unsigned int size)
 void
 kill_hash(hash_tab * table, unsigned int size, int freeptrs)
 {
-    register hash_entry *np;
+    hash_entry *np;
 
     for (unsigned int i = 0; i < size; i++) {
-        for (register hash_entry *hp = table[i]; hp != NULL; hp = np) {
+        for (hash_entry *hp = table[i]; hp != NULL; hp = np) {
             np = hp->next; /* Don't dereference the pointer after */
             free((void *) hp->name);
 

--- a/src/help.c
+++ b/src/help.c
@@ -272,7 +272,7 @@ index_file(dbref player, const char *onwhat, const char *file)
  * @param segment the range of lines to view - only works for subfiles
  */
 void
-do_helpfile(dbref player, const char *dir, const char *file, char *topic, char *segment)
+do_helpfile(dbref player, const char *dir, const char *file, const char *topic, const char *segment)
 {
     if ((!*topic || !*segment) && strchr(match_args, ARG_DELIMITER))
         topic = match_args;

--- a/src/interface.c
+++ b/src/interface.c
@@ -2235,7 +2235,7 @@ queue_immediate_and_flush(struct descriptor_data *d, const char *msg)
         queue_immediate_raw(d, MCP_QUOTE_PREFIX);
     }
 
-    queue_immediate_raw(d, (const char *) buf);
+    queue_immediate_raw(d, buf);
     process_output(d);
 }
 
@@ -2689,27 +2689,27 @@ make_socket_v6(int port)
     /* Set all the different socket options */
     opt = 1;
 
-    if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *) &opt, sizeof(opt)) < 0) {
+    if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
         perror("setsockopt(SO_REUSEADDR)");
         exit(1);
     }
 
     opt = 1;
 
-    if (setsockopt(s, SOL_SOCKET, SO_KEEPALIVE, (char *) &opt, sizeof(opt)) < 0) {
+    if (setsockopt(s, SOL_SOCKET, SO_KEEPALIVE, &opt, sizeof(opt)) < 0) {
         perror("setsockopt(SO_KEEPALIVE)");
         exit(1);
     }
 
     opt = 1;
 
-    if (setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, (char *) &opt, sizeof(opt)) < 0) {
+    if (setsockopt(s, IPPROTO_IPV6, IPV6_V6ONLY, &opt, sizeof(opt)) < 0) {
         perror("setsockopt(IPV6_V6ONLY");
         exit(1);
     }
 
     /* Blank out the server structure */
-    memset((char *) &server, 0, sizeof(server));
+    memset(&server, 0, sizeof(server));
     server.sin6_family = AF_INET6;
     server.sin6_addr = bind_ipv6_address;
     server.sin6_port = htons(port);
@@ -2781,8 +2781,7 @@ addrout_v6(in_port_t lport, struct in6_addr *a, in_port_t prt)
         } else {
             time_t gethost_start = time(NULL);
 
-            struct hostent *he = gethostbyaddr(((char *) &addr),
-                                               sizeof(addr), AF_INET6);
+            struct hostent *he = gethostbyaddr(&addr, sizeof(addr), AF_INET6);
             time_t gethost_stop = time(NULL);
             time_t lag = gethost_stop - gethost_start;
 
@@ -2908,8 +2907,7 @@ addrout(in_port_t lport, in_addr_t a, in_port_t prt)
         } else {
             time_t gethost_start = time(NULL);
 
-            struct hostent *he = gethostbyaddr(((char *) &addr), sizeof(addr),
-                                               AF_INET);
+            struct hostent *he = gethostbyaddr(&addr, sizeof(addr), AF_INET);
             time_t gethost_stop = time(NULL);
             time_t lag = gethost_stop - gethost_start;
 
@@ -2972,13 +2970,13 @@ make_socket(int port)
     }
 
     opt = 1;
-    if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, (char *) &opt, sizeof(opt)) < 0) {
+    if (setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
         perror("setsockopt");
         exit(1);
     }
 
     opt = 1;
-    if (setsockopt(s, SOL_SOCKET, SO_KEEPALIVE, (char *) &opt, sizeof(opt)) < 0) {
+    if (setsockopt(s, SOL_SOCKET, SO_KEEPALIVE, &opt, sizeof(opt)) < 0) {
         perror("setsockopt");
         exit(1);
     }
@@ -3227,7 +3225,7 @@ process_input(struct descriptor_data *d)
                 case TELNET_AYT: /* Are you there? */
                     {
                         char sendbuf[] = "[Yes]\r\n";
-                        queue_immediate_raw(d, (const char *)sendbuf);
+                        queue_immediate_raw(d, sendbuf);
                         d->telnet_state = TELNET_STATE_NORMAL;
                         break;
                     }
@@ -3547,7 +3545,7 @@ process_input(struct descriptor_data *d)
 static int
 pem_passwd_cb(char *buf, int size, int rwflag, void *userdata)
 {
-    const char *pw = (const char *) userdata;
+    const char *pw = userdata;
     int pwlen = strlen(pw);
 
     strncpy(buf, pw, size);
@@ -3999,7 +3997,7 @@ shovechars()
 
     listen_bound_sockets();
 
-    gettimeofday(&last_slice, (struct timezone *) 0);
+    gettimeofday(&last_slice, NULL);
 
     avail_descriptors = max_open_files() - 5;
 
@@ -4013,7 +4011,7 @@ shovechars()
 
     /* And here, we do the actual player-interaction loop */
     while (shutdown_flag == 0) {
-        gettimeofday(&current_time, (struct timezone *) 0);
+        gettimeofday(&current_time, NULL);
         last_slice = update_quotas(last_slice, current_time);
 
         /* Process timed events, commands, and MUF stuff. */
@@ -4684,7 +4682,7 @@ notify(dbref player, const char *msg)
  * @param ... as many arguments as necessary
  */
 void
-notifyf(dbref player, char *format, ...)
+notifyf(dbref player, const char *format, ...)
 {
     va_list args;
     char bufr[BUFFER_LEN];
@@ -4710,7 +4708,7 @@ notifyf(dbref player, char *format, ...)
  * @param ... as many arguments as necessary.
  */
 void
-notifyf_nolisten(dbref player, char *format, ...)
+notifyf_nolisten(dbref player, const char *format, ...)
 {
     va_list args;
     char bufr[BUFFER_LEN];
@@ -5713,7 +5711,7 @@ phost(int c)
         return ((char *) d->hostname);
     }
 
-    return (char *) NULL;
+    return NULL;
 }
 
 /**
@@ -5735,7 +5733,7 @@ pdescrhost(int c)
         return ((char *) d->hostname);
     }
 
-    return (char *) NULL;
+    return NULL;
 }
 
 /**
@@ -5762,7 +5760,7 @@ puser(int c)
         return ((char *) d->username);
     }
 
-    return (char *) NULL;
+    return NULL;
 }
 
 /**
@@ -5784,7 +5782,7 @@ pdescruser(int c)
         return ((char *) d->username);
     }
 
-    return (char *) NULL;
+    return NULL;
 }
 
 /**
@@ -6335,7 +6333,7 @@ dump_status(void)
 static int
 ignore_dbref_compare(const void *Lhs, const void *Rhs)
 {
-    return *(dbref *) Lhs - *(dbref *) Rhs;
+    return *(const dbref *) Lhs - *(const dbref *) Rhs;
 }
 
 /**
@@ -7028,7 +7026,7 @@ main(int argc, char **argv)
                 int fd;
 
                 if ((fd = open("/dev/tty", O_RDWR)) >= 0) {
-                    ioctl(fd, TIOCNOTTY, (char *) 0); /* lose controll TTY */
+                    ioctl(fd, TIOCNOTTY, NULL); /* lose controll TTY */
                     close(fd);
                 }
             }

--- a/src/interp.c
+++ b/src/interp.c
@@ -429,7 +429,7 @@ scopedvar_getname(struct frame *fr, int level, int varnum)
  * @param line the line in the file from which this function was called.
  */
 void
-RCLEAR(struct inst *oper, char *file, int line)
+RCLEAR(struct inst *oper, const char *file, int line)
 {
     int varcnt;
 
@@ -1632,14 +1632,14 @@ do_abort_loop(dbref player, dbref program, const char *msg,
 struct inst *
 interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
 {
-    register struct inst *pc;
-    register int atop;
-    register struct inst *arg;
-    register struct inst *temp1;
-    register struct inst *temp2;
-    register struct stack_addr *sys;
-    register int instr_count;
-    register int stop;
+    struct inst *pc;
+    int atop;
+    struct inst *arg;
+    struct inst *temp1;
+    struct inst *temp2;
+    struct stack_addr *sys;
+    int instr_count;
+    int stop;
     int i = 0, tmp, writeonly, mlev;
     static struct inst retval;
     char dbuf[BUFFER_LEN];
@@ -1679,7 +1679,7 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
         struct line *tmpline;
 
         tmpline = PROGRAM_FIRST(program);
-        PROGRAM_SET_FIRST(program, (struct line *) read_program(program));
+        PROGRAM_SET_FIRST(program, read_program(program));
         do_compile(-1, OWNER(program), program, 0);
         free_prog_text(PROGRAM_FIRST(program));
         PROGRAM_SET_FIRST(program, tmpline);
@@ -2225,7 +2225,7 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
 
                             tmpline = PROGRAM_FIRST(temp1->data.objref);
                             PROGRAM_SET_FIRST(temp1->data.objref,
-                              (struct line *) read_program(temp1->data.objref));
+                                    read_program(temp1->data.objref));
                             do_compile(-1, OWNER(temp1->data.objref),
                                        temp1->data.objref, 0);
                             free_prog_text(PROGRAM_FIRST(temp1->data.objref));
@@ -2425,10 +2425,10 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
                             size_t k, outcount;
                             size_t count =
                                 (size_t)array_count(temp1->data.array);
-                            char **events = malloc(count * sizeof(char **));
+                            const char **events = malloc(count * sizeof(char **));
 
                             for (outcount = k = 0; k < count; k++) {
-                                char *val =
+                                const char *val =
                                     array_get_intkey_strval(temp1->data.array,
                                                             k);
 
@@ -2625,7 +2625,7 @@ push(struct inst *stack, int *top, int type, void *res)
     else if (type < PROG_STRING)
         stack[*top].data.number = *(int *) res;
     else
-        stack[*top].data.string = (struct shared_string *) res;
+        stack[*top].data.string = res;
 
     (*top)++;
 }
@@ -2818,7 +2818,7 @@ do_abort_interp(dbref player, const char *msg, struct inst *pc,
                 struct inst *arg, int atop, struct frame *fr,
                 struct inst *oper1, struct inst *oper2,
                 struct inst *oper3, struct inst *oper4, int nargs,
-                dbref program, char *file, int line)
+                dbref program, const char *file, int line)
 {
     char buffer[128];
 
@@ -2927,8 +2927,8 @@ debug_inst(struct frame *fr, int lev, struct inst *pc, int pid,
 
     /* + 10 because we must at least be able to store " ... ) ..." after that. */
     if (bstart + 10 > bend) {   /* we have no room. Eeek! */
-        /*                                  123456789012345678 */
-        memcpy((void *) buffer, (const void *) "Need buffer space!",
+        /*                             123456789012345678 */
+        memcpy(buffer, (const void *) "Need buffer space!",
                (buflen - 1 > 18) ? 18 : buflen - 1);
         return buffer;
     }

--- a/src/log.c
+++ b/src/log.c
@@ -35,7 +35,7 @@
  * @param args variable number of arguments, which are sprintf replacements
  */
 static void
-vlog2file(int prepend_time, const char *filename, char *format, va_list args)
+vlog2file(int prepend_time, const char *filename, const char *format, va_list args)
 {
     FILE *fp;
     time_t lt;
@@ -74,7 +74,7 @@ vlog2file(int prepend_time, const char *filename, char *format, va_list args)
  * @param ... whatever sprintf replacement variables
  */
 void
-log2file(const char *filename, char *format, ...)
+log2file(const char *filename, const char *format, ...)
 {
     va_list args;
     va_start(args, format);
@@ -116,7 +116,7 @@ log2file(const char *filename, char *format, ...)
  * @param ... the arguments
  */
 void
-log_sanity(char *format, ...)
+log_sanity(const char *format, ...)
 log_function(tp_file_log_sanity)
 
 /**
@@ -131,7 +131,7 @@ log_function(tp_file_log_sanity)
  * @param ... the arguments
  */
 void
-log_sanfix(char *format, ...)
+log_sanfix(const char *format, ...)
 log_function(tp_file_log_sanfix)
 
 /**
@@ -146,7 +146,7 @@ log_function(tp_file_log_sanfix)
  * @param ... the arguments
  */
 void
-log_status(char *format, ...)
+log_status(const char *format, ...)
 log_function(tp_file_log_status)
 
 /**
@@ -161,7 +161,7 @@ log_function(tp_file_log_status)
  * @param ... the arguments
  */
 void
-log_muf(char *format, ...)
+log_muf(const char *format, ...)
 log_function(tp_file_log_muf_errors)
 
 /**
@@ -176,7 +176,7 @@ log_function(tp_file_log_muf_errors)
  * @param ... the arguments
  */
 void
-log_gripe(char *format, ...)
+log_gripe(const char *format, ...)
 log_function(tp_file_log_gripes)
 
 /**
@@ -191,7 +191,7 @@ log_function(tp_file_log_gripes)
  * @param ... the arguments
  */
 void
-log_command(char *format, ...)
+log_command(const char *format, ...)
 log_function(tp_file_log_commands)
 
 /**

--- a/src/look.c
+++ b/src/look.c
@@ -1105,7 +1105,7 @@ init_checkflags(dbref player, const char *flags, struct flgchkdat *check)
         *(cptr++) = '\0';
 
     flags = buf;
-    skip_whitespace((const char **)&cptr);
+    skip_whitespace_var(&cptr);
 
     /* Determine output type */
     if (!*cptr) {

--- a/src/match.c
+++ b/src/match.c
@@ -609,10 +609,10 @@ match_exits(dbref obj, struct match_data *md)
                                 strcpyn(match_args, sizeof(match_args),
                                         (partial && notnull) ? p : (p + 1));
                                 {
-                                    char *pp;
+                                    const char *pp;
                                     int ip;
 
-                                    for (ip = 0, pp = (char *) md->match_name;
+                                    for (ip = 0, pp = md->match_name;
                                          *pp && (pp != p); pp++)
                                         match_cmdname[ip++] = *pp;
 
@@ -621,7 +621,7 @@ match_exits(dbref obj, struct match_data *md)
                             } else {
                                 *match_args = '\0';
                                 strcpyn(match_cmdname, sizeof(match_cmdname),
-                                        (char *) md->match_name);
+                                        md->match_name);
                             }
                         } else if ((strlen(md->match_name) - strlen(p) ==
                                    (size_t) md->longest_match) 
@@ -643,11 +643,11 @@ match_exits(dbref obj, struct match_data *md)
                                     strcpyn(match_args, sizeof(match_args),
                                             (partial && notnull) ? p : (p + 1));
                                     {
-                                        char *pp;
+                                        const char *pp;
                                         int ip;
 
                                         for (ip = 0,
-                                             pp = (char *) md->match_name;
+                                             pp = md->match_name;
                                              *pp && (pp != p); pp++)
                                             match_cmdname[ip++] = *pp;
 
@@ -656,7 +656,7 @@ match_exits(dbref obj, struct match_data *md)
                                 } else {
                                     *match_args = '\0';
                                     strcpyn(match_cmdname, sizeof(match_cmdname),
-                                            (char *) md->match_name);
+                                            md->match_name);
                                 }
                             }
                         }

--- a/src/mcp.c
+++ b/src/mcp.c
@@ -594,7 +594,7 @@ clean_mcpbinds(struct mcp_binding *mypub)
 void
 mcp_send_text(McpFrame *mfr, const char *text)
 {
-    queue_write((struct descriptor_data *) mfr->descriptor, text, strlen(text));
+    queue_write(mfr->descriptor, text, strlen(text));
 }
 
 /**
@@ -605,7 +605,7 @@ mcp_send_text(McpFrame *mfr, const char *text)
 void
 mcp_flush_text(McpFrame *mfr)
 {
-    struct descriptor_data *d = (struct descriptor_data *) mfr->descriptor;
+    struct descriptor_data *d = mfr->descriptor;
 
     if (d)
         process_output(d);

--- a/src/mcppkgs.c
+++ b/src/mcppkgs.c
@@ -34,7 +34,7 @@
  * @param text the text to send
  */
 void
-show_mcp_error(McpFrame * mfr, char *topic, char *text)
+show_mcp_error(McpFrame * mfr, const char *topic, const char *text)
 {
     McpMesg msg;
     McpVer supp = mcp_frame_package_supported(mfr, "org-fuzzball-notify");
@@ -93,10 +93,11 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
      */
     if (!strcasecmp(msg->mesgname, "set")) {
         dbref obj = NOTHING;
-        char *reference;
-        char *valtype;
+        const char *reference;
+        const char *valtype;
         char category[BUFFER_LEN];
         char *ptr;
+        const char *rptr;
         int lines;
         dbref player;
         char buf[BUFFER_LEN];
@@ -176,8 +177,8 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
                 return;
             }
 
-            for (ptr = reference; *ptr; ptr++) {
-                if (*ptr == PROP_DELIMITER) {
+            for (rptr = reference; *rptr; rptr++) {
+                if (*rptr == PROP_DELIMITER) {
                     show_mcp_error(mfr, "simpleedit-set", "Bad property name.");
                     return;
                 }
@@ -254,8 +255,8 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
                 return;
             }
 
-            for (ptr = reference; *ptr; ptr++) {
-                if (*ptr == PROP_DELIMITER) {
+            for (rptr = reference; *rptr; rptr++) {
+                if (*rptr == PROP_DELIMITER) {
                     show_mcp_error(mfr, "simpleedit-set", "Bad property name.");
                     return;
                 }
@@ -465,8 +466,8 @@ mcppkg_help_request(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
     }
 
     if (!strcasecmp(msg->mesgname, "request")) {
-        char *onwhat;
-        char *valtype;
+        const char *onwhat;
+        const char *valtype;
 
         onwhat = mcp_mesg_arg_getline(msg, "topic", 0);
         valtype = mcp_mesg_arg_getline(msg, "type", 0);

--- a/src/mfuns.c
+++ b/src/mfuns.c
@@ -895,7 +895,7 @@ mfn_concat(MFUNARGS)
     if (obj == UNKNOWN || obj == AMBIGUOUS || obj == NOTHING || obj == HOME)
         ABORT_MPI("CONCAT", "Match failed.");
 
-    ptr = get_concat_list(what, perms, obj, (char *) pname, buf, BUFFER_LEN, 1,
+    ptr = get_concat_list(what, perms, obj, pname, buf, BUFFER_LEN, 1,
                           mesgtyp, &blessed);
 
     if (!ptr)
@@ -964,7 +964,7 @@ mfn_select(MFUNARGS)
     i = targval = atoi(argv[0]);
 
     do {
-        ptr = get_list_item(player, obj, perms, (char *) pname, i--, mesgtyp, &blessed);
+        ptr = get_list_item(player, obj, perms, pname, i--, mesgtyp, &blessed);
     } while (limit-- > 0 && i >= 0 && ptr && !*ptr);
 
     if (ptr == NULL)
@@ -1118,7 +1118,7 @@ mfn_list(MFUNARGS)
     if (obj == UNKNOWN || obj == AMBIGUOUS || obj == NOTHING || obj == HOME)
         ABORT_MPI("LIST", "Match failed.");
 
-    ptr = get_concat_list(what, perms, obj, (char *) pname, buf, BUFFER_LEN, 0,
+    ptr = get_concat_list(what, perms, obj, pname, buf, BUFFER_LEN, 0,
                           mesgtyp, &blessed);
 
     if (!ptr)
@@ -1173,7 +1173,7 @@ mfn_lexec(MFUNARGS)
     while (*pname == PROPDIR_DELIMITER)
         pname++;
 
-    ptr = get_concat_list(what, perms, obj, (char *) pname, buf, BUFFER_LEN, 2,
+    ptr = get_concat_list(what, perms, obj, pname, buf, BUFFER_LEN, 2,
                           mesgtyp, &blessed);
 
     if (!ptr)
@@ -1224,7 +1224,8 @@ mfn_rand(MFUNARGS)
 {
     int num = 0;
     dbref trg = (dbref) 0, obj = what;
-    const char *pname, *ptr;
+    char *pname;
+    const char *ptr;
     int blessed = 0;
 
     pname = argv[0];
@@ -1239,12 +1240,12 @@ mfn_rand(MFUNARGS)
     if (obj == UNKNOWN || obj == AMBIGUOUS || obj == NOTHING || obj == HOME)
         ABORT_MPI("RAND", "Match failed.");
 
-    num = get_list_count(what, obj, perms, (char *) pname, mesgtyp, &blessed);
+    num = get_list_count(what, obj, perms, pname, mesgtyp, &blessed);
 
     if (!num)
         ABORT_MPI("RAND", "Failed list read.");
 
-    ptr = get_list_item(what, obj, perms, (char *) pname,
+    ptr = get_list_item(what, obj, perms, pname,
                         (((RANDOM() / 256) % num) + 1),
                         mesgtyp, &blessed);
 
@@ -1297,7 +1298,8 @@ mfn_timesub(MFUNARGS)
 {
     int num = 0;
     dbref trg = (dbref) 0, obj = what;
-    const char *pname, *ptr;
+    char *pname;
+    const char *ptr;
     int period = 0, offset = 0;
     int blessed = 0;
 
@@ -1315,7 +1317,7 @@ mfn_timesub(MFUNARGS)
     if (obj == UNKNOWN || obj == AMBIGUOUS || obj == NOTHING || obj == HOME)
         ABORT_MPI("TIMESUB", "Match failed.");
 
-    num = get_list_count(what, obj, perms, (char *) pname, mesgtyp, &blessed);
+    num = get_list_count(what, obj, perms, pname, mesgtyp, &blessed);
 
     if (!num)
         ABORT_MPI("TIMESUB", "Failed list read.");
@@ -1328,7 +1330,7 @@ mfn_timesub(MFUNARGS)
     if (offset < 0)
         offset = -offset;
 
-    ptr = get_list_item(what, obj, perms, (char *) pname, offset + 1, mesgtyp,
+    ptr = get_list_item(what, obj, perms, pname, offset + 1, mesgtyp,
                         &blessed);
 
     if (!ptr)
@@ -2806,7 +2808,7 @@ mfn_dice(MFUNARGS)
 const char *
 mfn_default(MFUNARGS)
 {
-    char *ptr;
+    const char *ptr;
 
     *buf = '\0';
     ptr = MesgParse(argv[0], buf, buflen);
@@ -2845,7 +2847,7 @@ mfn_default(MFUNARGS)
 const char *
 mfn_if(MFUNARGS)
 {
-    char *fbr, *ptr;
+    const char *fbr, *ptr;
 
     if (argc == 3) {
         fbr = argv[2];
@@ -3129,7 +3131,7 @@ mfn_convtime(MFUNARGS)
 #ifdef WIN32
     ABORT_MPI("CONVTIME", CURRENTLY_UNAVAILABLE);
 #else
-    char *error = 0;
+    const char *error = NULL;
 
     time_t seconds = time_string_to_seconds(argv[0], "%T%t%D", &error);
 
@@ -3757,9 +3759,9 @@ mfn_right(MFUNARGS)
      */
 
     char *ptr;
-    char *fptr;
+    const char *fptr;
     int i, len;
-    char *fillstr;
+    const char *fillstr;
 
     len = (argc > 1) ? atoi(argv[1]) : 78;
 
@@ -3816,9 +3818,9 @@ mfn_left(MFUNARGS)
      */
 
     char *ptr;
-    char *fptr;
+    const char *fptr;
     int i, len;
-    char *fillstr;
+    const char *fillstr;
 
     len = (argc > 1) ? atoi(argv[1]) : 78;
 
@@ -3877,9 +3879,9 @@ mfn_center(MFUNARGS)
      */
 
     char *ptr;
-    char *fptr;
+    const char *fptr;
     int i, len, halflen;
-    char *fillstr;
+    const char *fillstr;
 
     len = (argc > 1) ? atoi(argv[1]) : 78;
 

--- a/src/mfuns2.c
+++ b/src/mfuns2.c
@@ -738,7 +738,7 @@ mfn_fullname(MFUNARGS)
  * @return integer count of items or 0 if list is empty/NULL.
  */
 static int
-countlitems(char *list, char *sep)
+countlitems(char *list, const char *sep)
 {
     char *ptr;
     size_t seplen;
@@ -781,7 +781,7 @@ countlitems(char *list, char *sep)
  * @return a pointer to 'buf'
  */
 static char *
-getlitem(char *buf, size_t buflen, char *list, char *sep, int line)
+getlitem(char *buf, size_t buflen, char *list, const char *sep, int line)
 {
     char *ptr, *ptr2;
     char tmpchr;
@@ -2513,13 +2513,13 @@ mfn_timing(MFUNARGS)
     int usecs;
     double timelen;
 
-    gettimeofday(&start_time, (struct timezone *) 0);
+    gettimeofday(&start_time, NULL);
 
     ptr = mesg_parse(descr, player, what, perms, argv[0], buf, BUFFER_LEN,
                      mesgtyp);
     CHECKRETURN(ptr, "TIMING", "arg 1");
 
-    gettimeofday(&end_time, (struct timezone *) 0);
+    gettimeofday(&end_time, NULL);
     secs = end_time.tv_sec - start_time.tv_sec;
     usecs = end_time.tv_usec - start_time.tv_usec;
 
@@ -3004,7 +3004,7 @@ mfn_lmember(MFUNARGS)
     /* {lmember:list,item,delim} */
     int i = 1;
     char *ptr = argv[0];
-    char *delim = NULL;
+    const char *delim = NULL;
     int len;
     int len2 = strlen(argv[1]);
 

--- a/src/mufevent.c
+++ b/src/mufevent.c
@@ -146,7 +146,7 @@ muf_event_process_free(struct mufevent_process *ptr)
  */
 void
 muf_event_register_specific(dbref player, dbref prog, struct frame *fr,
-                            size_t eventcount, char **eventids)
+                            size_t eventcount, const char **eventids)
 {
     struct mufevent_process *newproc;
     struct mufevent_process *ptr;
@@ -860,7 +860,7 @@ muf_event_free(struct mufevent *ptr)
  * @param exclusive boolean as described above
  */
 void
-muf_event_add(struct frame *fr, char *event, struct inst *val, int exclusive)
+muf_event_add(struct frame *fr, const char *event, struct inst *val, int exclusive)
 {
     struct mufevent *newevent;
     struct mufevent *ptr;

--- a/src/p_array.c
+++ b/src/p_array.c
@@ -28,6 +28,8 @@
 #include "timequeue.h"
 #include "tune.h"
 
+typedef int (*comparator_t) (const void *, const void *);
+
 /*
  * TODO: These globals really probably shouldn't be globals.  I can only guess
  *       this is either some kind of primitive code re-use because all the
@@ -1391,15 +1393,15 @@ static struct inst *sortflag_index = NULL;
 static int
 sortcomp_generic(const void *x, const void *y)
 {
-    struct inst *a;
-    struct inst *b;
+    const struct inst *a;
+    const struct inst *b;
 
     if (!sortflag_descending) {
-        a = *(struct inst **) x;
-        b = *(struct inst **) y;
+        a = *(struct inst *const *) x;
+        b = *(struct inst *const *) y;
     } else {
-        a = *(struct inst **) y;
-        b = *(struct inst **) x;
+        a = *(struct inst *const *) y;
+        b = *(struct inst *const *) x;
     }
 
     if (sortflag_index) {
@@ -1462,7 +1464,7 @@ prim_array_sort(PRIM_PROTOTYPE)
     stk_array *arr;
     stk_array *nu;
     size_t count;
-    int (*comparator) (const void *, const void *);
+    comparator_t comparator;
     struct inst **tmparr = NULL;
 
     CHECKOP(2);
@@ -1553,7 +1555,7 @@ prim_array_sort_indexed(PRIM_PROTOTYPE)
     stk_array *arr;
     stk_array *nu;
     size_t count;
-    int (*comparator) (const void *, const void *);
+    comparator_t comparator;
     struct inst **tmparr = NULL;
 
     CHECKOP(3);

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -804,7 +804,7 @@ prim_setname(PRIM_PROTOTYPE)
 
             if (*password) {
                 *password++ = '\0';     /* terminate name */
-                skip_whitespace((const char **)&password);
+                skip_whitespace_var(&password);
             }
 
             /* check for null password */
@@ -2596,7 +2596,7 @@ prim_getlockstr(PRIM_PROTOTYPE)
         abort_interp("Permission denied.");
 
     {
-        char *tmpstr = (char *) unparse_boolexp(player, GETLOCK(ref), 0);
+        const char *tmpstr = (char *) unparse_boolexp(player, GETLOCK(ref), 0);
 
         CLEAR(oper1);
         PushString(tmpstr);
@@ -4425,3 +4425,4 @@ void prim_dump(PRIM_PROTOTYPE)
     result = 1;
     PushInt(result);
 }
+

--- a/src/p_mcp.c
+++ b/src/p_mcp.c
@@ -80,7 +80,7 @@ struct mcpevent_context {
 static void
 muf_mcp_context_cleanup(void *context)
 {
-    struct mcp_muf_context *mmc = (struct mcp_muf_context *) context;
+    struct mcp_muf_context *mmc = context;
 
     free(mmc);
 }
@@ -110,7 +110,7 @@ muf_mcp_context_cleanup(void *context)
 static void
 muf_mcp_callback(McpFrame * mfr, McpMesg * mesg, McpVer version, void *context)
 {
-    struct mcp_muf_context *mmc = (struct mcp_muf_context *) context;
+    struct mcp_muf_context *mmc = context;
     dbref obj = mmc->prog;
     struct mcp_binding *ptr;
     char *pkgname = mesg->package;
@@ -211,7 +211,7 @@ muf_mcp_callback(McpFrame * mfr, McpMesg * mesg, McpVer version, void *context)
 static void
 mcpevent_context_cleanup(void *context)
 {
-    struct mcpevent_context *mec = (struct mcpevent_context *) context;
+    struct mcpevent_context *mec = context;
     free(mec);
 }
 
@@ -239,7 +239,7 @@ static void
 muf_mcp_event_callback(McpFrame * mfr, McpMesg * mesg, McpVer version,
                        void *context)
 {
-    struct mcpevent_context *mec = (struct mcpevent_context *) context;
+    struct mcpevent_context *mec = context;
     int destpid = mec->pid;
     struct frame *destfr = timequeue_pid_frame(destpid);
     int descr = MCPFRAME_DESCR(mfr);
@@ -517,7 +517,7 @@ prim_mcp_register(PRIM_PROTOTYPE)
     mmc->prog = program;
 
     mcp_package_register(pkgname, vermin, vermax, muf_mcp_callback,
-                         (void *) mmc, muf_mcp_context_cleanup);
+                         mmc, muf_mcp_context_cleanup);
 
     CLEAR(oper1);
     CLEAR(oper2);
@@ -583,7 +583,7 @@ prim_mcp_register_event(PRIM_PROTOTYPE)
     mec->pid = fr->pid;
 
     mcp_package_register(pkgname, vermin, vermax, muf_mcp_event_callback,
-                         (void *) mec, mcpevent_context_cleanup);
+                         mec, mcpevent_context_cleanup);
 
     CLEAR(oper1);
     CLEAR(oper2);
@@ -867,7 +867,7 @@ fbgui_muf_event_cb(GUI_EVENT_CB_ARGS)
 {
     char buf[BUFFER_LEN];
     const char *name;
-    struct frame *fr = (struct frame *) context;
+    struct frame *fr = context;
     struct inst temp;
     struct inst temp1;
     struct inst temp2;
@@ -976,7 +976,7 @@ static void
 fbgui_muf_error_cb(GUI_ERROR_CB_ARGS)
 {
     char buf[BUFFER_LEN];
-    struct frame *fr = (struct frame *) context;
+    struct frame *fr = context;
     struct inst temp;
 
     temp.type = PROG_ARRAY;
@@ -1054,7 +1054,7 @@ prim_gui_dlog_create(PRIM_PROTOTYPE)
 {
     const char *dlogid = NULL;
     char *title = NULL;
-    char *wintype = NULL;
+    const char *wintype = NULL;
     stk_array *arr = NULL;
     McpMesg msg;
     McpFrame *mfr;

--- a/src/p_misc.c
+++ b/src/p_misc.c
@@ -198,7 +198,7 @@ prim_systime_precise(PRIM_PROTOTYPE)
     CHECKOP(0);
     CHECKOFLOW(1);
 
-    gettimeofday(&fulltime, (struct timezone *) 0);
+    gettimeofday(&fulltime, NULL);
 
     dbltime = fulltime.tv_sec + (((double) fulltime.tv_usec) / 1.0e6);
     PushFloat(dbltime);
@@ -328,7 +328,7 @@ prim_convtime(PRIM_PROTOTYPE)
 #ifdef WIN32
     abort_interp(CURRENTLY_UNAVAILABLE);
 #else
-    char *error = 0;
+    const char *error = NULL;
 
     CHECKOP(1);
     oper1 = POP();
@@ -371,7 +371,7 @@ prim_fmttime(PRIM_PROTOTYPE)
 #ifdef WIN32
     abort_interp(CURRENTLY_UNAVAILABLE);
 #else
-    char *error = 0;
+    const char *error = NULL;
 
     CHECKOP(2);
     oper1 = POP();
@@ -1122,7 +1122,7 @@ prim_parselock(PRIM_PROTOTYPE)
     if (oper1->type != PROG_STRING)
         abort_interp("Invalid argument.");
 
-    if (oper1->data.string != (struct shared_string *) NULL) {
+    if (oper1->data.string != NULL) {
         lok = parse_boolexp(fr->descr, ProgUID, oper1->data.string->data, 0);
     } else {
         lok = TRUE_BOOLEXP;
@@ -1159,7 +1159,7 @@ prim_unparselock(PRIM_PROTOTYPE)
     if (oper1->type != PROG_LOCK)
         abort_interp("Invalid argument.");
 
-    if (oper1->data.lock != (struct boolexp *) TRUE_BOOLEXP) {
+    if (oper1->data.lock != TRUE_BOOLEXP) {
         ptr = unparse_boolexp(ProgUID, oper1->data.lock, 0);
     } else {
         ptr = NULL;

--- a/src/p_strings.c
+++ b/src/p_strings.c
@@ -2651,7 +2651,7 @@ prim_explode_array(PRIM_PROTOTYPE)
 {
     stk_array *nu;
     char *tempPtr;
-    char *lastPtr;
+    const char *lastPtr;
 
     CHECKOP(2);
     temp1 = *(oper1 = POP());
@@ -2680,7 +2680,7 @@ prim_explode_array(PRIM_PROTOTYPE)
             lastPtr = "";
         } else {
             strcpyn(buf, sizeof(buf), temp2.data.string->data);
-            tempPtr = lastPtr = buf;
+            lastPtr = tempPtr = buf;
 
             while (*tempPtr) {
                 if (!strncmp(tempPtr, delimit, delimlen)) {
@@ -3259,7 +3259,7 @@ prim_striplead(PRIM_PROTOTYPE)
 
     strcpyn(buf, sizeof(buf), DoNullInd(oper1->data.string));
     pname = buf;
-    skip_whitespace((const char **)&pname);
+    skip_whitespace_var(&pname);
     CLEAR(oper1);
     PushString(pname);
 }
@@ -3820,8 +3820,7 @@ prim_ansi_strcut(PRIM_PROTOTYPE)
     }
 
     *op = '\0';
-    memcpy((void *) outbuf2, (const void *) ptr,
-           oper1->data.string->length
+    memcpy(outbuf2, ptr, oper1->data.string->length
            - (size_t)(ptr - oper1->data.string->data) + 1);
 
     CLEAR(oper1);
@@ -4122,7 +4121,7 @@ prim_strip(PRIM_PROTOTYPE)
 
     strcpyn(buf, sizeof(buf), DoNullInd(oper1->data.string));
     pname = buf;
-    skip_whitespace((const char **)&pname);
+    skip_whitespace_var(&pname);
     remove_ending_whitespace(&pname);
     CLEAR(oper1);
     PushString(pname);

--- a/src/prochelp.c
+++ b/src/prochelp.c
@@ -62,7 +62,7 @@
  * of the associated function.  Does not escape HTML.
  */
 typedef struct {
-    char *token;
+    const char *token;
     void (*func)(FILE *);
 } replacement;
 
@@ -122,7 +122,7 @@ strcpyn(char *buf, size_t bufsize, const char *src)
 }
 
 /**
- * Skip over starting whitespaces in a string
+ * Skip over starting whitespaces in a variable string
  *
  * Note that this does not technically "trim" spaces; instead, it advances
  * the provided pointer to the first non-space (or to the end of the string
@@ -132,7 +132,7 @@ strcpyn(char *buf, size_t bufsize, const char *src)
  * @param parsebuf pointer to a string pointer.
  */
 static void
-skip_whitespace(const char **parsebuf)
+skip_whitespace_var(char **parsebuf)
 {
     while (**parsebuf && isspace(**parsebuf))
         (*parsebuf)++;
@@ -740,7 +740,7 @@ process_lines(FILE * infile, FILE * outfile, FILE * htmlfile)
                     fprintf(outfile, "Also see: ");
 
                     ptr = buf + 10;
-                    skip_whitespace((const char **)&ptr);
+                    skip_whitespace_var(&ptr);
 
                     while (ptr && *ptr) {
                         ptr2 = ptr;
@@ -748,7 +748,7 @@ process_lines(FILE * infile, FILE * outfile, FILE * htmlfile)
 
                         if (ptr) {
                             *ptr++ = '\0';
-                            skip_whitespace((const char **)&ptr);
+                            skip_whitespace_var(&ptr);
                         }
 
                         if (ptr2 > buf + 10) {

--- a/src/property.c
+++ b/src/property.c
@@ -807,11 +807,11 @@ get_property_class(dbref player, const char *pname)
         propfetch(player, p);
 #endif
         if (PropType(p) != PROP_STRTYP)
-            return (char *) NULL;
+            return NULL;
 
         return (PropDataStr(p));
     } else {
-        return (char *) NULL;
+        return NULL;
     }
 }
 

--- a/src/props.c
+++ b/src/props.c
@@ -456,8 +456,8 @@ PropPtr
 new_prop(PropPtr *avl, char *key)
 {
     PropPtr ret;
-    register PropPtr p = *avl;
-    register int cmp;
+    PropPtr p = *avl;
+    int cmp;
     static short balancep;
 
     if (p) {

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -458,7 +458,7 @@ static const char * addrout_v6(struct in6_addr *a, in_port_t prt,
         return buf;
     }
 
-    he = gethostbyaddr(((char *) &addr), sizeof(addr), AF_INET6);
+    he = gethostbyaddr(&addr, sizeof(addr), AF_INET6);
 
     if (he) {
         strcpyn(tmpbuf, sizeof(tmpbuf), he->h_name);
@@ -783,7 +783,7 @@ static const char * addrout(in_addr_t a, in_port_t prt, in_port_t myprt) {
         return buf;
     }
 
-    he = gethostbyaddr(((char *) &addr), sizeof(addr), AF_INET);
+    he = gethostbyaddr(&addr, sizeof(addr), AF_INET);
 
     if (he) {
         strcpyn(tmpbuf, sizeof(tmpbuf), he->h_name);

--- a/src/sanity.c
+++ b/src/sanity.c
@@ -847,7 +847,7 @@ do_sanity(dbref player)
  * @param ref2 the second reference
  */
 static void
-san_fixed_log(char *format, int unparse, dbref ref1, dbref ref2)
+san_fixed_log(const char *format, int unparse, dbref ref1, dbref ref2)
 {
     char buf1[4096];
     char buf2[4096];
@@ -1118,7 +1118,7 @@ rand_password(void)
 static void
 create_lostandfound(dbref * player, dbref * room)
 {
-    char *player_name = (char *)malloc(tp_player_name_limit+1);
+    char *player_name = malloc(tp_player_name_limit+1);
     char unparse_buf[16384];
     int temp = 0;
 
@@ -1313,7 +1313,7 @@ find_misplaced_objects(void)
                     break;
 
                 case TYPE_PLAYER: {
-                    char *name = (char *)malloc(tp_player_name_limit+1);
+                    char *name = malloc(tp_player_name_limit+1);
 
                     /* Loop to find a name we can use */
 

--- a/src/set.c
+++ b/src/set.c
@@ -65,13 +65,13 @@ do_name(int descr, dbref player, const char *name, char *newname)
 
         if (*password) {
             *password++ = '\0';     /* terminate name */
-            skip_whitespace((const char **)&password);
+            skip_whitespace_var(&password);
         }
 
         /* check for null password */
         if (!*password) {
             notify(player, "You must specify a password to change a player name.");
-            notify(player, "E.g.: name player = newname password");
+            notify(player, "E.g.: @name player = newname password");
             return;
         }
 
@@ -720,7 +720,7 @@ do_set(int descr, dbref player, const char *name, const char *flag)
 
         /* copy the string so we can muck with it */
         const char *type = alloc_string(flag);  /* type */
-        char *pname = (char *) strchr(type, PROP_DELIMITER);    /* propname */
+        char *pname = strchr(type, PROP_DELIMITER);    /* propname */
         const char *x;      /* to preserve string location so we can free it */
         char *temp;
         int ival = 0;
@@ -1172,7 +1172,8 @@ do_register(int descr, dbref player, char *arg1, const char *arg2)
         target = player;
         objectstr = remaining;
     } else if (string_prefix(arg1, "#prop")) {
-        char *pattern, *targetstr;
+        char *pattern;
+        const char *targetstr;
 
         (void) strtok_r(arg1, " \t", &remaining);
         pattern = strtok_r(remaining, " \t", &remaining);

--- a/src/timequeue.c
+++ b/src/timequeue.c
@@ -183,7 +183,7 @@ alloc_timenode(int typ, int subtyp, time_t mytime, int descr, dbref player,
     ptr->descr = descr;
     ptr->fr = fr;
     ptr->called_prog = program;
-    ptr->called_data = strdup((char *) strdata);
+    ptr->called_data = strdup(strdata);
     ptr->command = alloc_string(strcmd);
     ptr->str3 = alloc_string(str3);
     ptr->eventnum = (fr) ? fr->pid : top_pid++;

--- a/src/tune.c
+++ b/src/tune.c
@@ -599,13 +599,13 @@ tune_load_parms_from_file(FILE * f, dbref player, int cnt)
                 *c++ = '\0';
                 p = buf;
                 remove_ending_whitespace(&p);
-                skip_whitespace((const char **)&c);
+                skip_whitespace_var(&c);
 
                 for (p = c; *p && *p != '\n' && *p != '\r'; p++) ;
 
                 *p = '\0';
                 p = buf;
-                skip_whitespace((const char **)&p);
+                skip_whitespace_var(&p);
 
                 if (*p) {
                     result = tune_setparm((dbref)1, p, c, MLEV_GOD);


### PR DESCRIPTION
This is most of a large patch from Dinoex, focusing on reducing the amount of casting required while promoting some variables to const pointers (and a few minor cleanups). I'm still going through the remaining bits. I've tested this, and it doesn't seem to cause any trouble (or even seem like it SHOULD), but please feel free to scrutinize! :)
