### PR TITLE
TODO cleanup: p_misc (mostly)

### DIFF
--- a/include/interp.h
+++ b/include/interp.h
@@ -359,6 +359,8 @@ struct publics {
  *
  * This will 'return' from whatever function it is in.
  *
+ * @TODO: Do this without relying on static operX variables.
+ *
  * @param C string error message to display
  */
 #define abort_interp(C) \


### PR DESCRIPTION
This cleans up most of the TODOs in p_misc.c.

**Global variables**

Variables for temporary ints, dbrefs, string buffers, and timestamps have been moved into the functions using them. The inst pointers "oper1" through "oper4" are currently ALL needed for the abort_interp macro. A TODO has been placed in interp.h for this.

**Code consolidation**
- Some operand sanity checks were combined when it made sense. Most of these are of the form "must be a valid object" and "must be a certain object type". 
- The DoNullInd() macro was used one place it was suggested, but the other could not be (due to its argument needing to be a certain type).
- `EXT-NAME-OK?` now uses strcasecmp() instead of lowercasing the type string beforehand. I'm not sure of the performance impact , as the possible "good" strings are limited.

**`STATS` and `STATS_ARRAY`**

These primitives now allow mlev < 3 to view their own statistics.

The core of these primitives has been rewritten.

**Still TODO**
- `CONVTIME` and `FMTTIME` need to be available on Windows. The suggestion in the code is to use timelib.
- `SMTP_SEND` has a comment to separate the email creation into a separate function.

_Suggestions welcome._
 