### PR TITLE
Revert to old version format

### DIFF
--- a/docs/help.txt
+++ b/docs/help.txt
@@ -1,4 +1,4 @@
-                     MUCK Reference Manual for fb7.0
+                 MUCK Reference Manual for Muck2.2fb7.00
                    by Revar Desmera <revar@belfry.com>
 
 You may get a listing of topics that you can get help on, either sorted

--- a/docs/man.txt
+++ b/docs/man.txt
@@ -1,4 +1,4 @@
-                     MUF Reference Manual for fb7.0
+                 MUF Reference Manual for Muck2.2fb7.00
                    by Revar Desmera <revar@belfry.com>
 
 You may get a listing of topics that you can get help on, either sorted

--- a/docs/mpihelp.txt
+++ b/docs/mpihelp.txt
@@ -1,4 +1,4 @@
-                     MPI Reference Manual for fb7.0
+                 MPI Reference Manual for Muck2.2fb7.00
                    by Revar Desmera <revar@belfry.com>
 
 You may get a listing of topics that you can get help on, either sorted

--- a/include/config.h
+++ b/include/config.h
@@ -19,7 +19,7 @@
 /**
  * Server version number
  */
-#define VERSION "fb7.0"
+#define VERSION "Muck2.2fb7.00"
 
 /************************************************************************
    Administrative Options


### PR DESCRIPTION
Unsure whether to make a this a pull request, an issue ticket, or a comment on the original commit, especially since I'm 2 years after the fact. Feel free to critique.

The new version number format, as of 1ee836a4, sorts _before_ previous version numbers. It also breaks the promise in `man __version` that `__version` will always start with `Muck2.2fb`. Granted if the old license isn't in effect anymore the version number doesn't _have_ to start with anything, but given that it breaks every version comparison ever written, I think this is a pretty major change.