### PR TITLE
Fixed docker to build based on local source files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,13 @@ RUN apt update && apt dist-upgrade -y
 RUN apt-get install -y build-essential \
       libpcre3-dev libssl-dev git autoconf \
       automake autoconf-archive
-RUN git clone https://github.com/fuzzball-muck/fuzzball.git && \
-    cd fuzzball && git pull origin master && \
+COPY . fuzzball/
+RUN cd fuzzball && \
     ./configure --with-ssl --prefix /root/scratch && make clean && \
-    make && make install
+    make && make install && cd docs && \
+    ../src/prochelp ../src/mpihelp.raw mpihelp.txt mpihelp.html && \
+    ../src/prochelp ../src/mufman.raw mufman.txt mufman.html && \
+    ../src/prochelp ../src/muckhelp.raw muckhelp.txt muckhelp.html
 
 FROM ubuntu:20.04
 RUN apt update && apt dist-upgrade -y \


### PR DESCRIPTION
Fixes @skylerbunny 's PR using local files to build instead of pulling it down from GIT.  The build is actually still pretty fast so even though I feel like I might be able to make this more efficient (using volumes or whatnot) I don't think its worth the trouble.