### PR TITLE
 Update starterdb wf with bugfix applied to fuzzball muf 

### DIFF
--- a/dbs/starterdb/muf/34.m
+++ b/dbs/starterdb/muf/34.m
@@ -9,9 +9,13 @@
   Version history
   1.001, 16 March 2003: don't use .rtimestr macro, use rtimestr in
     $lib/timestr. Default USE_ATLASTON to on.
+
+  1.002, 29 August 2023: if a stale dbref is on your wf list [a toaded player]
+    then laston #wf would fail with a crash error.  Added a filtering for
+    non-player refs on the wf list. [HopeIslandCoder]
 )
 $author Natasha O'Brien
-$version 1.001
+$version 1.002
 $note A Fuzzball 6 laston.
  
 $include $lib/strings
@@ -74,7 +78,20 @@ $else
     pmatch dup ok? if 1 array_make else pop 0 array_make then
 $endif
 ;
-: do-watchfor pop me @ prop_wflist array_get_reflist ;
+: do-watchfor
+  pop me @ prop_wflist array_get_reflist
+  
+  ( Filter out invalid ref's )
+  0 array_make
+  swap foreach
+    swap pop
+    dup player? if
+      swap array_appenditem
+    else
+      pop
+    then
+  repeat
+;
 : do-room  ( strY -- arr )
     pop loc @ contents_array  ( arrContents )
     0 array_make swap foreach swap pop  ( arrPlayers db )


### PR DESCRIPTION
Starterdb's wf is actually slightly different from the fuzzball MUF repo's wf and I believe it is to avoid the use of a macro that is present in the fuzzball MUF repo's version.  Good thing I checked the diffs before committing :)  It might be a good idea to copy the starterdb's wf to fuzzball MUF's for consistency sake or vise versa based on what makes the most sense.

However, that's more investigation than I want to do right now and I'm not sure it matters enough to put an issue in for it, since 99% of people will just get laston from starterdb and never look at the one in the fuzzball MUF repo.