### PR TITLE
Address several compiler warnings (some pedantic).

### DIFF
--- a/include/mfun.h
+++ b/include/mfun.h
@@ -2915,6 +2915,7 @@ const char *mfn_with(MFUNARGS);
  */
 const char *mfn_xor(MFUNARGS);
 
+#ifndef NO_MFUN_LIST
 /**
  * This structure defines a single MPI function and is used by the list of
  * MPI functions.
@@ -3090,5 +3091,5 @@ static struct mfun_dat mfun_list[] = {
 
     {NULL, NULL, 0, 0, 0, 0, 0} /* Ends the mfun list */
 };
-
+#endif /* !NO_MFUN_LIST */
 #endif /* !MFUN_H */

--- a/src/boolexp.c
+++ b/src/boolexp.c
@@ -681,8 +681,10 @@ size_boolexp(struct boolexp *b)
             case BOOLEXP_AND:
             case BOOLEXP_OR:
                 result += size_boolexp(b->sub2);
+                /* fall through */
             case BOOLEXP_NOT:
                 result += size_boolexp(b->sub1);
+                /* fall through */
             case BOOLEXP_CONST:
                 break; /* CONST size is "baked into" sizeof *b */
             case BOOLEXP_PROP:
@@ -823,8 +825,9 @@ unparse_boolexp1(dbref player, struct boolexp *b, short outer_type, int fullname
                 if (PropType(b->prop_check) == PROP_STRTYP)
                     strcatn(buftop, sizeof(boolexp_buf) - (size_t)(buftop - boolexp_buf),
                             PropDataStr(b->prop_check));
-                    buftop += strlen(buftop);
-                    break;
+
+                buftop += strlen(buftop);
+                break;
             default:
                 panic("unparse_boolexp1(): bad type !");
         }

--- a/src/edit.c
+++ b/src/edit.c
@@ -581,6 +581,7 @@ disassemble(dbref player, dbref program)
             case PROG_CLEARED:
                 snprintf(buf, sizeof(buf), "%d: (line ?) CLEARED INST AT %s:%d",
                          i, (char *) curr->data.addr, curr->line);
+                /* fall through */
             default:
                 snprintf(buf, sizeof(buf), "%d: (line ?) UNKNOWN INST", i);
         }
@@ -635,8 +636,10 @@ do_delete(dbref player, dbref program, int arg[], int argc)
     switch (argc) {
         case 0:
             arg[0] = PROGRAM_CURR_LINE(program);
+            /* fall through */
         case 1:
             arg[1] = arg[0];
+            /* fall through */
         case 2:
             /*
              * delete from line 1 to line 2
@@ -680,7 +683,8 @@ do_delete(dbref player, dbref program, int arg[], int argc)
                 notifyf(player, "%d line%s deleted", n, n != 1 ? "s" : "");
             } else
                 notify(player, "No line to delete!");
-                break;
+
+            break;
         default:
             notify(player, "Too many arguments!");
             break;
@@ -775,8 +779,10 @@ list_program(dbref player, dbref program, int *oarg, int argc,
     switch (argc) {
         case 0:
             arg[0] = PROGRAM_CURR_LINE(program);
+            /* fall through */
         case 1:
             arg[1] = arg[0];
+            /* fall through */
         case 2:
             if ((arg[0] > arg[1]) && (arg[1] != -1)) {
                 notifyf_nolisten(player, "%sArguments don't make sense!%s", msg_start, msg_end);
@@ -1310,16 +1316,17 @@ read_program(dbref i)
 
         if (!*buf)
             strcpyn(buf, sizeof(buf), " ");
-            nu->this_line = alloc_string(buf);
 
-            if (!first) {
-                prev = nu;
-                first = nu;
-            } else {
-                prev->next = nu;
-                nu->prev = prev;
-                prev = nu;
-            }
+        nu->this_line = alloc_string(buf);
+
+        if (!first) {
+            prev = nu;
+            first = nu;
+        } else {
+            prev->next = nu;
+            nu->prev = prev;
+            prev = nu;
+        }
     }
 
     fclose(f);

--- a/src/fbsignal.c
+++ b/src/fbsignal.c
@@ -257,6 +257,7 @@ bailout(int sig)
 void
 sig_dump_status(int i)
 {
+    (void)i;
     dump_status();
 }
 
@@ -272,6 +273,7 @@ sig_dump_status(int i)
 void
 sig_emerg(int i)
 {
+    (void)i;
     /*
      * @TODO This should probably log_status as well ?
      */
@@ -307,6 +309,8 @@ wall_status(const char *s)
 void
 sig_reconfigure(int i)
 {
+    (void)i;
+
     wall_status("Configuration reload requested remotely.");
 
 #ifdef USE_SSL
@@ -328,6 +332,8 @@ sig_reconfigure(int i)
 void
 sig_shutdown(int i)
 {
+    (void)i;
+
     log_status("SHUTDOWN: via SIGNAL");
     shutdown_flag = 1;
     restart_flag = 0;
@@ -341,6 +347,8 @@ sig_shutdown(int i)
 void
 sig_reap(int i)
 {
+    (void)i;
+
     /*
      * If DISKBASE is not defined, then there are two types of
      * children that can die.  First is the nameservice resolver.
@@ -445,6 +453,8 @@ sig_reap(int i)
 void
 sig_reap(int i)
 {
+    (void)i;
+
 }
 #endif
 
@@ -456,6 +466,7 @@ sig_reap(int i)
 void
 sig_shutdown(int i)
 {
+    (void)i;
 }
 
 /*

--- a/src/interface.c
+++ b/src/interface.c
@@ -1209,8 +1209,7 @@ welcome_user(struct descriptor_data *d)
              * to DEFAULT_WELCOME_MESSAGE anyway.
              */
             size_t ct = fread(buf, sizeof(char), BUFFER_LEN - 1, f);
-            if (ct >= 0)
-                buf[ct] = '\0';
+            buf[ct] = '\0';
             fclose(f);
         }
     }
@@ -3202,6 +3201,9 @@ process_input_naws(struct descriptor_data *d, const char* q)
             d->detected_width = ntohs(*((unsigned short*)d->width_buf));
 
             break;
+
+        default:
+            break;
     }
 }
 
@@ -3776,7 +3778,6 @@ update_server_certificates(void)
 {
     time_t new_mtime_cert_file;
     time_t new_mtime_key_file;
-    SSL_CTX* new_ctx;
 
     new_mtime_cert_file = cert_file_mtime( tp_ssl_cert_file );
     new_mtime_key_file = cert_file_mtime( tp_ssl_key_file );
@@ -3811,7 +3812,6 @@ update_server_certificates(void)
 static SSL_CTX *
 configure_new_ssl_ctx(void)
 {
-    EC_KEY *eckey;
     int ssl_status_ok = 1;
 
     SSL_CTX *new_ssl_ctx = SSL_CTX_new(SSLv23_server_method());
@@ -3860,10 +3860,9 @@ configure_new_ssl_ctx(void)
      * In OpenSSL >= 1.0.2, this exists; otherwise, fallback to the older
      * API where we have to name a curve.
      */
-    eckey = NULL;
     SSL_CTX_set_ecdh_auto(new_ssl_ctx, 1);
 #else
-    eckey = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+    EC_KEY eckey = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
     SSL_CTX_set_tmp_ecdh(new_ssl_ctx, eckey);
 #endif
 
@@ -3941,8 +3940,8 @@ reconfigure_ssl(void)
  * Also, this doesn't wait for the resolver's pid.... it waits for any
  * process to exit.  Theoretically a forked dump could make this return.
  */
-void
-static kill_resolver(void)
+static void
+kill_resolver(void)
 {
     int i;
 

--- a/src/interp.c
+++ b/src/interp.c
@@ -2869,10 +2869,13 @@ do_abort_interp(dbref player, const char *msg, struct inst *pc,
     switch (nargs) {
         case 4:
             RCLEAR(oper4, file, line);
+            /* fall through */
         case 3:
             RCLEAR(oper3, file, line);
+            /* fall through */
         case 2:
             RCLEAR(oper2, file, line);
+            /* fall through */
         case 1:
             RCLEAR(oper1, file, line);
     }

--- a/src/look.c
+++ b/src/look.c
@@ -92,6 +92,7 @@ can_see(dbref player, dbref thing, int can_see_loc)
                 if (tp_dark_sleepers) {
                     return (!Dark(thing) && PLAYER_DESCRCOUNT(thing));
                 }
+                /* fall through */
             default:
                 return (!Dark(thing) || (controls(player, thing) && !(FLAGS(player) & STICKY)));
         }

--- a/src/mfuns.c
+++ b/src/mfuns.c
@@ -22,6 +22,7 @@
 #include "fbtime.h"
 #include "game.h"
 #include "interface.h"
+#define NO_MFUN_LIST
 #include "mfun.h"
 #include "mpi.h"
 #include "props.h"

--- a/src/mfuns2.c
+++ b/src/mfuns2.c
@@ -23,6 +23,7 @@
 #include "inst.h"
 #include "interp.h"
 #include "interface.h"
+#define NO_MFUN_LIST
 #include "mfun.h"
 #include "mpi.h"
 #include "player.h"

--- a/src/move.c
+++ b/src/move.c
@@ -896,6 +896,8 @@ do_get(int descr, dbref player, const char *what, const char *obj)
     switch (Typeof(thing)) {
         case TYPE_THING:
             ts_useobject(thing);
+            /* fall through */
+
         case TYPE_PROGRAM:
             if (obj && *obj) {
                 cando = could_doit(descr, player, thing);
@@ -918,6 +920,7 @@ do_get(int descr, dbref player, const char *what, const char *obj)
                 }
 
                 break;
+
         default:
             notify(player, "You can't take that!");
             break;
@@ -975,15 +978,15 @@ do_drop(int descr, dbref player, const char *name, const char *obj)
         if (Wizard(OWNER(player)))
             match_absolute(&md);    /* the wizard has long fingers */
 
-            if ((cont = noisy_match_result(&md)) == NOTHING) {
-                return;
-            }
+        if ((cont = noisy_match_result(&md)) == NOTHING) {
+            return;
+        }
     }
 
     switch (Typeof(thing)) {
         case TYPE_THING:
             ts_useobject(thing);
-
+            /* fall through */
         case TYPE_PROGRAM:
             if (LOCATION(thing) != player) {
                 /* Shouldn't ever happen. */

--- a/src/p_connects.c
+++ b/src/p_connects.c
@@ -703,7 +703,7 @@ prim_nextdescr(PRIM_PROTOTYPE)
 void
 prim_descriptors(PRIM_PROTOTYPE)
 {
-    int mydescr, mycount = 0;
+    int mycount = 0;
     int *darr;
     int dcount;
     struct descriptor_data* d;

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -255,6 +255,7 @@ prim_moveto(PRIM_PROTOTYPE)
                         && !(Typeof(dest) == TYPE_THING
                         && (FLAGS(dest) & VEHICLE)))
                     abort_interp("Bad destination.");
+                /* fall through */
 
             case TYPE_THING:
                 if (parent_loop_check(victim, dest))
@@ -295,6 +296,7 @@ prim_moveto(PRIM_PROTOTYPE)
                     abort_interp("Destination doesn't accept zombies.");
 
                 ts_lastuseobject(victim);
+                /* fall through */
 
             case TYPE_PROGRAM: {
                 dbref matchroom = NOTHING;

--- a/src/p_stack.c
+++ b/src/p_stack.c
@@ -1317,6 +1317,7 @@ prim_checkargs(PRIM_PROTOTYPE)
 
                             if (Typeof(ref) == TYPE_GARBAGE)
                                 ABORT_CHECKARGS("Invalid dbref.");
+                            /* fall through */
 
                         case 'd':
                             if (ref < HOME)
@@ -1327,6 +1328,7 @@ prim_checkargs(PRIM_PROTOTYPE)
                         case 'P':
                             if (ref < 0)
                                 ABORT_CHECKARGS("Expected player dbref.");
+                            /* fall through */
 
                         case 'p':
                             if ((ref >= 0) && (Typeof(ref) != TYPE_PLAYER))
@@ -1340,6 +1342,7 @@ prim_checkargs(PRIM_PROTOTYPE)
                         case 'R':
                             if ((ref < 0) && (ref != HOME))
                                 ABORT_CHECKARGS("Expected room dbref.");
+                            /* fall through */
 
                         case 'r':
                             if ((ref >= 0) && (Typeof(ref) != TYPE_ROOM))
@@ -1350,6 +1353,7 @@ prim_checkargs(PRIM_PROTOTYPE)
                         case 'T':
                             if (ref < 0)
                                 ABORT_CHECKARGS("Expected thing dbref.");
+                            /* fall through */
 
                         case 't':
                             if ((ref >= 0) && (Typeof(ref) != TYPE_THING))
@@ -1363,6 +1367,7 @@ prim_checkargs(PRIM_PROTOTYPE)
                         case 'E':
                             if (ref < 0)
                                 ABORT_CHECKARGS("Expected exit dbref.");
+                            /* fall through */
 
                         case 'e':
                             if ((ref >= 0) && (Typeof(ref) != TYPE_EXIT))
@@ -1376,6 +1381,7 @@ prim_checkargs(PRIM_PROTOTYPE)
                         case 'F':
                             if (ref < 0)
                                 ABORT_CHECKARGS("Expected program dbref.");
+                            /* fall through */
 
                         case 'f':
                             if ((ref >= 0) && (Typeof(ref) != TYPE_PROGRAM))

--- a/src/player.c
+++ b/src/player.c
@@ -230,6 +230,8 @@ toad_player(int descr, dbref player, dbref victim, dbref recipient)
                         FLAGS(stuff) &= ~(ABODE | WIZARD);
                         SetMLevel(stuff, 1);
                     }
+                    /* fall through */
+
                 case TYPE_ROOM:
                 case TYPE_THING:
                 case TYPE_EXIT:

--- a/src/prochelp.c
+++ b/src/prochelp.c
@@ -414,7 +414,6 @@ print_sections(FILE * f, FILE * hf)
     char sectname[256];
     char *osectptr;
     char *sectptr;
-    char buf[256];
     char buf3[256];
     char buf4[256];
     char *currsect;
@@ -429,7 +428,6 @@ print_sections(FILE * f, FILE * hf)
 
     for (struct topiclist *sptr = secthead; sptr; sptr = sptr->next) {
         currsect = sptr->section;
-        buf[0] = '\0';
 
         strcpyn(sectname, sizeof(sectname), currsect);
         sectptr = strchr(sectname, '|');

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -939,10 +939,6 @@ static int do_resolve(void) {
             sscanf(bufptr, "(%" SCNu16 ")%" SCNu16, &prt, &myprt);
             *bufptr = '\0';
 
-            if (myprt > 65535 || myprt < 0) {
-                continue;
-            }
-
             if (inet_pton(AF_INET6, buf, &fullip_v6) <= 0) {
                 continue;
             }
@@ -962,15 +958,11 @@ static int do_resolve(void) {
             sscanf(buf, "%d.%d.%d.%d(%" SCNu16 ")%" SCNu16, &ip1, &ip2, &ip3,
                    &ip4, &prt, &myprt);
 
-            if (ip1 < 0 || ip2 < 0 || ip3 < 0 || ip4 < 0 || prt < 0) {
+            if (ip1 < 0 || ip2 < 0 || ip3 < 0 || ip4 < 0) {
                 continue;
             }
 
-            if (ip1 > 255 || ip2 > 255 || ip3 > 255 || ip4 > 255 || prt > 65535) {
-                continue;
-            }
-
-            if (myprt > 65535 || myprt < 0) {
+            if (ip1 > 255 || ip2 > 255 || ip3 > 255 || ip4 > 255) {
                 continue;
             }
 

--- a/src/sanity.c
+++ b/src/sanity.c
@@ -1577,7 +1577,8 @@ do_sanfix(dbref player)
         else
             fprintf(stderr, "however the database is still corrupt.\n"
                     "Please re-run sanity check for details and fix it by hand.\n");
-            fprintf(stderr, "For details of repairs made, check %s.\n", tp_file_log_sanfix);
+
+        fprintf(stderr, "For details of repairs made, check %s.\n", tp_file_log_sanfix);
     }
 
     if (sanity_violated) {

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -228,6 +228,7 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
                 notify(player, "You can't make a container contain itself!");
                 break;
             }
+            /* fall through */
         case TYPE_PROGRAM:
             if (Typeof(destination) != TYPE_ROOM
                 && Typeof(destination) != TYPE_PLAYER


### PR DESCRIPTION
- implicit-fallthrough
- type-limits
- switch
- unused-paramater (in fbsignal)
- misleading-indentation
- unused-variable
- unused-but-set-variable
- old-style-declaration