### PR TITLE
Modify new_object to take a flag, so players don't get old refs.

### DIFF
--- a/include/db.h
+++ b/include/db.h
@@ -2173,7 +2173,7 @@ int member(dbref thing, dbref list);
  *       otherwise
  * @return the database ref of the object
  */
-dbref new_object(int isplayer);
+dbref new_object(bool isplayer);
 
 /**
  * Find a dbref in an objnode list

--- a/include/db.h
+++ b/include/db.h
@@ -2169,9 +2169,11 @@ int member(dbref thing, dbref list);
  * This may be a recycled garbage object or a new object.  Either way,
  * it will be empty and ready for use.
  *
+ * @param isplayer boolean true if the object is to be a player, false
+ *       otherwise
  * @return the database ref of the object
  */
-dbref new_object(void);
+dbref new_object(int isplayer);
 
 /**
  * Find a dbref in an objnode list

--- a/src/db.c
+++ b/src/db.c
@@ -139,14 +139,16 @@ db_clear_object(dbref i)
  * This may be a recycled garbage object or a new object.  Either way,
  * it will be empty and ready for use.
  *
+ * @param isplayer boolean true if the object is to be a player, false
+ *       otherwise
  * @return the database ref of the object
  */
 dbref
-new_object(void)
+new_object(int isplayer)
 {
     dbref newobj;
 
-    if (recyclable != NOTHING) {
+    if (!isplayer && recyclable != NOTHING) {
         newobj = recyclable;
         recyclable = NEXTOBJ(newobj);
 
@@ -184,7 +186,7 @@ new_object(void)
 static dbref
 create_object(const char *name, dbref owner, object_flag_type flags)
 {
-    dbref newobj = new_object();
+    dbref newobj = new_object((flags & TYPE_MASK) == TYPE_PLAYER);
 
     NAME(newobj) = alloc_string(name);
     FLAGS(newobj) = flags;

--- a/src/db.c
+++ b/src/db.c
@@ -144,7 +144,7 @@ db_clear_object(dbref i)
  * @return the database ref of the object
  */
 dbref
-new_object(int isplayer)
+new_object(bool isplayer)
 {
     dbref newobj;
 

--- a/src/player.c
+++ b/src/player.c
@@ -166,7 +166,7 @@ create_player(const char *name, const char *password)
         return NOTHING;
 
     /* else he doesn't already exist, create him */
-    player = new_object();
+    player = new_object(1);
 
     /* initialize everything */
     NAME(player) = alloc_string(name);

--- a/src/player.c
+++ b/src/player.c
@@ -166,7 +166,7 @@ create_player(const char *name, const char *password)
         return NOTHING;
 
     /* else he doesn't already exist, create him */
-    player = new_object(1);
+    player = new_object(true);
 
     /* initialize everything */
     NAME(player) = alloc_string(name);

--- a/src/sanity.c
+++ b/src/sanity.c
@@ -1122,7 +1122,7 @@ create_lostandfound(dbref * player, dbref * room)
     char unparse_buf[16384];
     int temp = 0;
 
-    *room = new_object(0);
+    *room = new_object(false);
     NAME(*room) = alloc_string("lost+found");
     LOCATION(*room) = GLOBAL_ENVIRONMENT;
     EXITS(*room) = NOTHING;
@@ -1141,7 +1141,7 @@ create_lostandfound(dbref * player, dbref * room)
         *player = GOD;
     } else {
         const char *rpass;
-        *player = new_object(1);
+        *player = new_object(true);
         NAME(*player) = alloc_string(player_name);
         LOCATION(*player) = *room;
         FLAGS(*player) = TYPE_PLAYER | SANEBIT;

--- a/src/sanity.c
+++ b/src/sanity.c
@@ -1122,7 +1122,7 @@ create_lostandfound(dbref * player, dbref * room)
     char unparse_buf[16384];
     int temp = 0;
 
-    *room = new_object();
+    *room = new_object(0);
     NAME(*room) = alloc_string("lost+found");
     LOCATION(*room) = GLOBAL_ENVIRONMENT;
     EXITS(*room) = NOTHING;
@@ -1141,7 +1141,7 @@ create_lostandfound(dbref * player, dbref * room)
         *player = GOD;
     } else {
         const char *rpass;
-        *player = new_object();
+        *player = new_object(1);
         NAME(*player) = alloc_string(player_name);
         LOCATION(*player) = *room;
         FLAGS(*player) = TYPE_PLAYER | SANEBIT;

--- a/tests/command-cases/player.yml
+++ b/tests/command-cases/player.yml
@@ -1,0 +1,18 @@
+- name: pcreate
+  setup: |
+    @pcreate testplayer=testpassword
+  commands: |
+    ex *testplayer
+  expect:
+    - "testplayer\\(#2"
+    - "Type: PLAYER"
+
+- name: pcreate-no-oldrefs
+  setup: |
+    @create IdTwo
+    @recycle #2
+    @pcreate testplayer=testpassword
+  commands: |
+    ex *testplayer
+  expect:
+    - "testplayer\\(#3"


### PR DESCRIPTION
This addresses issue #680.

I added a couple very simplistic tests based on `create.yml` in `player.yml`, which could probably stand to be expanded-upon, but the perfect is the enemy of the good. Similarly, I was very tempted to try to use `<stdbool.h>` (and define `bool`, `true`, and `false` in `config.h` if it wasn't available), but decided modifying `configure.ac` was a step slightly too far.