### PR TITLE
Move guest-check inside do_set, and allow general wizards to un-guest.

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -1393,7 +1393,6 @@ process_command(int descr, dbref player, const char *command)
                             case 'e':
                             case 'E':
                                 Matched("@set");
-                                NOGUEST("@set", player);
                                 do_set(descr, player, arg1, arg2);
                                 break;
 

--- a/src/set.c
+++ b/src/set.c
@@ -787,6 +787,13 @@ do_set(int descr, dbref player, const char *name, const char *flag)
         return;
     }
 
+
+    if (ISGUEST(player) &&
+           (!Wizard(player) || *flag != NOT_TOKEN || !string_prefix("GUEST", p))) {
+        notifyf_nolisten(player, "Guests are not allowed to @set.");
+        return;
+    }
+
     /* identify flag */
 
     /*


### PR DESCRIPTION
A little redundant in order have the guest-check near the beginning, but "set" and friends are screaming for a refactor anyway.