### PR TITLE
wiz.c changes

### DIFF
--- a/docs/help.txt
+++ b/docs/help.txt
@@ -40,18 +40,18 @@ Symbols
   @examine           @fail              @find              @force
   @force_lock        @idescribe         @kill              @link
   @linklock          @list              @lock              @mcpedit
-  @mcpprogram        @memory            @mpitops           @muftops
-  @name              @newpassword       @odrop             @oecho
-  @ofail             @open              @osuccess          @owned
-  @ownlock           @password          @pcreate           @pecho
-  @program           @propset           @ps                @readlock
-  @reconfiguressl    @recycle           @register          @relink
-  @restart           @restrict          @sanchange         @sanfix
-  @sanity            @set               @shutdown          @stats
-  @success           @sweep             @teledump          @teleport
-  @toad              @tops              @trace             @tune
-  @unbless           @uncompile         @unlink            @unlock
-  @usage             @version           @wall              
+  @mcpprogram        @memory            @name              @newpassword
+  @odrop             @oecho             @ofail             @open
+  @osuccess          @owned             @ownlock           @password
+  @pcreate           @pecho             @program           @propset
+  @ps                @readlock          @reconfiguressl    @recycle
+  @register          @relink            @restart           @restrict
+  @sanchange         @sanfix            @sanity            @set
+  @shutdown          @stats             @success           @sweep
+  @teledump          @teleport          @toad              @tops
+  @trace             @tune              @unbless           @uncompile
+  @unlink            @unlock            @usage             @version
+  @wall              
 
 A's
   abode  
@@ -1960,12 +1960,11 @@ Wizardly Commands
 
 @armageddon        @bless             @boot              @credits
 @debug             @dump              @examine           @force
-@memory            @mpitops           @muftops           @newpassword
-@pcreate           @reconfiguressl    @restart           @restrict
-@sanchange         @sanfix            @sanity            @shutdown
-@teledump          @toad              @tops              @tune
-@unbless           @uncompile         @usage             @version
-@wall              
+@memory            @newpassword       @pcreate           @reconfiguressl
+@restart           @restrict          @sanchange         @sanfix
+@sanity            @shutdown          @teledump          @toad
+@tops              @tune              @unbless           @uncompile
+@usage             @version           @wall              
 
 ~----------------------------------------------------------------------------
 ~
@@ -2191,13 +2190,13 @@ More options will be added in the future.
 
   Examples:
     @debug display propcache    display database property cache
-Also see: @MEMORY, @MPITOPS, @MUFTOPS, @TOPS and @USAGE
+Also see: @MEMORY, @TOPS and @USAGE
 ~
 ~
 @TOPS
 @TOPS
-@TOPS <count>
-@TOPS reset
+@TOPS [muf|mpi] <count>
+@TOPS [muf|mpi] reset
 
   Show process usage and runtime statistics for both MUF and MPI
 programs.  Count controls the maximum rows of results shown.  If left
@@ -2207,9 +2206,10 @@ blank, it uses the default of '10'.
 
   Examples:
     @tops              show default amount of profiling statistics
-    @tops 5            show 5 rows of profiling statistics
-    @tops reset        reset all collected profiling statistics
-Also see: @DEBUG, @MEMORY, @MPITOPS, @MUFTOPS and @USAGE
+    @tops 3            show 3 rows of all profiling statistics
+    @tops muf 5        show 5 rows of MUF profiling statistics
+    @tops mpi reset    reset MPI collected profiling statistics
+Also see: @DEBUG, @MEMORY and @USAGE
 ~
 ~
 @MEMORY
@@ -2218,43 +2218,7 @@ Also see: @DEBUG, @MEMORY, @MPITOPS, @MUFTOPS and @USAGE
   Wizard only command that gives detailed memory stats for the muck
 server process.  If HAVE_MALLINFO is used, this command shows more
 information.
-Also see: @DEBUG, @MPITOPS, @MUFTOPS, @TOPS and @USAGE
-~
-~
-@MPITOPS
-@MPITOPS
-@MPITOPS <count>
-@MPITOPS reset
-
-  Show process usage and runtime statistics only for MPI programs.
-Count controls the maximum rows of results shown.  If left blank, it
-uses the default of '10'.
-
-  This is a wizard-only command.
-
-  Examples:
-    @mpitops           show default amount of profiling statistics
-    @mpitops 5         show 5 rows of profiling statistics
-    @mpitops reset     reset collected MPI profiling statistics
-Also see: @DEBUG, @MEMORY, @MUFTOPS, @TOPS and @USAGE
-~
-~
-@MUFTOPS
-@MUFTOPS
-@MUFTOPS <count>
-@MUFTOPS reset
-
-  Show process usage and runtime statistics only for MUF programs.
-Count controls the maximum rows of results shown.  If left blank, it
-uses the default of '10'.
-
-  This is a wizard-only command.
-
-  Examples:
-    @muftops           show default amount of profiling statistics
-    @muftops 5         show 5 rows of profiling statistics
-    @muftops reset     reset collected MUF profiling statistics
-Also see: @DEBUG, @MEMORY, @MPITOPS, @TOPS and @USAGE
+Also see: @DEBUG, @TOPS and @USAGE
 ~
 ~
 @USAGE
@@ -2262,7 +2226,7 @@ Also see: @DEBUG, @MEMORY, @MPITOPS, @TOPS and @USAGE
 
   Wizard only command that gives system resource usage stats for the
 muck server process.
-Also see: @DEBUG, @MEMORY, @MPITOPS, @MUFTOPS and @TOPS
+Also see: @DEBUG, @MEMORY and @TOPS
 ~
 ~
 @EXAMINE

--- a/docs/muckhelp.html
+++ b/docs/muckhelp.html
@@ -61,8 +61,6 @@
     <li><a href="#@mcpedit">@mcpedit</a></li>
     <li><a href="#@mcpprogram">@mcpprogram</a></li>
     <li><a href="#@memory">@memory</a></li>
-    <li><a href="#@mpitops">@mpitops</a></li>
-    <li><a href="#@muftops">@muftops</a></li>
     <li><a href="#@name">@name</a></li>
     <li><a href="#@newpassword">@newpassword</a></li>
     <li><a href="#@odrop">@odrop</a></li>
@@ -3087,8 +3085,6 @@ edit package, an editor window will appear instead of using the text edit mode.
     <li><a href="#@examine">@examine</a></li>
     <li><a href="#@force">@force</a></li>
     <li><a href="#@memory">@memory</a></li>
-    <li><a href="#@mpitops">@mpitops</a></li>
-    <li><a href="#@muftops">@muftops</a></li>
     <li><a href="#@newpassword">@newpassword</a></li>
     <li><a href="#@pcreate">@pcreate</a></li>
     <li><a href="#@reconfiguressl">@reconfiguressl</a></li>
@@ -3431,8 +3427,6 @@ More options will be added in the future.
 </pre>
 <p>Also see:
     <a href="#@memory">@MEMORY</a>,
-    <a href="#@mpitops">@MPITOPS</a>,
-    <a href="#@muftops">@MUFTOPS</a>,
     <a href="#@tops">@TOPS</a> and
     <a href="#@usage">@USAGE</a>
 </p>
@@ -3441,9 +3435,9 @@ More options will be added in the future.
 
 <h3 id="@tops">@TOPS
 <br>
-@TOPS &lt;count&gt;
+@TOPS [muf|mpi] &lt;count&gt;
 <br>
-@TOPS reset
+@TOPS [muf|mpi] reset
 <br>
 
 <br>
@@ -3459,14 +3453,13 @@ blank, it uses the default of '10'.
   Examples:
 <pre>
     @tops              show default amount of profiling statistics
-    @tops 5            show 5 rows of profiling statistics
-    @tops reset        reset all collected profiling statistics
+    @tops 3            show 3 rows of all profiling statistics
+    @tops muf 5        show 5 rows of MUF profiling statistics
+    @tops mpi reset    reset MPI collected profiling statistics
 </pre>
 <p>Also see:
     <a href="#@debug">@DEBUG</a>,
-    <a href="#@memory">@MEMORY</a>,
-    <a href="#@mpitops">@MPITOPS</a>,
-    <a href="#@muftops">@MUFTOPS</a> and
+    <a href="#@memory">@MEMORY</a> and
     <a href="#@usage">@USAGE</a>
 </p>
 <!-- HTML_TOPICEND -->
@@ -3482,74 +3475,6 @@ server process.  If HAVE_MALLINFO is used, this command shows more
 information.
 <p>Also see:
     <a href="#@debug">@DEBUG</a>,
-    <a href="#@mpitops">@MPITOPS</a>,
-    <a href="#@muftops">@MUFTOPS</a>,
-    <a href="#@tops">@TOPS</a> and
-    <a href="#@usage">@USAGE</a>
-</p>
-<!-- HTML_TOPICEND -->
-
-
-<h3 id="@mpitops">@MPITOPS
-<br>
-@MPITOPS &lt;count&gt;
-<br>
-@MPITOPS reset
-<br>
-
-<br>
-</h3>
-  Show process usage and runtime statistics only for MPI programs.
-Count controls the maximum rows of results shown.  If left blank, it
-uses the default of '10'.
-
-<p>
-  This is a wizard-only command.
-
-<p>
-  Examples:
-<pre>
-    @mpitops           show default amount of profiling statistics
-    @mpitops 5         show 5 rows of profiling statistics
-    @mpitops reset     reset collected MPI profiling statistics
-</pre>
-<p>Also see:
-    <a href="#@debug">@DEBUG</a>,
-    <a href="#@memory">@MEMORY</a>,
-    <a href="#@muftops">@MUFTOPS</a>,
-    <a href="#@tops">@TOPS</a> and
-    <a href="#@usage">@USAGE</a>
-</p>
-<!-- HTML_TOPICEND -->
-
-
-<h3 id="@muftops">@MUFTOPS
-<br>
-@MUFTOPS &lt;count&gt;
-<br>
-@MUFTOPS reset
-<br>
-
-<br>
-</h3>
-  Show process usage and runtime statistics only for MUF programs.
-Count controls the maximum rows of results shown.  If left blank, it
-uses the default of '10'.
-
-<p>
-  This is a wizard-only command.
-
-<p>
-  Examples:
-<pre>
-    @muftops           show default amount of profiling statistics
-    @muftops 5         show 5 rows of profiling statistics
-    @muftops reset     reset collected MUF profiling statistics
-</pre>
-<p>Also see:
-    <a href="#@debug">@DEBUG</a>,
-    <a href="#@memory">@MEMORY</a>,
-    <a href="#@mpitops">@MPITOPS</a>,
     <a href="#@tops">@TOPS</a> and
     <a href="#@usage">@USAGE</a>
 </p>
@@ -3565,9 +3490,7 @@ uses the default of '10'.
 muck server process.
 <p>Also see:
     <a href="#@debug">@DEBUG</a>,
-    <a href="#@memory">@MEMORY</a>,
-    <a href="#@mpitops">@MPITOPS</a>,
-    <a href="#@muftops">@MUFTOPS</a> and
+    <a href="#@memory">@MEMORY</a> and
     <a href="#@tops">@TOPS</a>
 </p>
 <!-- HTML_TOPICEND -->

--- a/include/commands.h
+++ b/include/commands.h
@@ -797,46 +797,6 @@ void do_motd(dbref player, char *text);
  */
 void do_move(int descr, dbref player, const char *direction, int lev);
 
-/**
- * Implementation of the \@mpitops command
- *
- * Defined in wiz.c
- *
- * This shows statistics about programs that have been running.  These
- * statistics are shown for top 'arg1' number of programs.  The default
- * is '10'.  'reset' can also be passed to reset the statistic numbers.
- *
- * This iterates over the entire DB and puts the programs in a
- * 'struct profnode' linked list.  For large numbers of 'arg1', this is
- * really inefficient since its sorting a linked list.
- *
- * This does not do any permission checking.
- *
- * @param player the player doing the call
- * @param arg1 Either a string containing a number, the word "reset", or ""
- */
-void do_mpi_topprofs(dbref player, char *arg1);
-
-/**
- * Implementation of the \@muftops command
- *
- * Defined in wiz.c
- *
- * This shows statistics about programs that have been running.  These
- * statistics are shown for top 'arg1' number of programs.  The default
- * is '10'.  'reset' can also be passed to reset the statistic numbers.
- *
- * This iterates over the entire DB and puts the programs in a
- * 'struct profnode' linked list.  For large numbers of 'arg1', this is
- * really inefficient since its sorting a linked list.
- *
- * This does not do any permission checking.
- *
- * @param player the player doing the call
- * @param arg1 Either a string containing a number, the word "reset", or ""
- */
-void do_muf_topprofs(dbref player, char *arg1);
-
 /*
  * N
  */

--- a/src/game.c
+++ b/src/game.c
@@ -1100,20 +1100,6 @@ process_command(int descr, dbref player, const char *command)
                                 do_memory(player);
                                 break;
 #endif
-                            case 'p':
-                            case 'P':
-                                Matched("@mpitops");
-                                WIZARDONLY("@mpitops", player);
-                                do_mpi_topprofs(player, arg1);
-                                break;
-
-                            case 'u':
-                            case 'U':
-                                Matched("@muftops");
-                                WIZARDONLY("@muftops", player);
-                                do_muf_topprofs(player, arg1);
-                                break;
-
                             default:
                                 goto bad;
                         }

--- a/src/muckhelp.raw
+++ b/src/muckhelp.raw
@@ -2017,13 +2017,13 @@ More options will be added in the future.
 ~~code
     @debug display propcache    display database property cache
 ~~endcode
-~~alsosee @MEMORY,@MPITOPS,@MUFTOPS,@TOPS,@USAGE
+~~alsosee @MEMORY,@TOPS,@USAGE
 ~
 ~
 @TOPS
 @TOPS
-@TOPS <count>
-@TOPS reset
+@TOPS [muf|mpi] <count>
+@TOPS [muf|mpi] reset
 
   Show process usage and runtime statistics for both MUF and MPI
 programs.  Count controls the maximum rows of results shown.  If left
@@ -2034,10 +2034,11 @@ blank, it uses the default of '10'.
   Examples:
 ~~code
     @tops              show default amount of profiling statistics
-    @tops 5            show 5 rows of profiling statistics
-    @tops reset        reset all collected profiling statistics
+    @tops 3            show 3 rows of all profiling statistics
+    @tops muf 5        show 5 rows of MUF profiling statistics
+    @tops mpi reset    reset MPI collected profiling statistics
 ~~endcode
-~~alsosee @DEBUG,@MEMORY,@MPITOPS,@MUFTOPS,@USAGE
+~~alsosee @DEBUG,@MEMORY,@USAGE
 ~
 ~
 @MEMORY
@@ -2046,47 +2047,7 @@ blank, it uses the default of '10'.
   Wizard only command that gives detailed memory stats for the muck
 server process.  If HAVE_MALLINFO is used, this command shows more
 information.
-~~alsosee @DEBUG,@MPITOPS,@MUFTOPS,@TOPS,@USAGE
-~
-~
-@MPITOPS
-@MPITOPS
-@MPITOPS <count>
-@MPITOPS reset
-
-  Show process usage and runtime statistics only for MPI programs.
-Count controls the maximum rows of results shown.  If left blank, it
-uses the default of '10'.
-
-  This is a wizard-only command.
-
-  Examples:
-~~code
-    @mpitops           show default amount of profiling statistics
-    @mpitops 5         show 5 rows of profiling statistics
-    @mpitops reset     reset collected MPI profiling statistics
-~~endcode
-~~alsosee @DEBUG,@MEMORY,@MUFTOPS,@TOPS,@USAGE
-~
-~
-@MUFTOPS
-@MUFTOPS
-@MUFTOPS <count>
-@MUFTOPS reset
-
-  Show process usage and runtime statistics only for MUF programs.
-Count controls the maximum rows of results shown.  If left blank, it
-uses the default of '10'.
-
-  This is a wizard-only command.
-
-  Examples:
-~~code
-    @muftops           show default amount of profiling statistics
-    @muftops 5         show 5 rows of profiling statistics
-    @muftops reset     reset collected MUF profiling statistics
-~~endcode
-~~alsosee @DEBUG,@MEMORY,@MPITOPS,@TOPS,@USAGE
+~~alsosee @DEBUG,@TOPS,@USAGE
 ~
 ~
 @USAGE
@@ -2094,7 +2055,7 @@ uses the default of '10'.
 
   Wizard only command that gives system resource usage stats for the
 muck server process.
-~~alsosee @DEBUG,@MEMORY,@MPITOPS,@MUFTOPS,@TOPS
+~~alsosee @DEBUG,@MEMORY,@TOPS
 ~
 ~
 @EXAMINE

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -313,6 +313,8 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
  * Two kinds of wildcards are understood; * and **.  ** is a recursive
  * wildcard, * is just a 'local' match.
  *
+ * The caller is responsible for permission checks.
+ *
  * @private
  * @param player the player doing the operation
  * @param thing the thing we are operating on
@@ -327,8 +329,8 @@ blessprops_wildcard(dbref player, dbref thing, const char *dir,
 {
     char propname[BUFFER_LEN];
     char wld[BUFFER_LEN];
-    char buf[BUFFER_LEN];
-    char buf2[BUFFER_LEN];
+    char buf[BUFFER_LEN+1];
+    char buf2[BUFFER_LEN+11];
     char *ptr, *wldcrd;
     PropPtr propadr, pptr;
     int i, cnt = 0;
@@ -1027,16 +1029,16 @@ do_usage(dbref player)
     psize = sysconf(_SC_PAGESIZE);
     getrusage(RUSAGE_SELF, &usage);
 
-    notifyf(player, "Performed %d input servicings.", usage.ru_inblock);
-    notifyf(player, "Performed %d output servicings.", usage.ru_oublock);
-    notifyf(player, "Sent %d messages over a socket.", usage.ru_msgsnd);
-    notifyf(player, "Received %d messages over a socket.", usage.ru_msgrcv);
-    notifyf(player, "Received %d signals.", usage.ru_nsignals);
-    notifyf(player, "Page faults NOT requiring physical I/O: %d", usage.ru_minflt);
-    notifyf(player, "Page faults REQUIRING physical I/O: %d", usage.ru_majflt);
-    notifyf(player, "Swapped out of main memory %d times.", usage.ru_nswap);
-    notifyf(player, "Voluntarily context switched %d times.", usage.ru_nvcsw);
-    notifyf(player, "Involuntarily context switched %d times.", usage.ru_nivcsw);
+    notifyf(player, "Performed %ld input servicings.", usage.ru_inblock);
+    notifyf(player, "Performed %ld output servicings.", usage.ru_oublock);
+    notifyf(player, "Sent %ld messages over a socket.", usage.ru_msgsnd);
+    notifyf(player, "Received %ld messages over a socket.", usage.ru_msgrcv);
+    notifyf(player, "Received %ld signals.", usage.ru_nsignals);
+    notifyf(player, "Page faults NOT requiring physical I/O: %ld", usage.ru_minflt);
+    notifyf(player, "Page faults REQUIRING physical I/O: %ld", usage.ru_majflt);
+    notifyf(player, "Swapped out of main memory %ld times.", usage.ru_nswap);
+    notifyf(player, "Voluntarily context switched %ld times.", usage.ru_nvcsw);
+    notifyf(player, "Involuntarily context switched %ld times.", usage.ru_nivcsw);
     notifyf(player, "User time used: %ld sec and %ld usec.", usage.ru_utime.tv_sec, usage.ru_utime.tv_usec);
     notifyf(player, "System time used: %ld sec and %ld usec.", usage.ru_stime.tv_sec, usage.ru_stime.tv_usec);
     notifyf(player, "Pagesize for this machine: %ld", psize);
@@ -1049,266 +1051,75 @@ do_usage(dbref player)
 #endif /* !NO_USAGE_COMMAND */
 
 /**
- * @TODO: These "topprofs" calls are almost all copy/paste.  I've noted in
- *        other TODO's such as under do_muf_topprofs that there is a lot
- *        of duplicate code ... but these calls are almost 100% duplicated,
- *        so maybe we can refactor them to use a common core function.
+ * Adds a 'struct profnode' to a given ordered linked list, if the size
+ * limit has not been reached.
+ *
+ * @param tops linked list of profiling nodes
+ * @param limit maximum size of list
+ * @param nodecount current size of list
+ * @param obj object to profile
+ * @param type object type: muf/mpi
+ * @param comptime time that request occurred
  */
-
-/**
- * Implementation of the \@muftops command
- *
- * This shows statistics about programs that have been running.  These
- * statistics are shown for top 'arg1' number of programs.  The default
- * is '10'.  'reset' can also be passed to reset the statistic numbers.
- *
- * This iterates over the entire DB and puts the programs in a
- * 'struct profnode' linked list.  For large numbers of 'arg1', this is
- * really inefficient since its sorting a linked list.
- *
- * This does not do any permission checking.
- *
- * @param player the player doing the call
- * @param arg1 Either a string containing a number, the word "reset", or ""
- */
-void
-do_muf_topprofs(dbref player, char *arg1)
+static void
+add_to_proflist(struct profnode **tops, size_t limit, int *nodecount, dbref obj, short type, time_t comptime)
 {
-    struct profnode *tops = NULL, *curr = NULL;
-    int nodecount = 0;
-    int count = atoi(arg1);
-    time_t current_systime = time(NULL);
+    struct profnode *curr = NULL;
+    struct profnode *newnode = malloc(sizeof(struct profnode));
+    struct timeval proftime = type ? PROGRAM_PROFTIME(obj) : DBFETCH(obj)->mpi_proftime;
+    time_t profstart = type ? PROGRAM_PROFSTART(obj) : mpi_prof_start_time;
+    int profuses = type ? PROGRAM_PROF_USES(obj) : DBFETCH(obj)->mpi_prof_use;
 
-    if (!strcasecmp(arg1, "reset")) {
-        for (dbref i = db_top; i-- > 0;) {
-            if (Typeof(i) == TYPE_PROGRAM) {
-                PROGRAM_SET_PROFTIME(i, 0, 0);
-                PROGRAM_SET_PROFSTART(i, current_systime);
-                PROGRAM_SET_PROF_USES(i, 0);
-            }
+    newnode->next = NULL;
+    newnode->prog = obj;
+    newnode->proftime = proftime.tv_sec;
+    newnode->proftime += (proftime.tv_usec / 1000000.0);
+    newnode->comptime = comptime - profstart;
+    newnode->usecount = profuses;
+    newnode->type = type;
+
+    if (newnode->comptime > 0) {
+        newnode->pcnt = 100.0 * newnode->proftime / newnode->comptime;
+    } else {
+        newnode->pcnt = 0.0;
+    }
+
+    if (!*tops) {
+        *tops = newnode;
+        (*nodecount)++;
+    } else if (newnode->pcnt < (*tops)->pcnt) {
+        if (*nodecount < limit) {
+            newnode->next = *tops;
+            *tops = newnode;
+            (*nodecount)++;
+        } else {
+            free(newnode);
+        }
+    } else {
+        if (*nodecount >= limit) {
+            curr = *tops;
+            *tops = (*tops)->next;
+            free(curr);
+        } else {
+            (*nodecount)++;
         }
 
-        notify(player, "MUF profiling statistics cleared.");
-        return;
-    }
-
-    if (count < 0) {
-        notify(player, "Count has to be a positive number.");
-        return;
-    } else if (count == 0) {
-        count = 10;
-    }
-
-    for (dbref i = db_top; i-- > 0;) {
-        if (Typeof(i) == TYPE_PROGRAM && PROGRAM_CODE(i)) {
-
-            /* @TODO: For all these topprofs calls, the following lines
-             *        of code are copy/pasted.  This is nasty and unnecessary.
-             *
-             *        The linked list implementation is kind of awful for
-             *        large datasets.  For the dataset of 10 (default)
-             *        it isn't bad.  In a perfect world, we'd use our
-             *        AVL generic implementation, but for now, we should
-             *        abstract this into a function that manages adding
-             *        nodes to get rid of this duplicate logic.
-             */
-            struct profnode *newnode = malloc(sizeof(struct profnode));
-            struct timeval tmpt = PROGRAM_PROFTIME(i);
-
-            newnode->next = NULL;
-            newnode->prog = i;
-            newnode->proftime = tmpt.tv_sec;
-            newnode->proftime += (tmpt.tv_usec / 1000000.0);
-            newnode->comptime = current_systime - PROGRAM_PROFSTART(i);
-            newnode->usecount = PROGRAM_PROF_USES(i);
-            newnode->type = 1;
-
-            if (newnode->comptime > 0) {
-                newnode->pcnt = 100.0 * newnode->proftime / newnode->comptime;
-            } else {
-                newnode->pcnt = 0.0;
-            }
-
-            if (!tops) {
-                tops = newnode;
-                nodecount++;
-            } else if (newnode->pcnt < tops->pcnt) {
-                if (nodecount < count) {
-                    newnode->next = tops;
-                    tops = newnode;
-                    nodecount++;
-                } else {
-                    free(newnode);
-                }
-            } else {
-                if (nodecount >= count) {
-                    curr = tops;
-                    tops = tops->next;
-                    free(curr);
-                } else {
-                    nodecount++;
-                }
-
-                if (!tops) {
-                    tops = newnode;
-                } else if (newnode->pcnt < tops->pcnt) {
-                    newnode->next = tops;
-                    tops = newnode;
-                } else {
-                    for (curr = tops; curr->next; curr = curr->next) {
-                        if (newnode->pcnt < curr->next->pcnt) {
-                            break;
-                        }
-                    }
-
-                    newnode->next = curr->next;
-                    curr->next = newnode;
+        if (!*tops) {
+            *tops = newnode;
+        } else if (newnode->pcnt < (*tops)->pcnt) {
+            newnode->next = *tops;
+            *tops = newnode;
+        } else {
+            for (curr = *tops; curr->next; curr = curr->next) {
+                if (newnode->pcnt < curr->next->pcnt) {
+                    break;
                 }
             }
+
+            newnode->next = curr->next;
+            curr->next = newnode;
         }
     }
-
-    notify(player, "     %CPU   TotalTime  UseCount  Program");
-
-    /* Output the produced result */
-    while (tops) {
-        char unparse_buf[BUFFER_LEN];
-        curr = tops;
-        unparse_object(player, curr->prog, unparse_buf, sizeof(unparse_buf));
-        notifyf(player, "%10.3f %10.3f %9ld %s", curr->pcnt, curr->proftime, curr->usecount,
-                unparse_buf);
-        tops = tops->next;
-        free(curr);
-    }
-
-    notifyf(player, "Profile Length (sec): %5lld  %%idle: %5.2f%%  Total Cycles: %5lu",
-            (long long) (current_systime - sel_prof_start_time),
-            ((double) (sel_prof_idle_sec + (sel_prof_idle_usec / 1000000.0)) * 100.0) /
-            (double) ((current_systime - sel_prof_start_time) + 0.01), sel_prof_idle_use);
-    notify(player, "*Done*");
-}
-
-/**
- * Implementation of the \@mpitops command
- *
- * This shows statistics about programs that have been running.  These
- * statistics are shown for top 'arg1' number of programs.  The default
- * is '10'.  'reset' can also be passed to reset the statistic numbers.
- *
- * This iterates over the entire DB and puts the programs in a
- * 'struct profnode' linked list.  For large numbers of 'arg1', this is
- * really inefficient since its sorting a linked list.
- *
- * This does not do any permission checking.
- *
- * @param player the player doing the call
- * @param arg1 Either a string containing a number, the word "reset", or ""
- */
-void
-do_mpi_topprofs(dbref player, char *arg1)
-{
-    struct profnode *tops = NULL, *curr = NULL;
-    int nodecount = 0;
-    int count = atoi(arg1);
-    time_t current_systime = time(NULL);
-
-    if (!strcasecmp(arg1, "reset")) {
-        for (dbref i = db_top; i-- > 0;) {
-            if (DBFETCH(i)->mpi_prof_use) {
-                DBFETCH(i)->mpi_prof_use = 0;
-                DBFETCH(i)->mpi_proftime.tv_usec = 0;
-                DBFETCH(i)->mpi_proftime.tv_sec = 0;
-            }
-        }
-
-        mpi_prof_start_time = current_systime;
-        notify(player, "MPI profiling statistics cleared.");
-        return;
-    }
-
-    if (count < 0) {
-        notify(player, "Count has to be a positive number.");
-        return;
-    } else if (count == 0) {
-        count = 10;
-    }
-
-    for (dbref i = db_top; i-- > 0;) {
-        if (DBFETCH(i)->mpi_prof_use) {
-            /* @TODO: See other note -- this code is duplicate */
-            struct profnode *newnode = malloc(sizeof(struct profnode));
-            newnode->next = NULL;
-            newnode->prog = i;
-            newnode->proftime = DBFETCH(i)->mpi_proftime.tv_sec;
-            newnode->proftime += (DBFETCH(i)->mpi_proftime.tv_usec / 1000000.0);
-            newnode->comptime = current_systime - mpi_prof_start_time;
-            newnode->usecount = DBFETCH(i)->mpi_prof_use;
-            newnode->type = 0;
-
-            if (newnode->comptime > 0) {
-                newnode->pcnt = 100.0 * newnode->proftime / newnode->comptime;
-            } else {
-                newnode->pcnt = 0.0;
-            }
-
-            if (!tops) {
-                tops = newnode;
-                nodecount++;
-            } else if (newnode->pcnt < tops->pcnt) {
-                if (nodecount < count) {
-                    newnode->next = tops;
-                    tops = newnode;
-                    nodecount++;
-                } else {
-                    free(newnode);
-                }
-            } else {
-                if (nodecount >= count) {
-                    curr = tops;
-                    tops = tops->next;
-                    free(curr);
-                } else {
-                    nodecount++;
-                }
-
-                if (!tops) {
-                    tops = newnode;
-                } else if (newnode->pcnt < tops->pcnt) {
-                    newnode->next = tops;
-                    tops = newnode;
-                } else {
-                    for (curr = tops; curr->next; curr = curr->next) {
-                        if (newnode->pcnt < curr->next->pcnt) {
-                            break;
-                        }
-                    }
-
-                    newnode->next = curr->next;
-                    curr->next = newnode;
-                }
-            }
-        }
-    }
-
-    notify(player, "     %CPU   TotalTime  UseCount  Object");
-
-    /* Output the results */
-    while (tops) {
-        char unparse_buf[BUFFER_LEN];
-        curr = tops;
-        unparse_object(player, curr->prog, unparse_buf, sizeof(unparse_buf));
-        notifyf(player, "%10.3f %10.3f %9ld %s", curr->pcnt, curr->proftime, curr->usecount,
-                unparse_buf);
-        tops = tops->next;
-        free(curr);
-    }
-
-    notifyf(player, "Profile Length (sec): %5lld  %%idle: %5.2f%%  Total Cycles: %5lu",
-            (long long) (current_systime - sel_prof_start_time),
-            (((double) sel_prof_idle_sec + (sel_prof_idle_usec / 1000000.0)) * 100.0) /
-            (double) ((current_systime - sel_prof_start_time) + 0.01), sel_prof_idle_use);
-
-    notify(player, "*Done*");
 }
 
 /**
@@ -1324,184 +1135,97 @@ do_mpi_topprofs(dbref player, char *arg1)
  *
  * This does not do any permission checking.
  *
+ * @see add_to_proflist
+ *
  * @param player the player doing the call
  * @param arg1 Either a string containing a number, the word "reset", or ""
  */
 void
 do_topprofs(dbref player, char *arg1)
 {
-    /* @TODO: This function is terrible.  It's like the previous two topprofs
-     *        copy/pasted together into one function.
-     */
     struct profnode *tops = NULL, *curr = NULL;
-    int nodecount = 0;
-    int count = atoi(arg1);
     time_t current_systime = time(NULL);
+    short type = -1;
+    char *option;
+    int count = -1;
+    int nodecount = 0;
 
-    if (!strcasecmp(arg1, "reset")) {
+    (void) strtok_r(arg1, " \t", &option);
+
+    if (!strcasecmp(arg1, "mpi")) {
+        type = 0;
+    } else if (!strcasecmp(arg1, "muf")) {
+        type = 1;
+    } else {
+        option = arg1;
+    }
+
+    if (!strcasecmp(option, "reset")) {
         for (dbref i = db_top; i-- > 0;) {
-            if (DBFETCH(i)->mpi_prof_use) {
+            if (type != 1 && DBFETCH(i)->mpi_prof_use) {
                 DBFETCH(i)->mpi_prof_use = 0;
                 DBFETCH(i)->mpi_proftime.tv_usec = 0;
                 DBFETCH(i)->mpi_proftime.tv_sec = 0;
             }
 
-            if (Typeof(i) == TYPE_PROGRAM) {
+            if (type != 0 && Typeof(i) == TYPE_PROGRAM && PROGRAM_CODE(i)) {
                 PROGRAM_SET_PROFTIME(i, 0, 0);
                 PROGRAM_SET_PROFSTART(i, current_systime);
                 PROGRAM_SET_PROF_USES(i, 0);
             }
         }
 
-        sel_prof_idle_sec = 0;
-        sel_prof_idle_usec = 0;
-        sel_prof_start_time = current_systime;
-        sel_prof_idle_use = 0;
-        mpi_prof_start_time = current_systime;
-        notify(player, "All profiling statistics cleared.");
+        if (type == -1) {
+            sel_prof_idle_sec = 0;
+            sel_prof_idle_usec = 0;
+            sel_prof_start_time = current_systime;
+            sel_prof_idle_use = 0;
+            mpi_prof_start_time = current_systime;
+        }
+
+        notify(player, "Profiling statistics cleared.");
         return;
     }
 
+    count = atoi(option);
     if (count < 0) {
-        notify(player, "Count has to be a positive number.");
+        notify_nolisten(player, "Count must be a positive number.", 1);
         return;
-    } else if (count == 0) {
+    }
+
+    if (count == 0) {
         count = 10;
     }
 
     for (dbref i = db_top; i-- > 0;) {
-        if (DBFETCH(i)->mpi_prof_use) {
-            /* @TODO: The same duplicate linked list code as noted above */
-            struct profnode *newnode = malloc(sizeof(struct profnode));
-            newnode->next = NULL;
-            newnode->prog = i;
-            newnode->proftime = DBFETCH(i)->mpi_proftime.tv_sec;
-            newnode->proftime += (DBFETCH(i)->mpi_proftime.tv_usec / 1000000.0);
-            newnode->comptime = current_systime - mpi_prof_start_time;
-            newnode->usecount = DBFETCH(i)->mpi_prof_use;
-            newnode->type = 0;
-
-            if (newnode->comptime > 0) {
-                newnode->pcnt = 100.0 * newnode->proftime / newnode->comptime;
-            } else {
-                newnode->pcnt = 0.0;
-            }
-
-            if (!tops) {
-                tops = newnode;
-                nodecount++;
-            } else if (newnode->pcnt < tops->pcnt) {
-                if (nodecount < count) {
-                    newnode->next = tops;
-                    tops = newnode;
-                    nodecount++;
-                } else {
-                    free(newnode);
-                }
-            } else {
-                if (nodecount >= count) {
-                    curr = tops;
-                    tops = tops->next;
-                    free(curr);
-                } else {
-                    nodecount++;
-                }
-
-                if (!tops) {
-                    tops = newnode;
-                } else if (newnode->pcnt < tops->pcnt) {
-                    newnode->next = tops;
-                    tops = newnode;
-                } else {
-                    for (curr = tops; curr->next; curr = curr->next) {
-                        if (newnode->pcnt < curr->next->pcnt) {
-                            break;
-                        }
-                    }
-
-                    newnode->next = curr->next;
-                    curr->next = newnode;
-                }
-            }
+        if (type != 1 && DBFETCH(i)->mpi_prof_use) {
+            add_to_proflist(&tops, count, &nodecount, i, 0, current_systime);
         }
 
-        if (Typeof(i) == TYPE_PROGRAM && PROGRAM_CODE(i)) {
-            /* @TODO: Wow, this is duplicated even in the same function */
-            struct profnode *newnode = malloc(sizeof(struct profnode));
-            struct timeval tmpt = PROGRAM_PROFTIME(i);
-
-            newnode->next = NULL;
-            newnode->prog = i;
-            newnode->proftime = tmpt.tv_sec;
-            newnode->proftime += (tmpt.tv_usec / 1000000.0);
-            newnode->comptime = current_systime - PROGRAM_PROFSTART(i);
-            newnode->usecount = PROGRAM_PROF_USES(i);
-            newnode->type = 1;
-
-            if (newnode->comptime > 0) {
-                newnode->pcnt = 100.0 * newnode->proftime / newnode->comptime;
-            } else {
-                newnode->pcnt = 0.0;
-            }
-
-            if (!tops) {
-                tops = newnode;
-                nodecount++;
-            } else if (newnode->pcnt < tops->pcnt) {
-                if (nodecount < count) {
-                    newnode->next = tops;
-                    tops = newnode;
-                    nodecount++;
-                } else {
-                    free(newnode);
-                }
-            } else {
-                if (nodecount >= count) {
-                    curr = tops;
-                    tops = tops->next;
-                    free(curr);
-                } else {
-                    nodecount++;
-                }
-
-                if (!tops) {
-                    tops = newnode;
-                } else if (newnode->pcnt < tops->pcnt) {
-                    newnode->next = tops;
-                    tops = newnode;
-                } else {
-                    for (curr = tops; curr->next; curr = curr->next) {
-                        if (newnode->pcnt < curr->next->pcnt) {
-                            break;
-                        }
-                    }
-
-                    newnode->next = curr->next;
-                    curr->next = newnode;
-                }
-            }
+        if (type != 0 && Typeof(i) == TYPE_PROGRAM && PROGRAM_CODE(i)) {
+            add_to_proflist(&tops, count, &nodecount, i, 1, current_systime);
         }
     }
 
-    notify(player, "     %CPU   TotalTime  UseCount  Type  Object");
+    notifyf_nolisten(player, "     %%CPU   TotalTime  UseCount%sObject", type == -1 ? "  Type  " : "  ");
 
     /* Output results */
     while (tops) {
         char unparse_buf[BUFFER_LEN];
         curr = tops;
         unparse_object(player, curr->prog, unparse_buf, sizeof(unparse_buf));
-        notifyf(player, "%10.3f %10.3f %9ld%5s   %s", curr->pcnt, curr->proftime,
-                curr->usecount, curr->type ? "MUF" : "MPI", unparse_buf);
+        notifyf_nolisten(player, "%10.3f %10.3f %9ld%s%s", curr->pcnt, curr->proftime,
+                curr->usecount, type == -1 ? (curr->type ? "  MUF   " : "  MPI   ") : "  ", unparse_buf);
         tops = tops->next;
         free(curr);
     }
 
-    notifyf(player, "Profile Length (sec): %5lld  %%idle: %5.2f%%  Total Cycles: %5lu",
+    notifyf_nolisten(player, "Profile Length (sec): %5lld  %%idle: %5.2f%%  Total Cycles: %5lu",
             (long long) (current_systime - sel_prof_start_time),
             ((double) (sel_prof_idle_sec + (sel_prof_idle_usec / 1000000.0)) * 100.0) /
             (double) ((current_systime - sel_prof_start_time) + 0.01), sel_prof_idle_use);
 
-    notify(player, "*Done*");
+    notify_nolisten(player, "*Done*", 1);
 }
 
 #ifndef NO_MEMORY_COMMAND

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -1054,6 +1054,7 @@ do_usage(dbref player)
  * Adds a 'struct profnode' to a given ordered linked list, if the size
  * limit has not been reached.
  *
+ * @private
  * @param tops linked list of profiling nodes
  * @param limit maximum size of list
  * @param nodecount current size of list


### PR DESCRIPTION
* Changed some [un]bless logic: The strict_god_priv check happens outside the loop, and unbless includes that check now, and both use buffers spaced to avoid warnings for the response.
* Changed usage output to expect larger number ranges.
* Refactored profiling command set into one command - `@tops`:
- This command now has an optional parameter [muf|mpi] that can switch to the corresponding logic.
- This is mostly moving logic around, so any profound updates (stop reading the entire database, stop sorting linked lists, etc.) have not been made.
- I believe there were some (more) issues in the original code as a result of copying into the other two commands. The last line of output in particular can show over 100% idle time and the "profile length" only seems to be reset when you "reset" all objects.

Please test. I don't think I made things worse. Also feel free to modify if needed.