### PR TITLE
Fix MUF error messages not logging to .debug

### DIFF
--- a/src/interp.c
+++ b/src/interp.c
@@ -1433,8 +1433,9 @@ interp_err(dbref player, dbref program, struct inst *pc,
                          NAME(OWNER(origprog)));
     }
 
-    notifyf_nolisten(player, "\033[1m%s(#%d), line %d; %s: %s\033[0m",
+    snprintf(buf, sizeof(buf), "\033[1m%s(#%d), line %d; %s: %s\033[0m",
                      NAME(program), program, pc ? pc->line : -1, msg1, msg2);
+    notify_nolisten(player, buf, 1);
 
     lt = time(NULL);
     strftime(tbuf, 32, "%c", localtime(&lt));


### PR DESCRIPTION
Fixes a bug introduced way back in e35d6543 -- `buf` was no longer being written to, so `.debug/lasterr` wasn't getting written properly.