### PR TITLE
Workaround for newlines in IPv6 hostnames

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -2786,6 +2786,7 @@ new_connection_v6(in_port_t port, int sock_, int is_ssl)
     struct sockaddr_in6 addr;
     socklen_t addr_len;
     char hostname[128];
+	size_t hostlen;
 
     addr_len = (socklen_t) sizeof(addr);
     newsock = accept(sock_, (struct sockaddr *) &addr, &addr_len);
@@ -2797,6 +2798,13 @@ new_connection_v6(in_port_t port, int sock_, int is_ssl)
         fcntl(newsock, F_SETFD, FD_CLOEXEC);
 #endif
         strcpyn(hostname, sizeof(hostname), addrout_v6(port, &(addr.sin6_addr), addr.sin6_port));
+		/*
+		 * On some systems the ipv6 hostname ends with a newline, which messes
+		 * with the status log.
+		 */
+		hostlen = strlen(hostname);
+		if (hostname[hostlen-1] == '\n')
+			hostname[hostlen-1] = '\0';
         log_status("ACCEPT: %s on descriptor %d", hostname, newsock);
         log_status("CONCOUNT: There are now %d open connections.", ++ndescriptors);
         return initializesock(newsock, newsock, hostname, is_ssl, 0);


### PR DESCRIPTION
"On some systems" is my vague way of saying "I was only able to test it on two systems running Ubuntu 20.04".