### PR TITLE
#424 Terminal Size introspection implementation

### DIFF
--- a/docs/man.txt
+++ b/docs/man.txt
@@ -142,6 +142,9 @@ G's
   gui_dlog_show      gui_dlog_simple    gui_dlog_tabbed    gui_value_get
   gui_value_set      gui_values_get     
 
+H's
+  height  
+
 I's
   if           ignore_add   ignore_del   ignoring?    inf          instances
   instr        instring     int          int?         interp       intostr
@@ -205,19 +208,19 @@ R's
 
 S's
   secure_sysvars     set                set_error          setdesc
-  setdrop            setfail            setlink            setlinks_array
-  setlockstr         setmode            setname            setodrop
-  setofail           setosucc           setown             setprop
-  setseed            setsucc            setsysparm         shallow_copy
-  sign               sin                sleep              smatch
-  smtp_send          split              sqrt               srand
-  stats              stats_array        stod               strcat
-  strcmp             strcut             strdecrypt         strencrypt
-  string?            stringcmp          stringpfx          strip
-  striplead          striptail          strlen             strncmp
-  strtof             subst              succ               supplicant
-  swap               sysparm            sysparm_array      systime
-  systime_precise    
+  setdrop            setfail            setheight          setlink
+  setlinks_array     setlockstr         setmode            setname
+  setodrop           setofail           setosucc           setown
+  setprop            setseed            setsucc            setsysparm
+  setwidth           shallow_copy       sign               sin
+  sleep              smatch             smtp_send          split
+  sqrt               srand              stats              stats_array
+  stod               strcat             strcmp             strcut
+  strdecrypt         strencrypt         string?            stringcmp
+  stringpfx          strip              striplead          striptail
+  strlen             strncmp            strtof             subst
+  succ               supplicant         swap               sysparm
+  sysparm_array      systime            systime_precise    
 
 T's
   tan          tell         testlock     textattr     then         thing?
@@ -232,7 +235,7 @@ V's
   var        var!       variable   version    
 
 W's
-  watchpid   while      wizcall    
+  watchpid   while      width      wizcall    
 
 X's
   xor            xyz_to_polar   
@@ -5492,8 +5495,9 @@ awake?             descr              descr_array        descr_setuser
 descrboot          descrbufsize       descrcount         descrdbref
 descrflush         descrhost          descridle          descriptors
 descrleastidle     descrmostidle      descrnotify        descrsecure?
-descrtime          descruser          firstdescr         lastdescr
-nextdescr          online             online_array       
+descrtime          descruser          firstdescr         height
+lastdescr          nextdescr          online             online_array
+setheight          setwidth           width              
 
 ~----------------------------------------------------------------------------
 ~
@@ -5686,6 +5690,83 @@ buffer.  If more data is written to the buffer than it has space for, the
 data at the beginning of the buffer gets erased with an <output flushed>.
 Remember that each NOTIFY adds a CR LF byte pair at the end of each line.
 Also note that \r in lines gets translated to CR LF byte pairs.
+~
+~
+SETWIDTH
+SETWIDTH ( int:descr int:width -- )
+
+  For the given descriptor, set the reported terminal width.  Note that this
+set width can be overriden if the players's client sends an updated size and
+is mostly here for cases where a user's client doesn't provide size information
+but you wish to use the WIDTH function.
+
+  Width is in number of characters on a line visible without scrolling.
+The maximum width is 65535.
+
+  Sizing is per-descriptor instead of per-player, because each descriptor
+represents a different connection (and a player may have multiple), and
+each connection may have a different terminal size.
+(Requires MUCKER level 3)
+Also see: SETHEIGHT, HEIGHT and WIDTH
+~
+~
+SETHEIGHT
+SETHEIGHT ( int:descr int:height -- )
+
+  For the given descriptor, set the reported terminal height.  Note that this
+set height can be overriden if the players's client sends an updated size and
+is mostly here for cases where a user's client doesn't provide size information
+but you wish to use the HEIGHT function.
+
+  Height is in number of lines visible without scrolling.
+The maximum height is 65535.
+
+  Sizing is per-descriptor instead of per-player, because each descriptor
+represents a different connection (and a player may have multiple), and
+each connection may have a different terminal size.
+(Requires MUCKER level 3)
+Also see: SETWIDTH, HEIGHT and WIDTH
+~
+~
+WIDTH
+WIDTH ( int:descr -- int:columns )
+
+  For the given descriptor, fetch the width of the client window in
+characters.  This is the maximum number of characters the client can display
+without scrolling.
+
+  Not all clients support NAWS (the Telnet protocol that reports screen size)
+and not all clients properly support NAWS (some don't report updates to
+screen size).  If the size is unknown, this will return 0.  You may use
+the SETWIDTH and SETHEIGHT primitives to force a size setting in such a
+case.
+
+  Sizing is per-descriptor instead of per-player, because each descriptor
+represents a different connection (and a player may have multiple), and
+each connection may have a different terminal size.
+Also see: SETWIDTH, SETHEIGHT and HEIGHT
+~
+~
+HEIGHT
+HEIGHT ( int:descr -- int:rows )
+
+  For the given descriptor, fetch the height of the client window in
+rows (lines).  This is the maximum number of lines the client can display
+without scrolling.  Though practically speaking, you may need to subtract
+a few lines from this in order to insure no scrolling as this count of lines
+may include input fields and other UI elements as would vary from client to
+client.
+
+  Not all clients support NAWS (the Telnet protocol that reports screen size)
+and not all clients properly support NAWS (some don't report updates to
+screen size).  If the size is unknown, this will return 0.  You may use
+the SETWIDTH and SETHEIGHT primitives to force a size setting in such a
+case.
+
+  Sizing is per-descriptor instead of per-player, because each descriptor
+represents a different connection (and a player may have multiple), and
+each connection may have a different terminal size.
+Also see: SETWIDTH, SETHEIGHT and WIDTH
 ~
 ~
 ~

--- a/docs/mpihelp.html
+++ b/docs/mpihelp.html
@@ -1062,6 +1062,9 @@ screen width is unknown.  Example:
     {right:Hello,10,_.}
 </pre>
 would return the string &quot;_._._Hello&quot;
+<p>Also see:
+    <a href="#width">WIDTH</a>
+</p>
 <!-- HTML_TOPICEND -->
 
 
@@ -1081,6 +1084,9 @@ screen width is unknown.  Example:
     {left:Hello,10,_.}
 </pre>
 would return the string &quot;Hello_._._&quot;
+<p>Also see:
+    <a href="#width">WIDTH</a>
+</p>
 <!-- HTML_TOPICEND -->
 
 
@@ -1100,6 +1106,9 @@ screen width is unknown.  Example:
     {center:Hello,10,1234567890}
 </pre>
 would return the string &quot;123Hello12&quot;
+<p>Also see:
+    <a href="#width">WIDTH</a>
+</p>
 <!-- HTML_TOPICEND -->
 
 

--- a/docs/mpihelp.html
+++ b/docs/mpihelp.html
@@ -115,6 +115,7 @@
 
 <h3>H's</h3>
 <ul>
+    <li><a href="#height">height</a></li>
     <li><a href="#holds">holds</a></li>
 </ul>
 
@@ -256,6 +257,7 @@
 <h3>W's</h3>
 <ul>
     <li><a href="#while">while</a></li>
+    <li><a href="#width">width</a></li>
     <li><a href="#with">with</a></li>
 </ul>
 
@@ -1789,9 +1791,11 @@ this just sees if obj1 is within the locational environment of obj2.
 <ul>
     <li><a href="#awake">awake</a></li>
     <li><a href="#descr">descr</a></li>
+    <li><a href="#height">height</a></li>
     <li><a href="#idle">idle</a></li>
     <li><a href="#online">online</a></li>
     <li><a href="#ontime">ontime</a></li>
+    <li><a href="#width">width</a></li>
 </ul>
 
 <h3 id="online">{online}
@@ -1838,6 +1842,34 @@ if there are multiple connects.
 <br>
 </h3>
     Returns the descriptor number that invoked the MPI.
+<!-- HTML_TOPICEND -->
+
+
+<h3 id="height">{height}
+<br>
+{height:default}
+<br>
+</h3>
+    Returns the reported height, in lines, of a the calling descriptor's
+terminal.  This function only works if the caller's client supports reporting
+terminal size or if the SETHEIGHT MUF primintive was used to set the caller's
+screen height.  If called with no parameters, this will return 0 if the
+caller's screen size is not set.  If called with a default parameter, we
+will return that default.  24 lines is usually a reasonable default.
+<!-- HTML_TOPICEND -->
+
+
+<h3 id="width">{width}
+<br>
+{width:default}
+<br>
+</h3>
+    Returns the reported width, in characters, of a the calling descriptor's
+terminal.  This function only works if the caller's client supports reporting
+terminal size or if the SETWIDTH MUF primintive was used to set the caller's
+screen width.  If called with no parameters, this will return 0 if the
+caller's screen size is not set.  If called with a default parameter, we
+will return that default.  80 characters is usually a reasonable default.
 <!-- HTML_TOPICEND -->
 
 <h2 id="VarFuncs">Variable Handling Functions</h2>

--- a/docs/mpihelp.html
+++ b/docs/mpihelp.html
@@ -1055,8 +1055,9 @@ and the end.
 </h3>
     Takes a string and pads it to fit the given fieldwidth, with the string
 right justified.  If no padstring is given, it assumes that it will pad the
-string with spaces.  If no fieldwidth is given, it assumes that the field
-width is 78 characters.  Example:
+string with spaces.  If no fieldwidth is given, it will use the introspected
+screen size if available (see WIDTH) or default to 78 characters if the
+screen width is unknown.  Example:
 <pre>
     {right:Hello,10,_.}
 </pre>
@@ -1073,8 +1074,9 @@ would return the string &quot;_._._Hello&quot;
 </h3>
     Takes a string and pads it to fit the given fieldwidth, with the string
 left justified.  If no padstring is given, it assumes that it will pad the
-string with spaces.  If no fieldwidth is given, it assumes that the field
-width is 78 characters.  Example:
+string with spaces.  If no fieldwidth is given, it will use the introspected
+screen size if available (see WIDTH) or default to 78 characters if the
+screen width is unknown.  Example:
 <pre>
     {left:Hello,10,_.}
 </pre>
@@ -1091,8 +1093,9 @@ would return the string &quot;Hello_._._&quot;
 </h3>
     Takes a string and pads it to fit the given fieldwidth, with the string
 center justified.  If no padstring is given, it assumes that it will pad the
-string with spaces.  If no fieldwidth is given, it assumes that the field
-width is 78 characters.  Example:
+string with spaces.  If no fieldwidth is given, it will use the introspected
+screen size if available (see WIDTH) or default to 78 characters if the
+screen width is unknown.  Example:
 <pre>
     {center:Hello,10,1234567890}
 </pre>

--- a/docs/mpihelp.txt
+++ b/docs/mpihelp.txt
@@ -66,7 +66,7 @@ G's
   ge  gt  
 
 H's
-  holds  
+  height  holds   
 
 I's
   idle     if       inc      index    index!   instr    isdbref  isnum
@@ -111,7 +111,7 @@ V's
   v        version  
 
 W's
-  while  with   
+  while  width  with   
 
 X's
   xor  
@@ -1280,7 +1280,7 @@ this just sees if obj1 is within the locational environment of obj2.
 Connection Related Functions|Connection|ConnFuncs
 Connection Related Functions
 
-awake   descr   idle    online  ontime  
+awake   descr   height  idle    online  ontime  width   
 
 ~----------------------------------------------------------------------------
 ~
@@ -1320,6 +1320,28 @@ if there are multiple connects.
 DESCR
 {descr}
     Returns the descriptor number that invoked the MPI.
+~
+~
+HEIGHT
+{height}
+{height:default}
+    Returns the reported height, in lines, of a the calling descriptor's
+terminal.  This function only works if the caller's client supports reporting
+terminal size or if the SETHEIGHT MUF primintive was used to set the caller's
+screen height.  If called with no parameters, this will return 0 if the
+caller's screen size is not set.  If called with a default parameter, we
+will return that default.  24 lines is usually a reasonable default.
+~
+~
+WIDTH
+{width}
+{width:default}
+    Returns the reported width, in characters, of a the calling descriptor's
+terminal.  This function only works if the caller's client supports reporting
+terminal size or if the SETWIDTH MUF primintive was used to set the caller's
+screen width.  If called with no parameters, this will return 0 if the
+caller's screen size is not set.  If called with a default parameter, we
+will return that default.  80 characters is usually a reasonable default.
 ~
 ~
 ~

--- a/docs/mpihelp.txt
+++ b/docs/mpihelp.txt
@@ -724,6 +724,7 @@ screen size if available (see WIDTH) or default to 78 characters if the
 screen width is unknown.  Example:
     {right:Hello,10,_.}
 would return the string "_._._Hello"
+Also see: WIDTH
 ~
 ~
 LEFT
@@ -737,6 +738,7 @@ screen size if available (see WIDTH) or default to 78 characters if the
 screen width is unknown.  Example:
     {left:Hello,10,_.}
 would return the string "Hello_._._"
+Also see: WIDTH
 ~
 ~
 CENTER
@@ -750,6 +752,7 @@ screen size if available (see WIDTH) or default to 78 characters if the
 screen width is unknown.  Example:
     {center:Hello,10,1234567890}
 would return the string "123Hello12"
+Also see: WIDTH
 ~
 ~
 INSTR

--- a/docs/mpihelp.txt
+++ b/docs/mpihelp.txt
@@ -719,8 +719,9 @@ RIGHT
 {right:string,fieldwidth,padstring}
     Takes a string and pads it to fit the given fieldwidth, with the string
 right justified.  If no padstring is given, it assumes that it will pad the
-string with spaces.  If no fieldwidth is given, it assumes that the field
-width is 78 characters.  Example:
+string with spaces.  If no fieldwidth is given, it will use the introspected
+screen size if available (see WIDTH) or default to 78 characters if the
+screen width is unknown.  Example:
     {right:Hello,10,_.}
 would return the string "_._._Hello"
 ~
@@ -731,8 +732,9 @@ LEFT
 {left:string,fieldwidth,padstring}
     Takes a string and pads it to fit the given fieldwidth, with the string
 left justified.  If no padstring is given, it assumes that it will pad the
-string with spaces.  If no fieldwidth is given, it assumes that the field
-width is 78 characters.  Example:
+string with spaces.  If no fieldwidth is given, it will use the introspected
+screen size if available (see WIDTH) or default to 78 characters if the
+screen width is unknown.  Example:
     {left:Hello,10,_.}
 would return the string "Hello_._._"
 ~
@@ -743,8 +745,9 @@ CENTER
 {center:string,fieldwidth,padstring}
     Takes a string and pads it to fit the given fieldwidth, with the string
 center justified.  If no padstring is given, it assumes that it will pad the
-string with spaces.  If no fieldwidth is given, it assumes that the field
-width is 78 characters.  Example:
+string with spaces.  If no fieldwidth is given, it will use the introspected
+screen size if available (see WIDTH) or default to 78 characters if the
+screen width is unknown.  Example:
     {center:Hello,10,1234567890}
 would return the string "123Hello12"
 ~

--- a/docs/mufman.html
+++ b/docs/mufman.html
@@ -369,6 +369,11 @@
     <li><a href="#gui_values_get">gui_values_get</a></li>
 </ul>
 
+<h3>H's</h3>
+<ul>
+    <li><a href="#height">height</a></li>
+</ul>
+
 <h3>I's</h3>
 <ul>
     <li><a href="#if">if</a></li>
@@ -555,6 +560,7 @@
     <li><a href="#setdesc">setdesc</a></li>
     <li><a href="#setdrop">setdrop</a></li>
     <li><a href="#setfail">setfail</a></li>
+    <li><a href="#setheight">setheight</a></li>
     <li><a href="#setlink">setlink</a></li>
     <li><a href="#setlinks_array">setlinks_array</a></li>
     <li><a href="#setlockstr">setlockstr</a></li>
@@ -568,6 +574,7 @@
     <li><a href="#setseed">setseed</a></li>
     <li><a href="#setsucc">setsucc</a></li>
     <li><a href="#setsysparm">setsysparm</a></li>
+    <li><a href="#setwidth">setwidth</a></li>
     <li><a href="#shallow_copy">shallow_copy</a></li>
     <li><a href="#sign">sign</a></li>
     <li><a href="#sin">sin</a></li>
@@ -652,6 +659,7 @@
 <ul>
     <li><a href="#watchpid">watchpid</a></li>
     <li><a href="#while">while</a></li>
+    <li><a href="#width">width</a></li>
     <li><a href="#wizcall">wizcall</a></li>
 </ul>
 
@@ -8644,10 +8652,14 @@ This primitive requires at least mucker level 4.
     <li><a href="#descrtime">descrtime</a></li>
     <li><a href="#descruser">descruser</a></li>
     <li><a href="#firstdescr">firstdescr</a></li>
+    <li><a href="#height">height</a></li>
     <li><a href="#lastdescr">lastdescr</a></li>
     <li><a href="#nextdescr">nextdescr</a></li>
     <li><a href="#online">online</a></li>
     <li><a href="#online_array">online_array</a></li>
+    <li><a href="#setheight">setheight</a></li>
+    <li><a href="#setwidth">setwidth</a></li>
+    <li><a href="#width">width</a></li>
 </ul>
 
 
@@ -8910,6 +8922,119 @@ buffer.  If more data is written to the buffer than it has space for, the
 data at the beginning of the buffer gets erased with an &lt;output flushed&gt;.
 Remember that each NOTIFY adds a CR LF byte pair at the end of each line.
 Also note that \r in lines gets translated to CR LF byte pairs.
+<!-- HTML_TOPICEND -->
+
+
+<h3 id="setwidth">SETWIDTH ( int:descr int:width -- )
+<br>
+
+<br>
+</h3>
+  For the given descriptor, set the reported terminal width.  Note that this
+set width can be overriden if the players's client sends an updated size and
+is mostly here for cases where a user's client doesn't provide size information
+but you wish to use the WIDTH function.
+
+<p>
+  Width is in number of characters on a line visible without scrolling.
+The maximum width is 65535.
+
+<p>
+  Sizing is per-descriptor instead of per-player, because each descriptor
+represents a different connection (and a player may have multiple), and
+each connection may have a different terminal size.
+(Requires MUCKER level 3)
+<p>Also see:
+    <a href="#setheight">SETHEIGHT</a>,
+    <a href="#height">HEIGHT</a> and
+    <a href="#width">WIDTH</a>
+</p>
+<!-- HTML_TOPICEND -->
+
+
+<h3 id="setheight">SETHEIGHT ( int:descr int:height -- )
+<br>
+
+<br>
+</h3>
+  For the given descriptor, set the reported terminal height.  Note that this
+set height can be overriden if the players's client sends an updated size and
+is mostly here for cases where a user's client doesn't provide size information
+but you wish to use the HEIGHT function.
+
+<p>
+  Height is in number of lines visible without scrolling.
+The maximum height is 65535.
+
+<p>
+  Sizing is per-descriptor instead of per-player, because each descriptor
+represents a different connection (and a player may have multiple), and
+each connection may have a different terminal size.
+(Requires MUCKER level 3)
+<p>Also see:
+    <a href="#setwidth">SETWIDTH</a>,
+    <a href="#height">HEIGHT</a> and
+    <a href="#width">WIDTH</a>
+</p>
+<!-- HTML_TOPICEND -->
+
+
+<h3 id="width">WIDTH ( int:descr -- int:columns )
+<br>
+
+<br>
+</h3>
+  For the given descriptor, fetch the width of the client window in
+characters.  This is the maximum number of characters the client can display
+without scrolling.
+
+<p>
+  Not all clients support NAWS (the Telnet protocol that reports screen size)
+and not all clients properly support NAWS (some don't report updates to
+screen size).  If the size is unknown, this will return 0.  You may use
+the SETWIDTH and SETHEIGHT primitives to force a size setting in such a
+case.
+
+<p>
+  Sizing is per-descriptor instead of per-player, because each descriptor
+represents a different connection (and a player may have multiple), and
+each connection may have a different terminal size.
+<p>Also see:
+    <a href="#setwidth">SETWIDTH</a>,
+    <a href="#setheight">SETHEIGHT</a> and
+    <a href="#height">HEIGHT</a>
+</p>
+<!-- HTML_TOPICEND -->
+
+
+<h3 id="height">HEIGHT ( int:descr -- int:rows )
+<br>
+
+<br>
+</h3>
+  For the given descriptor, fetch the height of the client window in
+rows (lines).  This is the maximum number of lines the client can display
+without scrolling.  Though practically speaking, you may need to subtract
+a few lines from this in order to insure no scrolling as this count of lines
+may include input fields and other UI elements as would vary from client to
+client.
+
+<p>
+  Not all clients support NAWS (the Telnet protocol that reports screen size)
+and not all clients properly support NAWS (some don't report updates to
+screen size).  If the size is unknown, this will return 0.  You may use
+the SETWIDTH and SETHEIGHT primitives to force a size setting in such a
+case.
+
+<p>
+  Sizing is per-descriptor instead of per-player, because each descriptor
+represents a different connection (and a player may have multiple), and
+each connection may have a different terminal size.
+<p>Also see:
+    <a href="#setwidth">SETWIDTH</a>,
+    <a href="#setheight">SETHEIGHT</a> and
+    <a href="#width">WIDTH</a>
+</p>
 <!-- HTML_TOPICEND -->
 
 

--- a/include/mfun.h
+++ b/include/mfun.h
@@ -1009,6 +1009,24 @@ const char *mfn_ge(MFUNARGS);
 const char *mfn_gt(MFUNARGS);
 
 /**
+ * MPI function to get the descriptor's screen height.
+ *
+ * arg0 is an optional default value if there is no screen height set.
+ *
+ * @param descr the descriptor of the caller
+ * @param player the ref of the calling player
+ * @param what the dbref of the trigger
+ * @param perms the dbref for permission consideration
+ * @param argc the number of arguments
+ * @param argv the array of strings for arguments
+ * @param buf the working buffer
+ * @param buflen the size of the buffer
+ * @param mesgtyp the type of the message
+ * @return string parsed results
+ */
+const char *mfn_height(MFUNARGS);
+
+/**
  * MPI function that returns true if obj1's location is obj2
  *
  * This is a lot like {contains} but it doesn't search the environment.
@@ -2828,6 +2846,24 @@ const char *mfn_version(MFUNARGS);
 const char *mfn_while(MFUNARGS);
 
 /**
+ * MPI function to get the descriptor's screen width..
+ *
+ * arg0 is an optional default value if there is no screen width set.
+ *
+ * @param descr the descriptor of the caller
+ * @param player the ref of the calling player
+ * @param what the dbref of the trigger
+ * @param perms the dbref for permission consideration
+ * @param argc the number of arguments
+ * @param argv the array of strings for arguments
+ * @param buf the working buffer
+ * @param buflen the size of the buffer
+ * @param mesgtyp the type of the message
+ * @return string parsed results
+ */
+const char *mfn_width(MFUNARGS);
+
+/**
  * MPI function that defines a variable context
  *
  * MPI is kind of weird and variables run within a context in the
@@ -2958,6 +2994,7 @@ static struct mfun_dat mfun_list[] = {
     {"FUNC", mfn_func, 0, 0, 1, 2, 9},  /* define a function */
     {"GE", mfn_ge, 1, 0, 1, 2, 2},
     {"GT", mfn_gt, 1, 0, 1, 2, 2},
+    {"HEIGHT", mfn_height, 1, 0, 1, 0, 1},
     {"HOLDS", mfn_holds, 1, 0, 1, 1, 2},
     {"IDLE", mfn_idle, 1, 0, 1, 1, 1},
     {"IF", mfn_if, 0, 0, 0, 2, 3},
@@ -3047,6 +3084,7 @@ static struct mfun_dat mfun_list[] = {
     {"V", mfn_v, 1, 0, 1, 1, 1},    /* variable value */
     {"VERSION", mfn_version, 0, 0, 0, 0, 0},
     {"WHILE", mfn_while, 0, 0, 0, 2, 2},
+    {"WIDTH", mfn_width, 1, 0, 1, 0, 1},
     {"WITH", mfn_with, 0, 0, 0, 3, 9},  /* declares var & val */
     {"XOR", mfn_xor, 1, 0, 1, 2, 2},    /* logical XOR */
 

--- a/include/p_connects.h
+++ b/include/p_connects.h
@@ -429,6 +429,69 @@ void prim_descr_securep(PRIM_PROTOTYPE);
 void prim_descr_bufsize(PRIM_PROTOTYPE);
 
 /**
+ * Implementation of MUF SETWIDTH
+ *
+ * Consumes a descriptor number and screensize.  Returns nothing.
+ *
+ * @param player the player running the MUF program
+ * @param program the program being run
+ * @param mlev the effective MUCKER level
+ * @param pc the program counter pointer
+ * @param arg the argument stack
+ * @param top the top-most item of the stack
+ * @param fr the program frame
+ */
+void prim_setwidth(PRIM_PROTOTYPE);
+
+/**
+ * Implementation of MUF SETHEIGHT
+ *
+ * Consumes a descriptor number and screensize.  Returns nothing.
+ *
+ * @param player the player running the MUF program
+ * @param program the program being run
+ * @param mlev the effective MUCKER level
+ * @param pc the program counter pointer
+ * @param arg the argument stack
+ * @param top the top-most item of the stack
+ * @param fr the program frame
+ */
+void prim_setheight(PRIM_PROTOTYPE);
+
+/**
+ * Implementation of MUF WIDTH
+ *
+ * Consumes a descriptor.  Puts the detected width on the stack.  This width
+ * maybe 0 if it is unknown.
+ *
+ * @param player the player running the MUF program
+ * @param program the program being run
+ * @param mlev the effective MUCKER level
+ * @param pc the program counter pointer
+ * @param arg the argument stack
+ * @param top the top-most item of the stack
+ * @param fr the program frame
+ */
+void prim_width(PRIM_PROTOTYPE);
+
+/**
+ * Implementation of MUF HEIGHT
+ *
+ * Consumes a descriptor.  Puts the detected height on the stack.  This height
+ * maybe 0 if it is unknown.
+ *
+ * @param player the player running the MUF program
+ * @param program the program being run
+ * @param mlev the effective MUCKER level
+ * @param pc the program counter pointer
+ * @param arg the argument stack
+ * @param top the top-most item of the stack
+ * @param fr the program frame
+ */
+void prim_height(PRIM_PROTOTYPE);
+
+
+/**
  * Primitive callback functions
  */
 #define PRIMS_CONNECTS_FUNCS prim_awakep, prim_online, prim_descrcount,    \
@@ -437,7 +500,7 @@ void prim_descr_bufsize(PRIM_PROTOTYPE);
     prim_lastdescr, prim_descr_time, prim_descr_host, prim_descr_user,     \
     prim_descr_boot, prim_descr_idle, prim_descr_notify, prim_descr_dbref, \
     prim_descr_least_idle, prim_descr_most_idle, prim_descr_securep,       \
-    prim_descr_bufsize
+    prim_descr_bufsize, prim_setwidth, prim_setheight, prim_width, prim_height
 
 /**
  * Primitive names - must be in same order as the callback functions
@@ -448,6 +511,6 @@ void prim_descr_bufsize(PRIM_PROTOTYPE);
     "LASTDESCR", "DESCRTIME", "DESCRHOST", "DESCRUSER",       \
     "DESCRBOOT", "DESCRIDLE", "DESCRNOTIFY", "DESCRDBREF",    \
     "DESCRLEASTIDLE", "DESCRMOSTIDLE", "DESCRSECURE?",        \
-    "DESCRBUFSIZE"
+    "DESCRBUFSIZE", "SETWIDTH", "SETHEIGHT", "WIDTH", "HEIGHT"
 
 #endif /* !P_CONNECTS_H */

--- a/src/mfuns.c
+++ b/src/mfuns.c
@@ -3761,17 +3761,21 @@ mfn_right(MFUNARGS)
     /* {right:string,fieldwidth,padstr} */
     /* Right justify string to a fieldwidth, filling with padstr */
 
-    /*
-     * TODO: As part of issue #424 it would be cool if we introspected
-     *       the proper terminal size by default if possible.
-     */
-
     char *ptr;
     const char *fptr;
     int i, len;
     const char *fillstr;
+    const struct descriptor_data* d;
 
-    len = (argc > 1) ? atoi(argv[1]) : 78;
+    d = descrdata_by_descr(descr);
+
+    if (argc > 1) {
+        len = atoi(argv[1]);
+    } else if (d->detected_width > 0) {
+        len = d->detected_width;
+    } else {
+        len = 78;
+    }
 
     if (len > BUFFER_LEN - 1)
         ABORT_MPI("RIGHT", "Fieldwidth too big.");
@@ -3820,17 +3824,21 @@ mfn_left(MFUNARGS)
     /* {left:string,fieldwidth,padstr} */
     /* Left justify string to a fieldwidth, filling with padstr */
 
-    /*
-     * TODO: As part of issue #424 it would be cool if we introspected
-     *       the proper terminal size by default if possible.
-     */
-
     char *ptr;
     const char *fptr;
     int i, len;
     const char *fillstr;
+    const struct descriptor_data* d;
 
-    len = (argc > 1) ? atoi(argv[1]) : 78;
+    d = descrdata_by_descr(descr);
+
+    if (argc > 1) {
+        len = atoi(argv[1]);
+    } else if (d->detected_width > 0) {
+        len = d->detected_width;
+    } else {
+        len = 78;
+    }
 
     if (len > BUFFER_LEN - 1)
         ABORT_MPI("LEFT", "Fieldwidth too big.");
@@ -3859,7 +3867,8 @@ mfn_left(MFUNARGS)
  *
  * arg0 is the message
  *
- * arg1 is the line width which defaults to 78
+ * arg1 is the line width which defaults to 78 unless the descriptor's
+ * width is set in which case it will use that.
  *
  * arg2 is the padding string which defaults to " " but can be any
  * string.
@@ -3881,17 +3890,21 @@ mfn_center(MFUNARGS)
     /* {center:string,fieldwidth,padstr} */
     /* Center justify string to a fieldwidth, filling with padstr */
 
-    /*
-     * TODO: As part of issue #424 it would be cool if we introspected
-     *       the proper terminal size by default if possible.
-     */
-
     char *ptr;
     const char *fptr;
     int i, len, halflen;
     const char *fillstr;
+    const struct descriptor_data* d;
 
-    len = (argc > 1) ? atoi(argv[1]) : 78;
+    d = descrdata_by_descr(descr);
+
+    if (argc > 1) {
+        len = atoi(argv[1]);
+    } else if (d->detected_width > 0) {
+        len = d->detected_width;
+    } else {
+        len = 78;
+    }
 
     if (len > BUFFER_LEN - 1)
         ABORT_MPI("CENTER", "Fieldwidth too big.");

--- a/src/mfuns2.c
+++ b/src/mfuns2.c
@@ -3389,3 +3389,73 @@ mfn_escape(MFUNARGS)
     *out = '\0';
     return buf;
 }
+
+/**
+ * MPI function to get the descriptor's screen height.
+ *
+ * arg0 is an optional default value if there is no screen height set.
+ *
+ * @param descr the descriptor of the caller
+ * @param player the ref of the calling player
+ * @param what the dbref of the trigger
+ * @param perms the dbref for permission consideration
+ * @param argc the number of arguments
+ * @param argv the array of strings for arguments
+ * @param buf the working buffer
+ * @param buflen the size of the buffer
+ * @param mesgtyp the type of the message
+ * @return string parsed results
+ */
+const char *
+mfn_height(MFUNARGS)
+{
+    int height;
+    const struct descriptor_data* d;
+
+    d = descrdata_by_descr(descr);
+
+    height = d->detected_height;
+
+    if ((argc > 0) && (height == 0)) {
+        return argv[0];
+    }
+
+    snprintf(buf, BUFFER_LEN, "%d", height);
+
+    return buf;
+}
+
+/**
+ * MPI function to get the descriptor's screen width..
+ *
+ * arg0 is an optional default value if there is no screen width set.
+ *
+ * @param descr the descriptor of the caller
+ * @param player the ref of the calling player
+ * @param what the dbref of the trigger
+ * @param perms the dbref for permission consideration
+ * @param argc the number of arguments
+ * @param argv the array of strings for arguments
+ * @param buf the working buffer
+ * @param buflen the size of the buffer
+ * @param mesgtyp the type of the message
+ * @return string parsed results
+ */
+const char *
+mfn_width(MFUNARGS)
+{
+    int width;
+    const struct descriptor_data* d;
+
+    d = descrdata_by_descr(descr);
+
+    width = d->detected_width;
+
+    if ((argc > 0) && (width == 0)) {
+        return argv[0];
+    }
+
+    snprintf(buf, BUFFER_LEN, "%d", width);
+
+    return buf;
+}

--- a/src/mpihelp.raw
+++ b/src/mpihelp.raw
@@ -558,7 +558,7 @@ screen width is unknown.  Example:
     {right:Hello,10,_.}
 ~~endcode
 would return the string "_._._Hello"
-~~seealso WIDTH
+~~alsosee WIDTH
 ~
 ~
 LEFT
@@ -574,7 +574,7 @@ screen width is unknown.  Example:
     {left:Hello,10,_.}
 ~~endcode
 would return the string "Hello_._._"
-~~seealso WIDTH
+~~alsosee WIDTH
 ~
 ~
 CENTER
@@ -590,7 +590,7 @@ screen width is unknown.  Example:
     {center:Hello,10,1234567890}
 ~~endcode
 would return the string "123Hello12"
-~~seealso WIDTH
+~~alsosee WIDTH
 ~
 ~
 INSTR

--- a/src/mpihelp.raw
+++ b/src/mpihelp.raw
@@ -551,12 +551,14 @@ RIGHT
 {right:string,fieldwidth,padstring}
     Takes a string and pads it to fit the given fieldwidth, with the string
 right justified.  If no padstring is given, it assumes that it will pad the
-string with spaces.  If no fieldwidth is given, it assumes that the field
-width is 78 characters.  Example:
+string with spaces.  If no fieldwidth is given, it will use the introspected
+screen size if available (see WIDTH) or default to 78 characters if the
+screen width is unknown.  Example:
 ~~code
     {right:Hello,10,_.}
 ~~endcode
 would return the string "_._._Hello"
+~~seealso WIDTH
 ~
 ~
 LEFT
@@ -565,12 +567,14 @@ LEFT
 {left:string,fieldwidth,padstring}
     Takes a string and pads it to fit the given fieldwidth, with the string
 left justified.  If no padstring is given, it assumes that it will pad the
-string with spaces.  If no fieldwidth is given, it assumes that the field
-width is 78 characters.  Example:
+string with spaces.  If no fieldwidth is given, it will use the introspected
+screen size if available (see WIDTH) or default to 78 characters if the
+screen width is unknown.  Example:
 ~~code
     {left:Hello,10,_.}
 ~~endcode
 would return the string "Hello_._._"
+~~seealso WIDTH
 ~
 ~
 CENTER
@@ -579,12 +583,14 @@ CENTER
 {center:string,fieldwidth,padstring}
     Takes a string and pads it to fit the given fieldwidth, with the string
 center justified.  If no padstring is given, it assumes that it will pad the
-string with spaces.  If no fieldwidth is given, it assumes that the field
-width is 78 characters.  Example:
+string with spaces.  If no fieldwidth is given, it will use the introspected
+screen size if available (see WIDTH) or default to 78 characters if the
+screen width is unknown.  Example:
 ~~code
     {center:Hello,10,1234567890}
 ~~endcode
 would return the string "123Hello12"
+~~seealso WIDTH
 ~
 ~
 INSTR

--- a/src/mpihelp.raw
+++ b/src/mpihelp.raw
@@ -1114,6 +1114,28 @@ DESCR
 {descr}
     Returns the descriptor number that invoked the MPI.
 ~
+~
+HEIGHT
+{height}
+{height:default}
+    Returns the reported height, in lines, of a the calling descriptor's
+terminal.  This function only works if the caller's client supports reporting
+terminal size or if the SETHEIGHT MUF primintive was used to set the caller's
+screen height.  If called with no parameters, this will return 0 if the
+caller's screen size is not set.  If called with a default parameter, we
+will return that default.  24 lines is usually a reasonable default.
+~
+~
+WIDTH
+{width}
+{width:default}
+    Returns the reported width, in characters, of a the calling descriptor's
+terminal.  This function only works if the caller's client supports reporting
+terminal size or if the SETWIDTH MUF primintive was used to set the caller's
+screen width.  If called with no parameters, this will return 0 if the
+caller's screen size is not set.  If called with a default parameter, we
+will return that default.  80 characters is usually a reasonable default.
+~
 ~~section Variable Handling Functions|Variable|Variables|Vars|Var|VarFuncs
 V|&|VARIABLE
 {&VAR}

--- a/src/mufman.raw
+++ b/src/mufman.raw
@@ -5200,6 +5200,83 @@ Remember that each NOTIFY adds a CR LF byte pair at the end of each line.
 Also note that \r in lines gets translated to CR LF byte pairs.
 ~
 ~
+SETWIDTH
+SETWIDTH ( int:descr int:width -- )
+
+  For the given descriptor, set the reported terminal width.  Note that this
+set width can be overriden if the players's client sends an updated size and
+is mostly here for cases where a user's client doesn't provide size information
+but you wish to use the WIDTH function.
+
+  Width is in number of characters on a line visible without scrolling.
+The maximum width is 65535.
+
+  Sizing is per-descriptor instead of per-player, because each descriptor
+represents a different connection (and a player may have multiple), and
+each connection may have a different terminal size.
+(Requires MUCKER level 3)
+~~alsosee SETHEIGHT,HEIGHT,WIDTH
+~
+~
+SETHEIGHT
+SETHEIGHT ( int:descr int:height -- )
+
+  For the given descriptor, set the reported terminal height.  Note that this
+set height can be overriden if the players's client sends an updated size and
+is mostly here for cases where a user's client doesn't provide size information
+but you wish to use the HEIGHT function.
+
+  Height is in number of lines visible without scrolling.
+The maximum height is 65535.
+
+  Sizing is per-descriptor instead of per-player, because each descriptor
+represents a different connection (and a player may have multiple), and
+each connection may have a different terminal size.
+(Requires MUCKER level 3)
+~~alsosee SETWIDTH,HEIGHT,WIDTH
+~
+~
+WIDTH
+WIDTH ( int:descr -- int:columns )
+
+  For the given descriptor, fetch the width of the client window in
+characters.  This is the maximum number of characters the client can display
+without scrolling.
+
+  Not all clients support NAWS (the Telnet protocol that reports screen size)
+and not all clients properly support NAWS (some don't report updates to
+screen size).  If the size is unknown, this will return 0.  You may use
+the SETWIDTH and SETHEIGHT primitives to force a size setting in such a
+case.
+
+  Sizing is per-descriptor instead of per-player, because each descriptor
+represents a different connection (and a player may have multiple), and
+each connection may have a different terminal size.
+~~alsosee SETWIDTH,SETHEIGHT,HEIGHT
+~
+~
+HEIGHT
+HEIGHT ( int:descr -- int:rows )
+
+  For the given descriptor, fetch the height of the client window in
+rows (lines).  This is the maximum number of lines the client can display
+without scrolling.  Though practically speaking, you may need to subtract
+a few lines from this in order to insure no scrolling as this count of lines
+may include input fields and other UI elements as would vary from client to
+client.
+
+  Not all clients support NAWS (the Telnet protocol that reports screen size)
+and not all clients properly support NAWS (some don't report updates to
+screen size).  If the size is unknown, this will return 0.  You may use
+the SETWIDTH and SETHEIGHT primitives to force a size setting in such a
+case.
+
+  Sizing is per-descriptor instead of per-player, because each descriptor
+represents a different connection (and a player may have multiple), and
+each connection may have a different terminal size.
+~~alsosee SETWIDTH,SETHEIGHT,WIDTH
+~
+~
 ~
 ~~section Event Handling Operators|EventOps
 ~

--- a/src/p_connects.c
+++ b/src/p_connects.c
@@ -5,6 +5,7 @@
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
 #include <stddef.h>
+#include <limits.h>
 
 #include "config.h"
 
@@ -1110,6 +1111,178 @@ prim_descr_bufsize(PRIM_PROTOTYPE)
 
     CHECKOFLOW(1);
     CLEAR(oper1);
+
+    PushInt(result);
+}
+
+/**
+ * Implementation of MUF SETWIDTH
+ *
+ * Consumes a descriptor number and screensize.  Returns nothing.
+ *
+ * @param player the player running the MUF program
+ * @param program the program being run
+ * @param mlev the effective MUCKER level
+ * @param pc the program counter pointer
+ * @param arg the argument stack
+ * @param top the top-most item of the stack
+ * @param fr the program frame
+ */
+void
+prim_setwidth(PRIM_PROTOTYPE)
+{
+    struct descriptor_data* d;
+
+    /* int int -- */
+    CHECKOP(2);
+    oper1 = POP(); /* size */
+    oper2 = POP(); /* descriptor */
+
+    if (mlev < 3)
+        abort_interp("Mucker level 3 primitive.");
+
+    if (oper1->type != PROG_INTEGER)
+        abort_interp("Argument not an integer. (1)");
+
+    if (oper2->type != PROG_INTEGER)
+        abort_interp("Argument not an integer. (2)");
+
+    if ((oper1->data.number < 0) || (oper1->data.number > USHRT_MAX))
+        abort_interp("Width must be between 0 and 65535.");
+
+    d = descrdata_by_descr(oper2->data.number);
+
+    if (!d)
+        abort_interp("Invalid descriptor number (2)");
+
+    d->detected_width = (int)oper1->data.number;
+
+    CLEAR(oper1);
+    CLEAR(oper2);
+}
+
+/**
+ * Implementation of MUF SETHEIGHT
+ *
+ * Consumes a descriptor number and screensize.  Returns nothing.
+ *
+ * @param player the player running the MUF program
+ * @param program the program being run
+ * @param mlev the effective MUCKER level
+ * @param pc the program counter pointer
+ * @param arg the argument stack
+ * @param top the top-most item of the stack
+ * @param fr the program frame
+ */
+void
+prim_setheight(PRIM_PROTOTYPE)
+{
+    struct descriptor_data* d;
+
+    /* int int -- */
+    CHECKOP(2);
+    oper1 = POP(); /* size */
+    oper2 = POP(); /* descriptor */
+
+    if (mlev < 3)
+        abort_interp("Mucker level 3 primitive.");
+
+    if (oper1->type != PROG_INTEGER)
+        abort_interp("Argument not an integer. (1)");
+
+    if (oper2->type != PROG_INTEGER)
+        abort_interp("Argument not an integer. (2)");
+
+    if ((oper1->data.number < 0) || (oper1->data.number > USHRT_MAX))
+        abort_interp("Height must be between 0 and 65535.");
+
+    d = descrdata_by_descr(oper2->data.number);
+
+    if (!d)
+        abort_interp("Invalid descriptor number (2)");
+
+    d->detected_height = (int)oper1->data.number;
+
+    CLEAR(oper1);
+    CLEAR(oper2);
+}
+
+/**
+ * Implementation of MUF WIDTH
+ *
+ * Consumes a descriptor.  Puts the detected width on the stack.  This width
+ * maybe 0 if it is unknown.
+ *
+ * @param player the player running the MUF program
+ * @param program the program being run
+ * @param mlev the effective MUCKER level
+ * @param pc the program counter pointer
+ * @param arg the argument stack
+ * @param top the top-most item of the stack
+ * @param fr the program frame
+ */
+void
+prim_width(PRIM_PROTOTYPE)
+{
+    const struct descriptor_data* d;
+
+    /* int -- int */
+    CHECKOP(1);
+    oper1 = POP(); /* descriptor */
+
+    if (oper1->type != PROG_INTEGER)
+        abort_interp("Argument not an integer. (1)");
+
+    d = descrdata_by_descr(oper1->data.number);
+
+    if (!d)
+        abort_interp("Invalid descriptor number (1)");
+
+    CHECKOFLOW(1);
+    CLEAR(oper1);
+
+    /* Convert short int to int */
+    result = d->detected_width; 
+
+    PushInt(result);
+}
+
+/**
+ * Implementation of MUF HEIGHT
+ *
+ * Consumes a descriptor.  Puts the detected height on the stack.  This height
+ * maybe 0 if it is unknown.
+ *
+ * @param player the player running the MUF program
+ * @param program the program being run
+ * @param mlev the effective MUCKER level
+ * @param pc the program counter pointer
+ * @param arg the argument stack
+ * @param top the top-most item of the stack
+ * @param fr the program frame
+ */
+void
+prim_height(PRIM_PROTOTYPE)
+{
+    const struct descriptor_data* d;
+
+    /* int -- int */
+    CHECKOP(1);
+    oper1 = POP(); /* descriptor */
+
+    if (oper1->type != PROG_INTEGER)
+        abort_interp("Argument not an integer. (1)");
+
+    d = descrdata_by_descr(oper1->data.number);
+
+    if (!d)
+        abort_interp("Invalid descriptor number (1)");
+
+    CHECKOFLOW(1);
+    CLEAR(oper1);
+
+    /* Convert short int to int */
+    result = d->detected_height; 
 
     PushInt(result);
 }


### PR DESCRIPTION
This resolves #424 

Allows the MUCK to get terminal size from telnet protocol, and provides both MUF and MPI prims to take advantage of them.  Also makes MPI right/left/center use introspected screen size if available.