### PR TITLE
Add MPI parsing to login screen

### DIFF
--- a/docs/man.txt
+++ b/docs/man.txt
@@ -4439,6 +4439,7 @@ Parameters available:
  (str)  description_default       - Default description
  (bool) diskbase_propvals         - Enable property value diskbasing (req. restart)
  (bool) do_mpi_parsing            - Parse MPI strings in messages
+ (bool) do_welcome_parsing        - Parse MPI in welcome file or proplist
  (time) dump_interval             - Interval between dumps
  (time) dump_warntime             - Interval between warning and dump
  (str)  dumpdone_mesg             - Database dump finished message
@@ -4575,6 +4576,8 @@ Parameters available:
  (bool) toad_recycle              - Recycle newly-created toads
  (bool) use_hostnames             - Resolve IP addresses into hostnames
  (int)  userlog_mlev              - Mucker Level required to write to userlog
+ (ref)  welcome_mpi_what          - Effective 'this' for welcome.txt MPI
+ (ref)  welcome_mpi_who           - Effective 'me' for welcome.txt MPI
  (bool) who_hides_dark            - Hide dark players from WHO list
  (bool) wiz_vehicles              - Only let Wizards set vehicle bits
 ~

--- a/docs/mufman.html
+++ b/docs/mufman.html
@@ -7127,6 +7127,7 @@ Parameters available:
  (str)  description_default       - Default description
  (bool) diskbase_propvals         - Enable property value diskbasing (req. restart)
  (bool) do_mpi_parsing            - Parse MPI strings in messages
+ (bool) do_welcome_parsing        - Parse MPI in welcome file or proplist
  (time) dump_interval             - Interval between dumps
  (time) dump_warntime             - Interval between warning and dump
  (str)  dumpdone_mesg             - Database dump finished message
@@ -7263,6 +7264,8 @@ Parameters available:
  (bool) toad_recycle              - Recycle newly-created toads
  (bool) use_hostnames             - Resolve IP addresses into hostnames
  (int)  userlog_mlev              - Mucker Level required to write to userlog
+ (ref)  welcome_mpi_what          - Effective 'this' for welcome.txt MPI
+ (ref)  welcome_mpi_who           - Effective 'me' for welcome.txt MPI
  (bool) who_hides_dark            - Hide dark players from WHO list
  (bool) wiz_vehicles              - Only let Wizards set vehicle bits
 </pre>

--- a/include/tune.h
+++ b/include/tune.h
@@ -113,6 +113,7 @@ extern dbref       tp_default_room_parent;      /**< Tune variable */
 extern const char *tp_description_default;      /**< Tune variable */
 extern bool        tp_diskbase_propvals;        /**< Tune variable */
 extern bool        tp_do_mpi_parsing;           /**< Tune variable */
+extern bool        tp_do_welcome_parsing;       /**< Tune variable */
 extern int         tp_dump_interval;            /**< Tune variable */
 extern int         tp_dump_warntime;            /**< Tune variable */
 extern const char *tp_dumpdone_mesg;            /**< Tune variable */
@@ -249,6 +250,8 @@ extern dbref       tp_toad_default_recipient;   /**< Tune variable */
 extern bool        tp_toad_recycle;             /**< Tune variable */
 extern bool        tp_use_hostnames;            /**< Tune variable */
 extern int         tp_userlog_mlev;             /**< Tune variable */
+extern dbref       tp_welcome_mpi_what;         /**< Tune variable */
+extern dbref       tp_welcome_mpi_who;          /**< Tune variable */
 extern bool        tp_who_hides_dark;           /**< Tune variable */
 extern bool        tp_wiz_vehicles;             /**< Tune variable */
 

--- a/include/tunelist.h
+++ b/include/tunelist.h
@@ -2252,7 +2252,7 @@ struct tune_entry tune_list[] = {
         "MPI",
         "",
         TP_TYPE_DBREF,
-        .defaultval.d=GOD,
+        .defaultval.d=GLOBAL_ENVIRONMENT,
         .currentval.d=&tp_welcome_mpi_what,
         MLEV_GOD,
         MLEV_GOD,

--- a/include/tunelist.h
+++ b/include/tunelist.h
@@ -62,6 +62,7 @@ dbref       tp_default_room_parent;                 /**> Described below */
 const char *tp_description_default;                 /**> Described below */
 bool        tp_diskbase_propvals;                   /**> Described below */
 bool        tp_do_mpi_parsing;                      /**> Described below */
+bool        tp_do_welcome_parsing;                  /**> Described below */
 int         tp_dump_interval;                       /**> Described below */
 int         tp_dump_warntime;                       /**> Described below */
 const char *tp_dumpdone_mesg;                       /**> Described below */
@@ -198,6 +199,8 @@ dbref       tp_toad_default_recipient;              /**> Described below */
 bool        tp_toad_recycle;                        /**> Described below */
 bool        tp_use_hostnames;                       /**> Described below */
 int         tp_userlog_mlev;                        /**> Described below */
+dbref       tp_welcome_mpi_what;                    /**> Described below */
+dbref       tp_welcome_mpi_who;                     /**> Described below */
 bool        tp_who_hides_dark;                      /**> Described below */
 bool        tp_wiz_vehicles;                        /**> Described below */
 
@@ -561,6 +564,18 @@ struct tune_entry tune_list[] = {
         .defaultval.b=true,
         .currentval.b=&tp_do_mpi_parsing,
         0,
+        MLEV_WIZARD,
+        true
+    },
+    {
+        "do_welcome_parsing",
+        "Parse MPI in welcome file or proplist",
+        "MPI",
+        "",
+        TP_TYPE_BOOLEAN,
+        .defaultval.b=false,
+        .currentval.b=&tp_do_welcome_parsing,
+        MLEV_WIZARD,
         MLEV_WIZARD,
         true
     },
@@ -2230,6 +2245,34 @@ struct tune_entry tune_list[] = {
         0,
         MLEV_WIZARD,
         true
+    },
+    {
+        "welcome_mpi_what",
+        "Effective 'this' for welcome.txt MPI",
+        "MPI",
+        "",
+        TP_TYPE_DBREF,
+        .defaultval.d=GOD,
+        .currentval.d=&tp_welcome_mpi_what,
+        MLEV_GOD,
+        MLEV_GOD,
+        true,
+        false,
+        NOTYPE 
+    },
+    {
+        "welcome_mpi_who",
+        "Effective 'me' for welcome.txt MPI",
+        "MPI",
+        "",
+        TP_TYPE_DBREF,
+        .defaultval.d=GOD,
+        .currentval.d=&tp_welcome_mpi_who,
+        MLEV_GOD,
+        MLEV_GOD,
+        true,
+        false,
+        TYPE_PLAYER
     },
     {
         "who_hides_dark",

--- a/src/interface.c
+++ b/src/interface.c
@@ -679,7 +679,7 @@ queue_ansi(struct descriptor_data *d, const char *msg)
         } else {
             strip_ansi(buf, msg);
         }
-    } else if (tp_do_welcome_parsing) {
+    } else if (tp_do_mpi_parsing && tp_do_welcome_parsing) {
         strip_bad_ansi(buf, msg);
     } else {
         strip_ansi(buf, msg);
@@ -2204,7 +2204,7 @@ queue_immediate_and_flush(struct descriptor_data *d, const char *msg)
         } else {
             strip_ansi(buf, msg);
         }
-    } else if (tp_do_welcome_parsing) {
+    } else if (tp_do_mpi_parsing && tp_do_welcome_parsing) {
         strip_bad_ansi(buf, msg);
     } else {
         strip_ansi(buf, msg);

--- a/src/interface.c
+++ b/src/interface.c
@@ -1181,58 +1181,67 @@ static void
 welcome_user(struct descriptor_data *d)
 {
     FILE *f;
-    char *ptr;
     char buf[BUFFER_LEN];
-
-    int welcome_proplist = 0;
-
+    *buf = '\0';
     /*
-     * @TODO This is kind of a weird way to read a list.  If I were doing
-     *       it, I would iterate over the value of WELCOME_PROPLIST#
-     *       which is the number of lines rather than ... just iterate
-     *       til props stop loading.  I think that is more technically
-     *       correct / expected.  If you do it this way, 'welcome_proplist'
-     *       can become the integer value of WELCOME_PROPLIST's length
-     *       prop instead of a boolean set every iteration of the loop.
+     * This is less efficient than reading the list directly, since we have to
+     * go through MPI permissions checking, but since we're fetching it as God
+     * we skip all the locks.
+     *
+     * This also allows us to cleanly handle all the different list formats we
+     * might have to deal with.
      */
-    for (int i = 1; ; i++) {
-        const char *line;
-        snprintf(buf, sizeof(buf), "%s#/%d", WELCOME_PROPLIST, i);
-
-        if ((line = get_property_class(GLOBAL_ENVIRONMENT, buf))) {
-            welcome_proplist = 1;
-            queue_ansi(d, line);
-            queue_write(d, "\r\n", 2);
+    int blessed = 1;
+    if (!get_concat_list(GOD, GOD, GLOBAL_ENVIRONMENT, WELCOME_PROPLIST,
+                         buf, sizeof(buf), 0, MPI_ISPRIVATE | MPI_ISBLESSED,
+                         &blessed))
+    {
+        /* Failed list read, fall back to file. */
+        if ((f = fopen(tp_file_welcome_screen, "rb")) == NULL) {
+            perror("spit_file: welcome.txt");
         } else {
-            break;
+            /*
+             * No major error handling here. If fread() fails then
+             * the buffer stays empty, and we end up falling back
+             * to DEFAULT_WELCOME_MESSAGE anyway.
+             */
+            size_t ct = fread(buf, sizeof(char), BUFFER_LEN - 1, f);
+            if (ct > 0)
+                buf[ct] = '\0';
+            fclose(f);
         }
     }
 
-    if (!welcome_proplist) {
-        /*
-         * @TODO Use show_file instead?
-         *       Could add a return value to show_file which returns
-         *       boolean if show_file was able to load, and show
-         *       the default message if it returns false.  Removes
-         *       duplicate code and makes this function more tidy.
-         */
-
-        if ((f = fopen(tp_file_welcome_screen, "rb")) == NULL) {
-            queue_ansi(d, DEFAULT_WELCOME_MESSAGE);
-            perror("spit_file: welcome.txt");
-        } else {
-            while (fgets(buf, sizeof(buf) - 3, f)) {
-                ptr = strchr(buf, '\n');
-                if (ptr && ptr > buf && *(ptr - 1) != '\r') {
-                    *ptr++ = '\r';
-                    *ptr++ = '\n';
-                    *ptr++ = '\0';
+    /*
+     * If we found something to show, queue it.
+     * Otherwise, fall back to the default.
+     */
+    if (*buf) {
+        char *t = buf, *tstart = buf;
+        while (*t) {
+            if (*t == '\n') {
+                *t++ = '\0';
+                queue_ansi(d, tstart);
+                queue_write(d, "\r\n", 2);
+                tstart = t;
+            } else if (*t == '\r') {
+                *t++ = '\0';
+                if (*t == '\n') {
+                    ++t;
                 }
-                queue_ansi(d, buf);
+                queue_ansi(d, tstart);
+                queue_write(d, "\r\n", 2);
+                tstart = t;
+            } else {
+                ++t;
             }
-
-            fclose(f);
         }
+        if (*tstart) {
+            queue_ansi(d, tstart);
+            queue_write(d, "\r\n", 2);
+        }
+    } else {
+        queue_ansi(d, DEFAULT_WELCOME_MESSAGE);
     }
 
     if (wizonly_mode) {

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -3078,7 +3078,7 @@ prim_toadplayer(PRIM_PROTOTYPE)
     }
 
     for (struct tune_entry *tent = tune_list; tent->name; tent++) {
-        if (tent->type == TP_TYPE_DBREF && result == *tent->currentval.d) {
+        if (tent->type == TP_TYPE_DBREF && victim == *tent->currentval.d) {
             abort_interp("That player cannot currently be @toaded.");
         }
     }

--- a/src/tune.c
+++ b/src/tune.c
@@ -495,7 +495,7 @@ tune_setparm(dbref player, const char *parmname, const char *val, int mlev)
                     return TUNESET_SYNTAX;
                 if (!ObjExists(obj))
                     return TUNESET_SYNTAX;
-                if (tent->type != NOTYPE && Typeof(obj) != tent->objecttype)
+                if (tent->objecttype != NOTYPE && Typeof(obj) != tent->objecttype)
                     return TUNESET_BADVAL;
 
                 *tent->currentval.d = obj;


### PR DESCRIPTION
Kinda sorta responds to #620.

Abusing {&cmd} and {&arg} to store descriptor and hostname feels bad, but you can't define MPI variables from outside of do_parse_mesg and since the only player we have is One (or whoever welcome_mpi_who is) it's the only information we have to work with.