### PR TITLE
Alterations to condescr branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,13 @@ RUN apt update && apt dist-upgrade -y
 RUN apt-get install -y build-essential \
       libpcre3-dev libssl-dev git autoconf \
       automake autoconf-archive
-RUN git clone https://github.com/fuzzball-muck/fuzzball.git && \
-    cd fuzzball && git pull origin master && \
+COPY . fuzzball/
+RUN cd fuzzball && \
     ./configure --with-ssl --prefix /root/scratch && make clean && \
-    make && make install
+    make && make install && cd docs && \
+    ../src/prochelp ../src/mpihelp.raw mpihelp.txt mpihelp.html && \
+    ../src/prochelp ../src/mufman.raw mufman.txt mufman.html && \
+    ../src/prochelp ../src/muckhelp.raw muckhelp.txt muckhelp.html
 
 FROM ubuntu:20.04
 RUN apt update && apt dist-upgrade -y \

--- a/Makefile.in
+++ b/Makefile.in
@@ -28,18 +28,10 @@ install:	Makefile
 	fi; \
 	fi
 
-docker:	all
-	cd docs && ../src/prochelp ../src/mpihelp.raw mpihelp.txt mpihelp.html > /dev/null
-	cd docs && ../src/prochelp ../src/mufman.raw man.txt mufman.html > /dev/null
-	cd docs && ../src/prochelp ../src/muckhelp.raw help.txt muckhelp.html > /dev/null
-	cd docs && ${INSTALL_DATA} help.txt man.txt mpihelp.txt ../game/data
+docker:
 	docker build -t fbmuck .
 
-docker-compose:	all
-	cd docs && ../src/prochelp ../src/mpihelp.raw mpihelp.txt mpihelp.html > /dev/null
-	cd docs && ../src/prochelp ../src/mufman.raw man.txt mufman.html > /dev/null
-	cd docs && ../src/prochelp ../src/muckhelp.raw help.txt muckhelp.html > /dev/null
-	cd docs && ${INSTALL_DATA} help.txt man.txt mpihelp.txt ../game/data
+docker-compose:
 	docker-compose build
 
 install-sysv-inits:	Makefile

--- a/include/interface.h
+++ b/include/interface.h
@@ -122,7 +122,6 @@ struct descriptor_data {
                              *   support console
                              */
     int connected;          /**< Is playing? (has gotten past login) */
-    int con_number;         /**< The connection number               */
     int booted;             /**< 0 = do not boot;
                              *   1 = boot without message;
                              *   2 = boot with goodbye
@@ -166,7 +165,7 @@ struct descriptor_data {
     const char *username;           /**< Ident username if available         */
     int quota;                      /**< Command burst quota                 */
     struct descriptor_data *next;   /**< Linked list of descriptors          */
-    struct descriptor_data **prev;  /**< Double linked list                  */
+    struct descriptor_data *prev;   /**< Double linked list                  */
     McpFrame mcpframe;              /**< MCP Frame information               */
 };
 
@@ -183,6 +182,13 @@ extern short db_conversion_flag;
  *      The list of descriptors being managed.
  */
 extern struct descriptor_data *descriptor_list;
+
+/**
+ * @var descriptor_list_tail
+ *      The list of descriptors being managed, but from the tail of the linked
+ *      list.
+ */
+extern struct descriptor_data *descriptor_list_tail;
 
 /**
  * @var global_dumpdone
@@ -645,24 +651,6 @@ dbref partial_pmatch(const char *name);
 int pdescrcount(void);
 
 /**
- * Get the player dbref for a given connection count number.
- *
- * Returns NOTHING if 'c' doesn't match.
- *
- * @param c the connection count number
- * @return the associated player dbref.
- */
-int pdbref(int c);
-
-/**
- * Get the descriptor for a given connection number
- *
- * @param c the connection number
- * @return the associated descriptor
- */
-int pdescr(int c);
-
-/**
  * Boot a given descriptor.
  *
  * Returns true if booted, false if not found.
@@ -782,7 +770,7 @@ char *pdescruser(int c);
 int pfirstdescr(void);
 
 /**
- * Get the last descriptor currently connected (connection number 1)
+ * Get the last descriptor currently connected and logged into the MUCK.
  *
  * @return the last descriptor currently connected.
  */

--- a/include/p_connects.h
+++ b/include/p_connects.h
@@ -35,7 +35,6 @@ void prim_awakep(PRIM_PROTOTYPE);
  * each connection to the server.
  *
  * @see pcount
- * @see pdbref
  *
  * @param player the player running the MUF program
  * @param program the program being run
@@ -54,7 +53,6 @@ void prim_online(PRIM_PROTOTYPE);
  * each connection to the server.
  *
  * @see pcount
- * @see pdbref
  *
  * @param player the player running the MUF program
  * @param program the program being run

--- a/src/mfuns.c
+++ b/src/mfuns.c
@@ -1690,7 +1690,7 @@ mfn_ontime(MFUNARGS)
     if (!conn)
         return "-1";
 
-    snprintf(buf, BUFFER_LEN, "%d", pdescrontime(pdescr(conn)));
+    snprintf(buf, BUFFER_LEN, "%d", pdescrontime(conn));
     return buf;
 }
 
@@ -1731,7 +1731,7 @@ mfn_idle(MFUNARGS)
     if (!conn)
         return "-1";
 
-    snprintf(buf, BUFFER_LEN, "%d", pdescridle(pdescr(conn)));
+    snprintf(buf, BUFFER_LEN, "%d", pdescridle(conn));
     return buf;
 }
 
@@ -1758,23 +1758,29 @@ mfn_online(MFUNARGS)
     int list_limit = MAX_MFUN_LIST_LEN;
     int count = pdescrcount();
     char buf2[BUFFER_LEN];
+    struct descriptor_data* d = descriptor_list_tail;
 
     if (!(mesgtyp & MPI_ISBLESSED))
         ABORT_MPI("ONLINE", "Permission denied.");
 
     *buf = '\0';
 
-    while (count && list_limit--) {
+    for ( ; list_limit && d; d = d->prev) {
+        if (!d->connected) {
+            continue;
+        }
+
         if (*buf)
             strcatn(buf, BUFFER_LEN, "\r");
 
-        ref2str(pdbref(count), buf2, sizeof(buf2));
+        ref2str(d->player, buf2, sizeof(buf2));
 
         if ((strlen(buf) + strlen(buf2)) >= (BUFFER_LEN - 3))
             break;
 
         strcatn(buf, BUFFER_LEN, buf2);
         count--;
+        list_limit--;
     }
 
     return buf;


### PR DESCRIPTION
@wyld-sw 
Okay I think this works -- WHO now shows people in the right order, and this gets rid of the whole connection table.

What I'd like to do before merging this is really test the hell out of this, especially I want to test all the MUF primitives for similar behaviors.  i.e. for instance first descriptor / last descriptor.  However I think this is good enough to code review.

Feel free to merge this into condescr branch, should be safe to do so, it won't touch master.  Feel free to help trace and test :)  This is kind of a big one so the more eyes won it the better.