### PR TITLE
More condescr fixes

### DIFF
--- a/src/p_connects.c
+++ b/src/p_connects.c
@@ -733,17 +733,27 @@ prim_descr_array(PRIM_PROTOTYPE)
     temp2.type = PROG_INTEGER;
 
     if (ref == NOTHING) {
-        d = descriptor_list;
+        result = 0;
+
+        for (d = descriptor_list; d; d = d->next) {
+            if (d->connected)
+                result++;
+        }
+
         newarr = new_array_packed(result, fr->pinning);
+
+        d = descriptor_list;
 
         for (int i = 0; d; d = d->next) {
             if (d->connected) {
                 temp1.data.number = i;
-                i++;
                 temp2.data.number = d->descriptor;
+
+                array_setitem(&newarr, &temp1, &temp2);
+                i++;
             }
         }
-	} else {
+    } else {
         darr = get_player_descrs(ref, &dcount);
         newarr = new_array_packed(dcount, fr->pinning);
 

--- a/src/p_connects.c
+++ b/src/p_connects.c
@@ -153,9 +153,18 @@ prim_online_array(PRIM_PROTOTYPE)
     temp1.line = 0;
     temp2.line = 0;
 
-    nu = new_array_packed(0, fr->pinning);
+    result = 0;
 
-    for (int i = 0; d; d = d->prev) {
+    for ( ; d; d = d->next) {
+        if (d->connected)
+            result++;
+    }
+
+    nu = new_array_packed(result, fr->pinning);
+
+    d = descriptor_list;
+
+    for (int i = 0; d; d = d->next) {
         if (d->connected) {
             temp1.data.number = i;
             temp2.data.number = d->player;

--- a/src/p_connects.c
+++ b/src/p_connects.c
@@ -106,9 +106,11 @@ prim_online(PRIM_PROTOTYPE)
 
     CHECKOFLOW(result+1);
 
+    result = 0;
+
     for ( ; d; d = d->prev) {
         if (d->connected) {
-            PushObject(d->descriptor);
+            PushObject(d->player);
             result++;
         }
     }


### PR DESCRIPTION
This fixes bugs in DESCR_ARRAY, ONLINE, and ONLINE_ARRAY that weren't caught in #655. To demonstrate:
```forth
: main
    #-1 descriptors debug_line popn
    #-1 descr_array debug_line pop
    online debug_line popn
    online_array debug_line pop
;
```

It also fixes ONLINE and ONLINE_ARRAY returning multiple dbrefs for players that have more than one descriptor connected and logged in. This was inadvertently introduced when migrating from the "connection" list to the descriptor list.

Regarding my comments in d1de0a9, I'm honestly unsure whether to replicate the original undocumented behavior. I don't know of any code that uses it besides one program from Nameless MUCK, which sorts the connection list itself anyway according to user input. If you'd like the old behavior back, just say the word.