### PR TITLE
ci: Move Windows to VS 2019, add rendered README to build artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,44 @@
-Fuzzball MUCK [![GNU/Linux Build Status](https://travis-ci.org/fuzzball-muck/fuzzball.svg?branch=master)](https://travis-ci.org/fuzzball-muck/fuzzball) [![Windows Build Status](https://ci.appveyor.com/api/projects/status/ktwrfcsjbv4xt3op/branch/master?svg=true)](https://ci.appveyor.com/project/fuzzball-muck/fuzzball/branch/master) [![FreeBSD Build Status](https://api.cirrus-ci.com/github/fuzzball-muck/fuzzball.svg)](https://cirrus-ci.com/github/fuzzball-muck/fuzzball)
+Fuzzball MUCK [![GNU/Linux Build Status][ci-linux-badge]](https://travis-ci.org/fuzzball-muck/fuzzball) [![Windows Build Status][ci-windows-badge]](https://ci.appveyor.com/project/fuzzball-muck/fuzzball/branch/master) [![FreeBSD Build Status][ci-freebsd-badge]](https://cirrus-ci.com/github/fuzzball-muck/fuzzball)
 ===============
 
-Fuzzball is a [MUCK][wiki-muck] server, an online text-based multi-user chat and roleplaying game.  Multiple people may join, set up characters, talk, and interact, exploring and building a common world.  Nearly every aspect of the game can be customized via [MPI-driven descriptions][help-mpi] and [MUF programs][help-muf].
+Fuzzball is a [MUCK](https://en.wikipedia.org/wiki/MUCK) server, an online text-based multi-user chat and roleplaying game.  Multiple people may join, set up characters, talk, and interact, exploring and building a common world.  Nearly every aspect of the game can be customized via [MPI-driven descriptions](https://www.fuzzball.org/docs/mpihelp.html) and [MUF programs](https://www.fuzzball.org/docs/mufman.html).
 
 ## Documentation
 
-* [Fuzzball website][web-home]
-* [GitHub repository][repo]
-* [A live version of the docs on GitHub][help-live]
-* [User commands][help-user]
-* [MPI functions][help-mpi]
-* [MUF reference][help-muf]
-* [MINK - The Muck Information Kiosk][help-mink]
+* [Fuzzball website](https://www.fuzzball.org/)
+* [GitHub repository](https://github.com/fuzzball-muck/fuzzball/)
+* [A live version of the docs on GitHub](https://fuzzball-muck.github.io/fuzzball/)
+* [User commands](https://www.fuzzball.org/docs/muckhelp.html)
+* [MPI functions](https://www.fuzzball.org/docs/mpihelp.html)
+* [MUF reference](https://www.fuzzball.org/docs/mufman.html)
+* [MINK - The Muck Information Kiosk](https://fuzzball-muck.github.io/muckman/)
 
 Fuzzball also offers a built-in help system.  Connect, then type ```help``` for guidance.
 
 ## Downloads
 * **Stable**
   * *Tested and supported, recommended for everyday usage*
-  * **Unix**: download from [the Fuzzball homepage][web-home], follow the steps in [the Unix README][docs-buildsrc-nix], skipping *Get Source*
-  * **Windows**: download from [the Fuzzball homepage][web-home], follow the steps under *Running* in [the Windows README](README_WINDOWS.md#running)
+  * **Unix**: download from [the Fuzzball homepage](https://www.fuzzball.org/), follow the steps in [the Unix README](README_UNIX.md#building), skipping *Get Source*
+  * **Windows**: download from [the Fuzzball homepage](https://www.fuzzball.org/), follow the steps under *Running* in [the Windows README](README_WINDOWS.md#running)
 * **Development**
   * *Try out the latest features and help find issues, but if it breaks you get to keep all the pieces*
-  * **Unix**: follow the steps in [the Unix README][docs-buildsrc-nix].
+  * **Unix**: follow the steps in [the Unix README](README_UNIX.md#building).
   * **Windows**: download a pre-built package from [the Appveyor build artifacts page](https://ci.appveyor.com/project/fuzzball-muck/fuzzball/branch/master/artifacts), follow the steps under *Running* in [the Windows README](README_WINDOWS.md#running).
 
 ### Building and Running from Source
-* [Unix README][docs-buildsrc-nix]
+* [Unix README](README_UNIX.md#building)
 * [Windows README](README_WINDOWS.md#building)
 
 ## Usage
 
-For a comprehensive guide to running a muck, check out [MINK - The Muck Information Kiosk][help-mink].
+For a comprehensive guide to running a muck, check out [MINK - The Muck Information Kiosk](https://fuzzball-muck.github.io/muckman/).
 
-If you only need a quick test environment, read the instructions for your operating system in [Building and Running from Source][docs-buildsrc] right above.
+If you only need a quick test environment, read the instructions for your operating system in [Building and Running from Source](#building-and-running-from-source) right above.
 
 ## Feedback
 
 You can send bug reports, feature requests, or other general feedback to <a href='mailto:feedback@fuzzball.org'>feedback@fuzzball.org</a>
 
-[docs-buildsrc]: #building-and-running-from-source
-[docs-buildsrc-nix]: README_UNIX.md#building
-[repo]: https://github.com/fuzzball-muck/fuzzball/
-[help-live]: https://fuzzball-muck.github.io/fuzzball/
-[help-user]: https://www.fuzzball.org/docs/muckhelp.html
-[help-mpi]: https://www.fuzzball.org/docs/mpihelp.html
-[help-muf]: https://www.fuzzball.org/docs/mufman.html
-[help-mink]: https://fuzzball-muck.github.io/muckman/
-[web-home]: https://www.fuzzball.org/
-[wiki-muck]: https://en.wikipedia.org/wiki/MUCK
+[ci-linux-badge]: https://travis-ci.org/fuzzball-muck/fuzzball.svg?branch=master
+[ci-windows-badge]: https://ci.appveyor.com/api/projects/status/ktwrfcsjbv4xt3op/branch/master?svg=true
+[ci-freebsd-badge]: https://api.cirrus-ci.com/github/fuzzball-muck/fuzzball.svg

--- a/README_UNIX.md
+++ b/README_UNIX.md
@@ -47,7 +47,7 @@ make install-sysv-inits  # Skip to not run at startup
 ```
 
 ## Running
-For a comprehensive guide to running a MUCK, check out [MINK - The Muck Information Kiosk][help-mink].
+For a comprehensive guide to running a MUCK, check out [MINK - The Muck Information Kiosk](http://www.rdwarf.com/users/mink/muckman/).
 
 ### Quick-start
 * **Follow the build directions above**
@@ -64,5 +64,3 @@ mv "$PREFIX/game/data/basedb.db" "$PREFIX/game/data/std-db.db" # Rename database
 /usr/local/sbin/fb-restart
 # If using a custom prefix, $PREFIX/sbin/fb-restart
 ```
-
-[help-mink]: http://www.rdwarf.com/users/mink/muckman/

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -48,13 +48,13 @@ nmake /f makefile.win
 ```
 
 ## Running
-* Install the [32-bit Visual C++ Redistributable for Visual Studio 2015][visual-runtime] (*Fuzzball currently does not support 64-bit*)
+* Install the [32-bit Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48145) (*Fuzzball currently does not support 64-bit*)
 * Manage the server with ```restart.exe```
 
-For a comprehensive guide to running a MUCK, check out [MINK - The Muck Information Kiosk][help-mink].
+For a comprehensive guide to running a MUCK, check out [MINK - The Muck Information Kiosk](http://www.rdwarf.com/users/mink/muckman/).
 
 ### Quick-start
-* **Follow the build directions, or [download a pre-built package][docs-downloads]**
+* **Follow the build directions, or [download a pre-built package](README.md#downloads)**
 * Set up configuration in ```restart.ini```
 ```bat
 cd "path\to\fuzzball\folder"
@@ -66,7 +66,3 @@ restart -c
 ```bat
 restart
 ```
-
-[help-mink]: http://www.rdwarf.com/users/mink/muckman/
-[docs-downloads]: README.md#downloads
-[visual-runtime]: https://www.microsoft.com/en-us/download/details.aspx?id=48145

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -48,7 +48,8 @@ nmake /f makefile.win
 ```
 
 ## Running
-* Install the [32-bit Visual C++ Redistributable for Visual Studio 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48145) (*Fuzzball currently does not support 64-bit*)
+* Install the [32-bit Visual C++ Redistributable for Visual Studio 2019](https://www.microsoft.com/en-us/download/details.aspx?id=48145) (*Fuzzball currently does not support 64-bit*)
+  * Pick the `x86` version, [or just use this direct link to `vc_redist.x86.exe`](https://aka.ms/vs/16/release/vc_redist.x86.exe)
 * Manage the server with ```restart.exe```
 
 For a comprehensive guide to running a MUCK, check out [MINK - The Muck Information Kiosk](http://www.rdwarf.com/users/mink/muckman/).

--- a/README_WINDOWS.md
+++ b/README_WINDOWS.md
@@ -2,6 +2,27 @@ Building and Running Fuzzball on Windows
 ===============
 *For documentation and general help, see [the general README](README.md)*
 
+## Running
+* Install the [32-bit Visual C++ Redistributable for Visual Studio 2019](https://www.microsoft.com/en-us/download/details.aspx?id=48145) (*Fuzzball currently does not support 64-bit*)
+  * Pick the `x86` version, [or just use this direct link to `vc_redist.x86.exe`](https://aka.ms/vs/16/release/vc_redist.x86.exe)
+* Manage the server with ```restart.exe```
+
+For a comprehensive guide to running a MUCK, check out [MINK - The Muck Information Kiosk](http://www.rdwarf.com/users/mink/muckman/).
+
+### Quick-start
+* **Follow the build directions, or [download a pre-built package](README.md#downloads)**
+* Set up configuration in ```restart.ini```
+```bat
+cd "path\to\fuzzball\folder"
+restart -c
+```
+* Edit and save ```restart.ini``` with your options, e.g. with ```notepad restart.ini```
+* If using SSL, save your certificate and key as ```data\server.pem```, or later configure ```@tune ssl_cert_file``` and ```@tune ssl_key_file```
+* Start the server
+```bat
+restart
+```
+
 ## Building
 Tools needed:
 * [Visual Studio 2015 or higher](https://www.visualstudio.com/downloads/download-visual-studio-vs)
@@ -45,25 +66,4 @@ set OPENSSLDIR=C:\path\to\openssl
 ### Build
 ```bat
 nmake /f makefile.win
-```
-
-## Running
-* Install the [32-bit Visual C++ Redistributable for Visual Studio 2019](https://www.microsoft.com/en-us/download/details.aspx?id=48145) (*Fuzzball currently does not support 64-bit*)
-  * Pick the `x86` version, [or just use this direct link to `vc_redist.x86.exe`](https://aka.ms/vs/16/release/vc_redist.x86.exe)
-* Manage the server with ```restart.exe```
-
-For a comprehensive guide to running a MUCK, check out [MINK - The Muck Information Kiosk](http://www.rdwarf.com/users/mink/muckman/).
-
-### Quick-start
-* **Follow the build directions, or [download a pre-built package](README.md#downloads)**
-* Set up configuration in ```restart.ini```
-```bat
-cd "path\to\fuzzball\folder"
-restart -c
-```
-* Edit and save ```restart.ini``` with your options, e.g. with ```notepad restart.ini```
-* If using SSL, save your certificate and key as ```data\server.pem```, or later configure ```@tune ssl_cert_file``` and ```@tune ssl_key_file```
-* Start the server
-```bat
-restart
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,26 @@ init:
         } else {
             $env:DEPLOY_IMAGE_NAME = "dev-$($env:APPVEYOR_REPO_COMMIT.Substring(0, 8))-$env:APPVEYOR_BUILD_NUMBER"
         }
+        function ConvertMarkdownToHtml([String] $InputFile, [String] $OutputDir) {
+            # Find the filename without path
+            $filename = Split-Path $InputFile -leaf
+
+            # Convert to Markdown
+            # See https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/convertfrom-markdown
+            # Convert ".md" links to ".md.htm", ensuring filename starts with a letter/number
+
+            # Check if we're running on PowerShell 7 or newer
+            if ($PSVersionTable.PSVersion -ge [Version]::new(7, 0, 0)) {
+                # ConvertFrom-Markdown is native
+                (ConvertFrom-Markdown -Path "$InputFile").Html | % {$_ -replace "<a href=""(\w.*)\.md(#.*)?"">", "<a href=""`$1.md.htm`$2"">"} | Out-File "$OutputDir/$filename.htm"
+            } else {
+                # Send to the AppVeyor PowerShell 7 program
+                # Don't use a PowerShell Script Block as it prevents parameters from being substituted in
+                & "C:\Program Files\PowerShell\7\pwsh.exe" -Command @"
+        (ConvertFrom-Markdown -Path ""$InputFile"").Html | % {`$_ -replace ""<a href=""""(\w.*)\.md(#.*)?"""">"", ""<a href=""""```$1.md.htm```$2"""">""} | Out-File ""$OutputDir/$filename.htm""
+        "@
+            }
+        }
 
 build_script:
     - ps: |
@@ -68,6 +88,7 @@ build_script:
 
         # Copy starter database folder
         cp -Recurse "$env:APPVEYOR_BUILD_FOLDER/dbs" "$artifact_root"
+
         # Copy documentation folders
         cp -Recurse "$env:APPVEYOR_BUILD_FOLDER/docs" "$artifact_root"
         md "$artifact_root/data/info"
@@ -75,13 +96,30 @@ build_script:
         cp "$env:APPVEYOR_BUILD_FOLDER/docs/mpi-intro2" "$artifact_root/data/info"
         cp "$env:APPVEYOR_BUILD_FOLDER/docs/muf-tutorial" "$artifact_root/data/info"
         cp "$env:APPVEYOR_BUILD_FOLDER/docs/changesfb7" "$artifact_root/data/info"
+
         # Copy source and include folder
         cp -Recurse "$env:APPVEYOR_BUILD_FOLDER/src" "$artifact_root"
         cp -Recurse "$env:APPVEYOR_BUILD_FOLDER/include" "$artifact_root"
+        # Copy Windows source
+        cp -Recurse "$env:APPVEYOR_BUILD_FOLDER/win32" "$artifact_root"
+
         # Copy text help files to data folder
         cp "$artifact_root/docs/*.txt" "$artifact_root/data/"
+
+        # Copy README files, transforming to Windows line endings
+        # See https://stackoverflow.com/questions/17579553/windows-command-to-convert-unix-line-endings/17580505#17580505
+        #
+        (Get-Content "$env:APPVEYOR_BUILD_FOLDER/README.md") | Set-Content "$artifact_root/README.md.txt"
+        (Get-Content "$env:APPVEYOR_BUILD_FOLDER/README_WINDOWS.md") | Set-Content "$artifact_root/README_WINDOWS.md.txt"
+        #
+        # Also render the Markdown into an HTML file for easier reference
+        ConvertMarkdownToHtml "$env:APPVEYOR_BUILD_FOLDER/README.md" "$artifact_root"
+        ConvertMarkdownToHtml "$env:APPVEYOR_BUILD_FOLDER/README_WINDOWS.md" "$artifact_root"
+
         # Copy compiled binaries and libraries
         cp -Recurse "$env:APPVEYOR_BUILD_FOLDER/build/*" "$artifact_root"
+
+        # Verify basics and make the archive
         if ((Test-Path "$artifact_root/fbmuck.exe") -And (Test-Path "$artifact_root/restart.exe")) {
             echo "Packaging release artifact..."
             7z a "$artifact_zip" "$artifact_root"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,12 @@
+# See https://www.appveyor.com/docs/build-environment/
+image: Visual Studio 2019
+
 version: '{build}'
 
 install:
     # Set up Visual Studio build environment, 32-bit output with a 64-bit builder
     # > Increment version number when newer version of Visual Studio supported by Appveyor
-    - cmd: '"C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/vcvarsall.bat" amd64_x86'
+    - cmd: '"C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvarsall.bat" amd64_x86'
     # Set up Conan package manager
     - cmd: set PATH=%PATH%;%PYTHON%/Scripts/
     - cmd: pip.exe install conan

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,6 +58,11 @@ build_script:
         mkdir "$artifact_root"
         # Copy contents of game folder
         cp -Recurse "$env:APPVEYOR_BUILD_FOLDER/game/*" "$artifact_root"
+        # Remove Unix "restart.in" if copied
+        if (Test-Path "$artifact_root/restart.in") {
+            Remove-Item "$artifact_root/restart.in"
+        }
+
         # Copy starter database folder
         cp -Recurse "$env:APPVEYOR_BUILD_FOLDER/dbs" "$artifact_root"
         # Copy documentation folders


### PR DESCRIPTION
## In short
* Bundle `README.md` and `README_WINDOWS.md` in Windows builds
  * Save as `.md.txt` with Windows line endings
  * Generate `.md.htm` HTML files via PowerShell
* Move AppVeyor builds to Visual Studio 2019
  * Needed to get PowerShell 7.0 on AppVeyor, used for Markdown rendering
* Make `README` Markdown easier to read as plain text
  * Inline URLs for easier access
  * No difference to rendered view
  * Move `Running` section on Windows to top
* Clean up Windows build artifact
  * Add `win32` source directory since other source is already included
  * Remove `restart.in`, only used on Unix

Criteria | Rank | Reason
---------|---------|-------------
Impact | ★☆☆ *1/3* | Provides better guidance for using Windows builds
Risk | ★☆☆ *1/3* | VS 2019 changes, larger artifacts, Markdown render bugs
Intrusiveness | ★☆☆ *1/3* | Documentation, Windows CI, shouldn't interfere with other pull requests

## Examples
### Live sample
Download the latest build artifact from AppVeyor for this pull request.

### Screenshots
#### `README_WINDOWS.md.htm` and `README.md.htm`

Of note, links between `README.md` and `README_WINDOWS.md` automatically get converted to `README.md.htm` and `README_WINDOWS.md.htm`, including any `#poundsign-hashtag-anchors` to point to specific sections.

![The "README_WINDOWS.md.htm" and "README.md.htm" files from the Windows build artifact open side-by-side in Firefox](https://zorro.casa/sync/Hosting/Utilities/Fuzzball/Development/pr/ft-ci-artifact-readme/Windows%20PowerShell%20generated%20Markdown%20HTML.png#v1 )

#### Fuzzball running on Windows, no SSL/TLS
![Screenshot of KDE Remote Desktop Client connected to Windows 10 on AppVeyor showing Fuzzball running, launched via cmd.exe, with Fuzzball server window open and a PuTTY window showing a successful connection to the MUCK](https://zorro.casa/sync/Hosting/Utilities/Fuzzball/Development/pr/ft-ci-artifact-readme/Windows%20Fuzzball%20running%20on%20AppVeyor.png#v1 )

#### Zip folder contents
```
     206 Sep 13  2020 data
      44 Sep 13  2020 dbs
     246 Sep 13  2020 docs
 1072640 Sep 13  2020 fbmuck.exe
     928 Sep 13  2020 include
 1307648 Sep 13  2020 libeay32.dll
      12 Sep 13  2020 logs
      12 Sep 13  2020 muf
    3802 Sep 13  2020 README.md.htm
    3106 Sep 13  2020 README.md.txt
    3632 Sep 13  2020 README_WINDOWS.md.htm
    2668 Sep 13  2020 README_WINDOWS.md.txt
  148480 Sep 13  2020 restart.exe
    1062 Sep 13  2020 src
  284672 Sep 13  2020 ssleay32.dll
     136 Sep 13  2020 win32
```