### PR TITLE
Tiny fixes

### DIFF
--- a/src/p_array.c
+++ b/src/p_array.c
@@ -1866,27 +1866,7 @@ prim_array_get_propvals(PRIM_PROTOTYPE)
                 }
 
                 if (goodflag) {
-                    /*
-                     * TODO: This hard-coded limit kind of sucks in a lot of
-                     *       ways.  The only reason this limit is here is to
-                     *       prevent someone from gobbling up all the server
-                     *       memory or causing a performance drag.
-                     *
-                     *       I'm of the opinion such limitations should be
-                     *       in the hands of MUCK owners rather than us
-                     *       making arbitrary choices -- there are times where
-                     *       I have chosen to use the outdated iterator
-                     *       approach (nextprop, etc.) over using the array
-                     *       funcs because I was not 100% sure there would be
-                     *       less than 512 props and I didn't want to paint
-                     *       myself into a corner.
-                     *
-                     *       Thus, I think this should be a tune param.
-                     *       Similar calls (like array_get_propdirs, etc.)
-                     *       can share the tune param.  At LEAST make it
-                     *       a #define so people can tweak it.
-                     */
-                    if (count++ >= 511) {
+                    if (count++ >= tp_max_propfetch) {
                         array_free(nu);
                         abort_interp("Too many properties to put in an array!");
                     }

--- a/src/p_array.c
+++ b/src/p_array.c
@@ -1977,16 +1977,17 @@ prim_array_get_proplist(PRIM_PROTOTYPE)
         }
     }
 
+    if (maxcount > tp_max_propfetch) {
+        maxcount = tp_max_propfetch;
+    }
+
     /*
-     * TODO: for some reason, we are... IN A LOOP.... checking if
-     *       maxcount > tp_max_propfetch *and* checking property permissions
+     * TODO: for some reason, we are... IN A LOOP.... checking property permissions
      *       on a propdir where only the base property name (i.e. the contents
      *       of 'dir') has any bearing on the permissions as the rest of the
      *       prop path will be a number which never has a bearing on prop perms.
      *
-     *       Firstly, let's check *here* if maxcount > tp_max_propfetch.
-     *
-     *       Secondly, this call silently doesn't display extra items but the
+     *       This call silently doesn't display extra items but the
      *       other similar calls throw an error if there are too many items.
      *       I think throwing an error makes more sense rather than just making
      *       it appear broken :)  So I would highly recommend we do that and
@@ -2021,13 +2022,6 @@ prim_array_get_proplist(PRIM_PROTOTYPE)
                 snprintf(propname, sizeof(propname), "%s%d", dir, count);
                 prptr = get_property(ref, propname);
             }
-        }
-
-        /*
-         * @TODO: see above, move this check
-         */
-        if (maxcount > tp_max_propfetch) {
-            maxcount = tp_max_propfetch;
         }
 
         if (maxcount) {


### PR DESCRIPTION
Two itty bitty changes:
1. Take care of the TODO in ``prim_array_get_propvals``, which the doc comment claimed was already implemented; and
2. Pull the check capping the returned array in ``prim_array_get_proplist`` out of the loop.