### PR TITLE
Clean up docker container implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,36 @@
 FROM ubuntu:20.04
+RUN apt update && apt dist-upgrade -y
+RUN apt-get install -y build-essential \
+      libpcre3-dev libssl-dev git autoconf \
+      automake autoconf-archive
+RUN git clone https://github.com/fuzzball-muck/fuzzball.git && \
+    cd fuzzball && git pull origin master && \
+    ./configure --with-ssl --prefix /root/scratch && make clean && \
+    make && make install
 
+FROM ubuntu:20.04
 RUN apt update && apt dist-upgrade -y \
     && apt-get install -y libssl1.1 openssl \
     && mkdir -p /opt/fbmuck-base \
     && mkdir -p /opt/fbmuck-ssl
+COPY --from=0 /root/scratch /usr
 
-# Copy binaries into /usr/bin
-COPY src/fbmuck src/fb-resolver scripts/docker-entrypoint.sh /usr/bin/
+# Copy docker-entrypoint.sh into /usr/bin
+COPY scripts/docker-entrypoint.sh /usr/bin/
 
 RUN chmod a+rx /usr/bin/docker-entrypoint.sh
 
-# Copy FB base into /opt/fbmuck-base in case we need to start a blank DB.
+# Copy FB base into /opt/fbmuck-base in case we need to start a blank DB
 COPY game/ dbs/starterdb/ /opt/fbmuck-base/
+# Additionally, copy files in docks into the fbmuck-base/data directory
+# so users have helpful things like help.txt
+COPY docs/ /opt/fbmuck-base/data
 
 # Rename the base db to the right db file name
 RUN mv /opt/fbmuck-base/data/starterdb.db /opt/fbmuck-base/data/std-db.db
 
-ENTRYPOINT /usr/bin/docker-entrypoint.sh
+# Uncomment this before building if you want the database saved upon
+# process termination
+#STOPSIGNAL SIGUSR2
+
+ENTRYPOINT ["bash", "/usr/bin/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN chmod a+rx /usr/bin/docker-entrypoint.sh
 
 # Copy FB base into /opt/fbmuck-base in case we need to start a blank DB
 COPY game/ dbs/starterdb/ /opt/fbmuck-base/
-# Additionally, copy files in docks into the fbmuck-base/data directory
+# Additionally, copy files in docs into the fbmuck-base/data directory
 # so users have helpful things like help.txt
 COPY docs/ /opt/fbmuck-base/data
 

--- a/README_DOCKER.md
+++ b/README_DOCKER.md
@@ -27,7 +27,7 @@ Several environment variables control the behavior of Fuzzball when run with doc
 * FB_USE_SSL - If this is '1', we will use SSL.  Any other value (or unset) will not enable SSL.
 * FB_SELF_SIGN - If this is '1', we will generate self-signed certs if there are no certs already made and FB_USE_SSL is 1.  Otherwise, if FB_USE_SSL is 1 and this is unset, and there are no SSL certificates, you will get an error.
 
-There is an .env file in this directory, which contains some defaults for these:
+There is a ```.env``` file in this directory, which contains some defaults for these:
 
 * FB_PORT defaults to 4201
 * FB_SSL_PORT defaults to 4202
@@ -80,9 +80,9 @@ docker run -d --init -p 4201:4201 -p 4202:4202 -e USE_SSL=1 -e SELF_SIGN=1 \
 
 ## Terminating the container
 
-Either implementation of the running Fuzzball Docker container respect the ```fbmuck``` binary's kill signals, when run as described in this document.
+Either implementation of the Fuzzball Docker containers respect the ```fbmuck``` binary's kill signals, when run as described in this document.
 
-Both the ```Dockerfile``` and ```docker-compose.yaml``` files contain lines which you can uncomment to leverage SIGUSR2 (if you wish the database to be saved before container shutdown). Otherwise, SIGKILL (the default) will terminate the Fuzzball process without saving.
+Both the ```Dockerfile``` and ```docker-compose.yaml``` files contain lines which you can uncomment to leverage SIGUSR2, if you wish the database to be saved before container shutdown. Otherwise, SIGKILL (the default) will terminate the Fuzzball process without saving.
 
 ## SSL
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: "3.3"
+version: "3.7"
 
 services:
   fbmuck:
@@ -7,6 +7,10 @@ services:
       context: ./
       dockerfile: Dockerfile
     command: /usr/bin/docker-entrypoint.sh
+    init: true
+    # Uncomment this before building if you want to have the database saved
+    #  when the container terminates
+    #stop_signal: SIGUSR2
     # If you aren't using SSL, you can comment out the line for FB_SSL_PORT
     # so that it doesn't open the second port.
     ports:

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -9,8 +9,8 @@ prefix=/opt
 exec_prefix=/usr
 
 #
-# You'll want to edit this to match the base directory of your muck's files.
-# This should be the directory containing the 'data' and 'muf' directories.
+# In a Docker environment, the GAMEDIR should always be the value below.
+# This assures that directory mapping will always point to the correct place.
 #
 GAMEDIR="$prefix/fbmuck"
 
@@ -144,4 +144,4 @@ touch $RESTARTS_LOGFILE
 echo "$(date +%Y-%m-%dT%H:%M:%S): $(who am i)" >> $RESTARTS_LOGFILE
 
 # echo "Server started at: $(date)"
-$SERVER -nodetach -gamedir $GAMEDIR -dbin $DBIN -dbout $DBOUT $PORTS
+exec $SERVER -nodetach -gamedir $GAMEDIR -dbin $DBIN -dbout $DBOUT $PORTS


### PR DESCRIPTION
- Make builds independant of the OS the container runs on
- Leverage tinit to allow better process handling
- Support non-default kill signals for the fbmuck process
- Update documentation