### PR TITLE
Unifies basic sanity checks for object creation.

### DIFF
--- a/dbs/minimal/data/minimal.db
+++ b/dbs/minimal/data/minimal.db
@@ -1,7 +1,7 @@
 ***Foxen9 TinyMUCK DUMP Format***
 2
 1
-169
+168
 %7bit_other_names=no
 %7bit_thing_names=yes
 %addpennies_muf_mlev=2
@@ -23,7 +23,6 @@
 %consistent_lock_source=yes
 %cpennies=Pennies
 %cpenny=Penny
-%create_fail_mesg=Either there is already a player with that name, or that name is illegal.
 %dark_sleepers=no
 %dbdump_warning=yes
 default_room_parent=#0

--- a/dbs/starterdb/data/starterdb.db
+++ b/dbs/starterdb/data/starterdb.db
@@ -1,7 +1,7 @@
 ***Foxen9 TinyMUCK DUMP Format***
 119
 1
-169
+168
 %7bit_other_names=no
 %7bit_thing_names=yes
 %addpennies_muf_mlev=2
@@ -23,7 +23,6 @@
 %consistent_lock_source=yes
 %cpennies=Pennies
 %cpenny=Penny
-%create_fail_mesg=Either there is already a player with that name, or that name is illegal.
 %dark_sleepers=no
 %dbdump_warning=yes
 default_room_parent=#109

--- a/include/config.h
+++ b/include/config.h
@@ -130,6 +130,13 @@ typedef int dbref;  /**< Type wrapper for dbref - must support negatives */
  */
 #define BUFFER_LEN ((MAX_COMMAND_LEN)*4)
 
+/**
+ * Maximum buffer length for short strings
+ *
+ * Suitable for command output, error messages, etc.
+ */
+#define SMALL_BUFFER_LEN 100
+
 /************************************************************************
    Various Messages 
  

--- a/include/config.h
+++ b/include/config.h
@@ -135,7 +135,7 @@ typedef int dbref;  /**< Type wrapper for dbref - must support negatives */
  *
  * Suitable for command output, error messages, etc.
  */
-#define SMALL_BUFFER_LEN 100
+#define SMALL_BUFFER_LEN 128
 
 /************************************************************************
    Various Messages 

--- a/include/db.h
+++ b/include/db.h
@@ -1900,7 +1900,8 @@ int controls_link(dbref who, dbref what);
  * With a given owner, name, and source (location).  Returns the DBREF
  * of the exit.  The 'name' memory is copied.
  *
- * Uses an error parameter to communicate the reason for failure.
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
  *
  * @param player the owner dbref
  * @param name the name of the new exit
@@ -1916,7 +1917,8 @@ dbref create_action(dbref player, const char *name, dbref source, char *error);
  * With a given name and owner/creator.  Returns the DBREF of the program. 
  * The 'name' memory is copied.  Initializes the "special" fields.
  *
- * Uses an error parameter to communicate the reason for failure.
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
  *
  * @param player the owner dbref
  * @param name the name of the new program
@@ -1934,7 +1936,8 @@ dbref create_program(dbref player, const char *name, char *error);
  *
  * If the player is JUMP_OK, then the created room will be JUMP_OK as well.
  *
- * Uses an error parameter to communicate the reason for failure.
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
  *
  * @param player the owner dbref
  * @param name the name of the new room
@@ -1954,7 +1957,8 @@ dbref create_room(dbref player, const char *name, dbref parent, char *error);
  * The home is set to the current room if the player controls the room;
  * otherwise the home is set to the player.
  *
- * Uses an error parameter to communicate the reason for failure.
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
  *
  * @param player the owner dbref
  * @param name the name of the new thing
@@ -1967,7 +1971,8 @@ dbref create_thing(dbref player, const char *name, dbref location, char *error);
 /**
  * Clones a thing.
  *
- * Uses an error parameter to communicate the reason for failure.
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
  *
  * @param thing the thing to clone
  * @param player the player for determining the cloned thing's home

--- a/include/db.h
+++ b/include/db.h
@@ -1900,12 +1900,15 @@ int controls_link(dbref who, dbref what);
  * With a given owner, name, and source (location).  Returns the DBREF
  * of the exit.  The 'name' memory is copied.
  *
+ * Uses an error parameter to communicate the reason for failure.
+ *
  * @param player the owner dbref
  * @param name the name of the new exit
  * @param source the location to put the exit
- * @return the dbref of the new exit
+ * @param[out] error why the create failed
+ * @return the dbref of the new exit, or NOTHING if it failed.
  */
-dbref create_action(dbref player, const char *name, dbref source);
+dbref create_action(dbref player, const char *name, dbref source, char *error);
 
 /**
  * Allocate an PROGRAM type object
@@ -1913,11 +1916,14 @@ dbref create_action(dbref player, const char *name, dbref source);
  * With a given name and owner/creator.  Returns the DBREF of the program. 
  * The 'name' memory is copied.  Initializes the "special" fields.
  *
- * @param name the name of the new exit
+ * Uses an error parameter to communicate the reason for failure.
+ *
  * @param player the owner dbref
- * @return the dbref of the new program
+ * @param name the name of the new program
+ * @param[out] error why the create failed
+ * @return the dbref of the new program, or NOTHING if it failed.
  */
-dbref create_program(dbref player, const char *name);
+dbref create_program(dbref player, const char *name, char *error);
 
 /**
  * Allocate an ROOM type object
@@ -1928,12 +1934,15 @@ dbref create_program(dbref player, const char *name);
  *
  * If the player is JUMP_OK, then the created room will be JUMP_OK as well.
  *
+ * Uses an error parameter to communicate the reason for failure.
+ *
  * @param player the owner dbref
  * @param name the name of the new room
  * @param parent the parent room's dbref
- * @return the dbref of the new room
+ * @param[out] error why the create failed
+ * @return the dbref of the new room, or NOTHING if it failed.
  */
-dbref create_room(dbref player, const char *name, dbref parent);
+dbref create_room(dbref player, const char *name, dbref parent, char *error);
 
 /**
  * Allocate an THING type object
@@ -1945,22 +1954,28 @@ dbref create_room(dbref player, const char *name, dbref parent);
  * The home is set to the current room if the player controls the room;
  * otherwise the home is set to the player.
  *
+ * Uses an error parameter to communicate the reason for failure.
+ *
  * @param player the owner dbref
  * @param name the name of the new thing
  * @param location the location to place the object
- * @return the dbref of the new thing
+ * @param[out] error why the create failed
+ * @return the dbref of the new thing, or NOTHING if it failed.
  */
-dbref create_thing(dbref player, const char *name, dbref location);
+dbref create_thing(dbref player, const char *name, dbref location, char *error);
 
 /**
  * Clones a thing.
  *
+ * Uses an error parameter to communicate the reason for failure.
+ *
  * @param thing the thing to clone
  * @param player the player for determining the cloned thing's home
  * @param copy_hidden_props if true, this copies hidden properties
- * @return the dbref of the cloned thing
+ * @param[out] error why the create failed
+ * @return the dbref of the cloned thing, or NOTHING if it failed.
  */
-dbref clone_thing(dbref thing, dbref player, int copy_hidden_props);
+dbref clone_thing(dbref thing, dbref player, int copy_hidden_props, char *error);
 
 /**
  * Clear a DB object

--- a/include/player.h
+++ b/include/player.h
@@ -74,7 +74,8 @@ void clear_players(void);
  * tp_player_start, tp_start_pennies and tp_pcreate_flags influence player
  * creation in what should be obvious ways.
  *
- * Uses an error parameter to communicate the reason for failure.
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
  *
  * @see ok_object_name
  * @see ok_password

--- a/include/player.h
+++ b/include/player.h
@@ -74,13 +74,17 @@ void clear_players(void);
  * tp_player_start, tp_start_pennies and tp_pcreate_flags influence player
  * creation in what should be obvious ways.
  *
+ * Uses an error parameter to communicate the reason for failure.
+ *
  * @see ok_object_name
  * @see ok_password
  *
  * @param name the player name to create
  * @param password the password that will be hashed and set
+ * @param[out] error why the create failed
+ * @return the dbref of the new program, or NOTHING if it failed.
  */
-dbref create_player(const char *name, const char *password);
+dbref create_player(const char *name, const char *password, char *error);
 
 /**
  * Deletes a player from the lookup cache: WARNING poorly named function

--- a/include/tunelist.h
+++ b/include/tunelist.h
@@ -53,7 +53,6 @@ const char *tp_connect_fail_mesg;                   /**> Described below */
 bool        tp_consistent_lock_source;              /**> Described below */
 const char *tp_cpennies;                            /**> Described below */
 const char *tp_cpenny;                              /**> Described below */
-const char *tp_create_fail_mesg;                    /**> Described below */
 bool        tp_dark_sleepers;                       /**> Described below */
 bool        tp_dbdump_warning;                      /**> Described below */
 dbref       tp_default_room_parent;                 /**> Described below */
@@ -474,21 +473,6 @@ struct tune_entry tune_list[] = {
         .currentval.s=&tp_cpenny,
         0,
         MLEV_WIZARD,
-        true
-    },
-    {
-        "create_fail_mesg",
-        "Failed player create message",
-        "Connecting",
-        "",
-        TP_TYPE_STRING,
-        .defaultval.s=
-            "Either there is already a player with that name, or that name " \
-            "is illegal.",
-        .currentval.s=&tp_create_fail_mesg,
-        0,
-        MLEV_WIZARD,
-        true,
         true
     },
     {

--- a/src/db.c
+++ b/src/db.c
@@ -201,7 +201,8 @@ create_object(const char *name, dbref owner, object_flag_type flags)
  * With a given owner, name, and source (location).  Returns the DBREF
  * of the exit.  The 'name' memory is copied.
  *
- * Uses an error parameter to communicate the reason for failure.
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
  *
  * @param player the owner dbref
  * @param name the name of the new exit
@@ -239,7 +240,8 @@ create_action(dbref player, const char *name, dbref source, char *error)
  * With a given name and owner/creator.  Returns the DBREF of the program. 
  * The 'name' memory is copied.  Initializes the "special" fields.
  *
- * Uses an error parameter to communicate the reason for failure.
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
  *
  * @param player the owner dbref
  * @param name the name of the new program
@@ -297,7 +299,8 @@ create_program(dbref player, const char *name, char *error)
  *
  * If the player is JUMP_OK, then the created room will be JUMP_OK as well.
  *
- * Uses an error parameter to communicate the reason for failure.
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
  * 
  * @param player the owner dbref
  * @param name the name of the new room
@@ -337,7 +340,8 @@ create_room(dbref player, const char *name, dbref parent, char *error)
  * The home is set to the current room if the player controls the room;
  * otherwise the home is set to the player.
  *
- * Uses an error parameter to communicate the reason for failure.
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
  * 
  * @param player the owner dbref
  * @param name the name of the new thing
@@ -379,7 +383,8 @@ create_thing(dbref player, const char *name, dbref location, char *error)
 /**
  * Clones a thing.
  *
- * Uses an error parameter to communicate the reason for failure.
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
  * 
  * @param thing the thing to clone
  * @param player the player for determining the cloned thing's home

--- a/src/db.c
+++ b/src/db.c
@@ -201,14 +201,22 @@ create_object(const char *name, dbref owner, object_flag_type flags)
  * With a given owner, name, and source (location).  Returns the DBREF
  * of the exit.  The 'name' memory is copied.
  *
+ * Uses an error parameter to communicate the reason for failure.
+ *
  * @param player the owner dbref
  * @param name the name of the new exit
  * @param source the location to put the exit
- * @return the dbref of the new exit
+ * @param[out] error why the create failed
+ * @return the dbref of the new exit, or NOTHING if it failed.
  */
 dbref
-create_action(dbref player, const char *name, dbref source)
+create_action(dbref player, const char *name, dbref source, char *error)
 {
+    if (!ok_object_name(name, TYPE_EXIT)) {
+        snprintf(error, SMALL_BUFFER_LEN, "You cannot use that name for an exit or action.");
+        return NOTHING;
+    }
+
     dbref newact = create_object(name, player, TYPE_EXIT);
 
     set_source(newact, source);
@@ -231,15 +239,24 @@ create_action(dbref player, const char *name, dbref source)
  * With a given name and owner/creator.  Returns the DBREF of the program. 
  * The 'name' memory is copied.  Initializes the "special" fields.
  *
- * @param name the name of the new program
+ * Uses an error parameter to communicate the reason for failure.
+ *
  * @param player the owner dbref
- * @return the dbref of the new program
+ * @param name the name of the new program
+ * @param[out] error why the create failed
+ * @return the dbref of the new program, or NOTHING if it failed.
  */
 dbref
-create_program(dbref player, const char *name)
+create_program(dbref player, const char *name, char *error)
 {
     char buf[BUFFER_LEN];
     int jj;
+
+    if (!ok_object_name(name, TYPE_PROGRAM)) {
+        snprintf(error, SMALL_BUFFER_LEN, "You cannot use that name for a program.");
+        return NOTHING;
+    }
+
     dbref newprog = create_object(name, player, TYPE_PROGRAM);
 
     snprintf(buf, sizeof(buf), "A scroll containing a spell called %s", name);
@@ -280,14 +297,22 @@ create_program(dbref player, const char *name)
  *
  * If the player is JUMP_OK, then the created room will be JUMP_OK as well.
  *
+ * Uses an error parameter to communicate the reason for failure.
+ * 
  * @param player the owner dbref
  * @param name the name of the new room
  * @param parent the parent room's dbref
- * @return the dbref of the new room
+ * @param[out] error why the create failed
+ * @return the dbref of the new room, or NOTHING if it failed.
  */
 dbref
-create_room(dbref player, const char *name, dbref parent)
+create_room(dbref player, const char *name, dbref parent, char *error)
 {
+    if (!ok_object_name(name, TYPE_ROOM)) {
+        snprintf(error, SMALL_BUFFER_LEN, "You cannot use that name for a room.");
+        return NOTHING;
+    }
+
     dbref newroom = create_object(name, player,
                     TYPE_ROOM | (FLAGS(player) & JUMP_OK));
 
@@ -312,15 +337,24 @@ create_room(dbref player, const char *name, dbref parent)
  * The home is set to the current room if the player controls the room;
  * otherwise the home is set to the player.
  *
+ * Uses an error parameter to communicate the reason for failure.
+ * 
  * @param player the owner dbref
  * @param name the name of the new thing
  * @param location the location to place the object
- * @return the dbref of the new thing
+ * @param[out] error why the create failed
+ * @return the dbref of the new thing, or NOTHING if it failed.
  */
 dbref
-create_thing(dbref player, const char *name, dbref location)
+create_thing(dbref player, const char *name, dbref location, char *error)
 {
     dbref loc;
+
+    if (!ok_object_name(name, TYPE_THING)) {
+        snprintf(error, SMALL_BUFFER_LEN, "You cannot use that name for a thing.");
+        return NOTHING;
+    }
+
     dbref newthing = create_object(name, player, TYPE_THING);
 
     LOCATION(newthing) = location;
@@ -345,15 +379,21 @@ create_thing(dbref player, const char *name, dbref location)
 /**
  * Clones a thing.
  *
+ * Uses an error parameter to communicate the reason for failure.
+ * 
  * @param thing the thing to clone
  * @param player the player for determining the cloned thing's home
  * @param copy_hidden_props if true, this copies hidden properties
- * @return the dbref of the cloned thing
+ * @param[out] error why the create failed
+ * @return the dbref of the cloned thing, or NOTHING if it failed.
  */
 dbref
-clone_thing(dbref thing, dbref player, int copy_hidden_props)
+clone_thing(dbref thing, dbref player, int copy_hidden_props, char *error)
 {
-    dbref new_thing = create_thing(player, NAME(thing), player);
+    dbref new_thing = create_thing(player, NAME(thing), player, error);
+    if (new_thing == NOTHING) {
+        return NOTHING;
+    }
 
     FLAGS(new_thing) = FLAGS(thing);
 

--- a/src/fbstrings.c
+++ b/src/fbstrings.c
@@ -273,7 +273,7 @@ pronoun_substitute(int descr, dbref player, const char *str)
     char c;
     char d;
     char prn[3];
-    char globprop[128];
+    char globprop[SMALL_BUFFER_LEN];
     static char buf[BUFFER_LEN * 2];
     char orig[BUFFER_LEN];
     char sexbuf[BUFFER_LEN];

--- a/src/fbtime.c
+++ b/src/fbtime.c
@@ -317,7 +317,7 @@ timestr_full(long dtime)
 const char *
 timestr_long(long dtime)
 {
-    static char buf[100], value[100];
+    static char buf[SMALL_BUFFER_LEN], value[SMALL_BUFFER_LEN];
     const char *str[7] = { "year", "month", "week", "day", "hour", "minute", "second" };
     int div[7] = { 31556736, 2621376, 604800, 86400, 3600, 60, 1 };
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -1650,8 +1650,9 @@ check_connect(struct descriptor_data *d, const char *msg)
     char user[MAX_COMMAND_LEN];
     char password[MAX_COMMAND_LEN];
     dbref player;
-
     char connect_string[BUFFER_LEN];
+    char error[SMALL_BUFFER_LEN] = "";
+
     snprintf(connect_string, sizeof(connect_string), "%sfrom %s",
 #ifdef USE_SSL
          d->ssl_session ? "securely " : "",
@@ -1755,10 +1756,10 @@ check_connect(struct descriptor_data *d, const char *msg)
                 queue_write(d, "\r\n", 2);
                 d->booted = 1;
             } else {
-                player = create_player(user, password);
+                player = create_player(user, password, error);
 
                 if (player == NOTHING) {
-                    queue_ansi(d, tp_create_fail_mesg);
+                    queue_ansi(d, error);
                     queue_write(d, "\r\n", 2);
                     log_status("FAILED CREATE: '%s', descriptor %d, %s",
                             user, d->descriptor, connect_string);

--- a/src/interface.c
+++ b/src/interface.c
@@ -2567,7 +2567,7 @@ static struct descriptor_data *
 initializesock(int s, int output_s, const char *hostname, int is_ssl, int is_console)
 {
     struct descriptor_data *d;
-    char buf[128], *ptr;
+    char buf[SMALL_BUFFER_LEN], *ptr;
 
     if (!(d = malloc(sizeof(struct descriptor_data))))
         panic("initializesock: Out of memory");
@@ -2593,7 +2593,7 @@ initializesock(int s, int output_s, const char *hostname, int is_ssl, int is_con
     d->input.tail = &d->input.head;
     
 #ifdef IP_FORWARDING
-    if (!(d->forwarded_buffer = malloc(128 * sizeof(char))))
+    if (!(d->forwarded_buffer = malloc(SMALL_BUFFER_LEN * sizeof(char))))
         panic("initializesock: Out of memory");
 #endif
 
@@ -2757,7 +2757,7 @@ make_socket_v6(int port)
 static const char *
 addrout_v6(in_port_t lport, struct in6_addr *a, in_port_t prt)
 {
-    static char buf[128];
+    static char buf[SMALL_BUFFER_LEN];
     char ip6addr[INET6_ADDRSTRLEN];
 
     struct in6_addr addr;
@@ -2837,7 +2837,7 @@ new_connection_v6(in_port_t port, int sock_, int is_ssl)
 
     struct sockaddr_in6 addr;
     socklen_t addr_len;
-    char hostname[128];
+    char hostname[SMALL_BUFFER_LEN];
     size_t hostlen;
 
     addr_len = (socklen_t) sizeof(addr);
@@ -2902,7 +2902,7 @@ new_connection_v6(in_port_t port, int sock_, int is_ssl)
 static const char *
 addrout(in_port_t lport, in_addr_t a, in_port_t prt)
 {
-    static char buf[128];
+    static char buf[SMALL_BUFFER_LEN];
     struct in_addr addr;
 
     memset(&addr, 0, sizeof(addr));
@@ -3073,7 +3073,7 @@ new_connection(in_port_t port, int sock_, int is_ssl)
     int newsock;
     struct sockaddr_in addr;
     socklen_t addr_len;
-    char hostname[128];
+    char hostname[SMALL_BUFFER_LEN];
 
     addr_len = (socklen_t) sizeof(addr);
     newsock = accept(sock_, (struct sockaddr *) &addr, &addr_len);

--- a/src/interp.c
+++ b/src/interp.c
@@ -1517,7 +1517,7 @@ do_abort_loop(dbref player, dbref program, const char *msg,
         panic("localvars_get(): NULL frame passed !");
     }
 
-    char buffer[128];
+    char buffer[SMALL_BUFFER_LEN];
 
     /* If we are in a try/catch, let's copy over some error info */
     if (fr->trys.top) {
@@ -2839,7 +2839,7 @@ do_abort_interp(dbref player, const char *msg, struct inst *pc,
                 struct inst *oper3, struct inst *oper4, int nargs,
                 dbref program, const char *file, int line)
 {
-    char buffer[128];
+    char buffer[SMALL_BUFFER_LEN];
 
     if (fr->trys.top) {
         fr->errorstr = strdup(msg);

--- a/src/mcp.c
+++ b/src/mcp.c
@@ -2134,24 +2134,7 @@ do_mcpprogram(int descr, dbref player, const char *name, const char *rname)
     dbref program;
     struct match_data md;
     char unparse_buf[BUFFER_LEN];
-
-    /* @TODO Should this sanity check be a part of create_program
-     *       instead?  A little scary to think we're creating programs
-     *       in two places (here and @program) but we're relying on
-     *       the sanity checks to be the same -- what if there is
-     *       a change to one and we forget to change the other?
-     *
-     *       We may want to consider moving all similar sanity checks
-     *       to the create_* functions -- a quick look suggests that
-     *       the create_* functions are "gullible" and accept whatever
-     *       is given to them.  This is really hazardous from an API
-     *       perspective.
-     */
-
-    if (!ok_object_name(name, TYPE_PROGRAM)) {
-        notify(player, "Please specify a valid name for this program.");
-        return;
-    }
+    char error[SMALL_BUFFER_LEN] = "";
 
     init_match(descr, player, name, TYPE_PROGRAM, &md);
 
@@ -2161,7 +2144,12 @@ do_mcpprogram(int descr, dbref player, const char *name, const char *rname)
     match_absolute(&md);
 
     if (*rname || (program = match_result(&md)) == NOTHING) {
-        program = create_program(player, name);
+        program = create_program(player, name, error);
+        if (program == NOTHING) {
+          notify_nolisten(player, error, 1);
+          return;
+        }
+
         unparse_object(player, program, unparse_buf, sizeof(unparse_buf));
         notifyf(player, "Program %s created.", unparse_buf);
 

--- a/src/mcp.c
+++ b/src/mcp.c
@@ -245,7 +245,7 @@ mcp_intern_is_quoted(const char **in, char *buf, int buflen)
 static int
 mcp_intern_is_keyval(McpMesg *msg, const char **in)
 {
-    char keyname[128];
+    char keyname[SMALL_BUFFER_LEN];
     char value[BUFFER_LEN];
     const char *old = *in;
     int deferred = 0;
@@ -322,8 +322,8 @@ mcp_intern_is_keyval(McpMesg *msg, const char **in)
 static int
 mcp_intern_is_mesg_start(McpFrame *mfr, const char *in)
 {
-    char mesgname[128];
-    char authkey[128];
+    char mesgname[SMALL_BUFFER_LEN];
+    char authkey[SMALL_BUFFER_LEN];
     char *subname = NULL;
     McpMesg *newmsg = NULL;
     size_t longlen = 0;
@@ -428,8 +428,8 @@ mcp_intern_is_mesg_start(McpFrame *mfr, const char *in)
 static int
 mcp_intern_is_mesg_cont(McpFrame *mfr, const char *in)
 {
-    char datatag[128];
-    char keyname[128];
+    char datatag[SMALL_BUFFER_LEN];
+    char keyname[SMALL_BUFFER_LEN];
     McpMesg *ptr;
 
     if (*in != '*') {
@@ -496,7 +496,7 @@ mcp_intern_is_mesg_cont(McpFrame *mfr, const char *in)
 static int
 mcp_intern_is_mesg_end(McpFrame *mfr, const char *in)
 {
-    char datatag[128];
+    char datatag[SMALL_BUFFER_LEN];
     McpMesg *ptr, **prev;
 
     if (*in != ':') {
@@ -814,7 +814,7 @@ mcp_basic_handler(McpFrame *mfr, McpMesg *mesg)
             mfr->authkey = strdup(auth);
         } else {
             McpMesg reply;
-            char authval[128];
+            char authval[SMALL_BUFFER_LEN];
 
             mcp_mesg_init(&reply, MCP_INIT_PKG, "");
             mcp_mesg_arg_append(&reply, "version", "2.1");
@@ -1452,7 +1452,7 @@ mcp_frame_output_mesg(McpFrame *mfr, McpMesg *msg)
 {
     char outbuf[BUFFER_LEN * 2];
     int bufrem = sizeof(outbuf);
-    char mesgname[128];
+    char mesgname[SMALL_BUFFER_LEN];
     char datatag[32];
     int mlineflag = 0;
     char *p;

--- a/src/p_mcp.c
+++ b/src/p_mcp.c
@@ -305,9 +305,9 @@ muf_mcp_event_callback(McpFrame * mfr, McpMesg * mesg, McpVer version,
         argval.data.array = contarr;
 
         if (msgname && *msgname) {
-            snprintf(buf, sizeof(buf), "MCP.%.128s-%.128s", pkgname, msgname);
+            snprintf(buf, sizeof(buf), "MCP.%.*s-%.*s", SMALL_BUFFER_LEN, pkgname, SMALL_BUFFER_LEN, msgname);
         } else {
-            snprintf(buf, sizeof(buf), "MCP.%.128s", pkgname);
+            snprintf(buf, sizeof(buf), "MCP.%.*s", SMALL_BUFFER_LEN, pkgname);
         }
 
         /* Add the event with all the data */

--- a/src/player.c
+++ b/src/player.c
@@ -151,7 +151,8 @@ set_password(dbref player, const char *password)
  * tp_player_start, tp_start_pennies and tp_pcreate_flags influence player
  * creation in what should be obvious ways.
  *
- * Uses an error parameter to communicate the reason for failure.
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
  *
  * @see ok_object_name
  * @see ok_password

--- a/src/player.c
+++ b/src/player.c
@@ -151,21 +151,31 @@ set_password(dbref player, const char *password)
  * tp_player_start, tp_start_pennies and tp_pcreate_flags influence player
  * creation in what should be obvious ways.
  *
+ * Uses an error parameter to communicate the reason for failure.
+ *
  * @see ok_object_name
  * @see ok_password
  *
  * @param name the player name to create
  * @param password the password that will be hashed and set
+ * @param[out] error why the create failed
+ * @return the dbref of the new program, or NOTHING if it failed.
  */
 dbref
-create_player(const char *name, const char *password)
+create_player(const char *name, const char *password, char *error)
 {
     dbref player;
 
-    if (!ok_object_name(name, TYPE_PLAYER) || !ok_password(password))
+    if (!ok_object_name(name, TYPE_PLAYER)) {
+        snprintf(error, SMALL_BUFFER_LEN, "You cannot use that name for a player.");
         return NOTHING;
+    }
 
-    /* else he doesn't already exist, create him */
+    if (!ok_password(password)) {
+        snprintf(error, SMALL_BUFFER_LEN, "You cannot use that password.");
+        return NOTHING;
+    }
+
     player = new_object(true);
 
     /* initialize everything */

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -84,12 +84,12 @@ int notify(int player, const char *msg) {
  * An entry for the host cache.  This is a double linked list.
  */
 static struct hostcache {
-    struct in6_addr ipnum_v6;   /* IPv6 IP           */
-    long ipnum;                 /* IPv4 IP           */
-    char name[128];             /* Hostname          */
-    time_t time;                /* Time we cached it */
-    struct hostcache *next;     /* Next entry        */
-    struct hostcache **prev;    /* Previous entry    */
+    struct in6_addr ipnum_v6;    /* IPv6 IP           */
+    long ipnum;                  /* IPv4 IP           */
+    char name[SMALL_BUFFER_LEN]; /* Hostname          */
+    time_t time;                 /* Time we cached it */
+    struct hostcache *next;      /* Next entry        */
+    struct hostcache **prev;     /* Previous entry    */
 } *hostcache_list = 0;
 
 /**
@@ -164,7 +164,7 @@ static void make_nonblocking(int s) {
  * @return 0 on a match, non-0 on failure
  */
 static int ipcmp(struct in6_addr *a, struct in6_addr *b) {
-    int i = 128;
+    int i = SMALL_BUFFER_LEN;
     char *A = (char *) a;
     char *B = (char *) b;
 
@@ -436,8 +436,8 @@ static const char * get_username_v6(struct in6_addr *a, in_port_t prt,
  */
 static const char * addrout_v6(struct in6_addr *a, in_port_t prt,
                                in_port_t myprt) {
-    static char buf[135];
-    char tmpbuf[135];
+    static char buf[SMALL_BUFFER_LEN+7];
+    char tmpbuf[SMALL_BUFFER_LEN+7];
     const char *ptr, *ptr2;
     struct hostent *he;
 
@@ -474,7 +474,7 @@ static const char * addrout_v6(struct in6_addr *a, in_port_t prt,
         return buf;
     }
 
-    inet_ntop(AF_INET6, a, tmpbuf, 128);
+    inet_ntop(AF_INET6, a, tmpbuf, SMALL_BUFFER_LEN);
     hostadd_timestamp_v6(a, tmpbuf);
     ptr = get_username_v6(a, prt, myprt);
 
@@ -757,8 +757,8 @@ static const char * get_username(in_addr_t a, in_port_t prt, in_port_t myprt) {
  * @return the host string
  */
 static const char * addrout(in_addr_t a, in_port_t prt, in_port_t myprt) {
-    static char buf[135];
-    char tmpbuf[135];
+    static char buf[SMALL_BUFFER_LEN+7];
+    char tmpbuf[SMALL_BUFFER_LEN+7];
     const char *ptr, *ptr2;
     struct hostent *he;
     struct in_addr addr;

--- a/src/timequeue.c
+++ b/src/timequeue.c
@@ -1142,13 +1142,13 @@ void
 do_process_status(dbref player)
 {
     char buf[BUFFER_LEN];
-    char pidstr[128];
-    char duestr[128];
-    char runstr[128];
-    char inststr[128];
-    char cpustr[128];
-    char progstr[128];
-    char prognamestr[128];
+    char pidstr[SMALL_BUFFER_LEN];
+    char duestr[SMALL_BUFFER_LEN];
+    char runstr[SMALL_BUFFER_LEN];
+    char inststr[SMALL_BUFFER_LEN];
+    char cpustr[SMALL_BUFFER_LEN];
+    char progstr[SMALL_BUFFER_LEN];
+    char prognamestr[SMALL_BUFFER_LEN];
     int count = 0;
     time_t rtime = time((time_t *) NULL);
     time_t etime;

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -991,15 +991,17 @@ void
 do_pcreate(dbref player, const char *user, const char *password)
 {
     dbref newguy;
+    char error[SMALL_BUFFER_LEN] = "";
 
-    newguy = create_player(user, password);
+    newguy = create_player(user, password, error);
 
     if (newguy == NOTHING) {
-        notify(player, "Create failed.");
-    } else {
-        log_status("PCREATED %s(%d) by %s(%d)", NAME(newguy), newguy, NAME(player), player);
-        notifyf(player, "Player %s created as object #%d.", user, newguy);
+        notify_nolisten(player, error, 1);
+        return;
     }
+
+    log_status("PCREATED %s(%d) by %s(%d)", NAME(newguy), newguy, NAME(player), player);
+    notifyf(player, "Player %s created as object #%d.", user, newguy);
 }
 
 #ifndef NO_USAGE_COMMAND


### PR DESCRIPTION
This places name sanity checking closer to the point of object creation, so it can be used in all caller contexts. Player passwords are also checked in this way.

Commands affected are `@action`, `@clone`, `@create`, `@dig`, `@mcpprogram`, `@open`, `@pcreate`, `@program`, and `create` on the login screen.
Primitives affected are `COPYOBJ`, `COPYPLAYER`, `NEWEXIT`, `NEWOBJECT`, `NEWPLAYER`, `NEWPROGRAM`, and `NEWROOM`.

**Techniques**
- Passing error messages with a string pointer. Seems like an old-style idea, so let me know if there's a more preferred way. It could eventually be an error struct...
- SMALL_BUFFER_LEN = ~100~ 128. I didn't want to use another huge chunk of space for this. ~100~ 128 may be flexible enough for now - I was able to use it in several other places where buffers are also used.

**Consequences**
- `create` on the login screen can now be more detailed if the creation fails, and tp_create_fail has been removed.
- Some error messages needed to be combined. do_action and do_open refer to "an exit or action", and do_clone (as it uses create_object) refers to "create" not "clone".

**Bonuses**
- This corrects the *arrow anti-pattern* or minor *pyramid of doom* in do_open. This is far from the only place this correction can be made.
- prim_newroom now uses the nearest ABODE room as a parent (or default), like do_dig does - if the parent argument is NOTHING.

**Future Work/Discussion**
- Charging a number of pennies to create certain objects has historically been a command-only transaction, and it might make sense to keep it this way?
- It's certainly possible to check types (can only parent a room to a room, can only clone things) in this manner, though a theoretical MUF preprocessor could also check types of all primitive arguments. I guess it wouldn't hurt to do both?
