### PR TITLE
Unifies setting and clearing lock properties.

### DIFF
--- a/include/db.h
+++ b/include/db.h
@@ -303,25 +303,27 @@ extern char match_cmdname[BUFFER_LEN];
  * A thin wrappera round @see get_property_lock
  *
  * @param x the object to look up
+ * @param y the lock to look up
  * @return the struct boolexp object or TRUE_BOOLEXP
  */
-#define GETLOCK(x)      (get_property_lock(x, MESGPROP_LOCK))
+#define GETLOCK(x,y)      (get_property_lock(x, y))
 
 /**
  * Sets a lock from a boolexp structure
  *
  * Typically you would take the return value from @see parse_boolexp
- * and then use it as the 'y' parameter here.  The object modification
+ * and then use it as the 'z' parameter here.  The object modification
  * timestamp is updated.
  *
  * @param x the object to set the lock on
- * @param y the struct boolexp to use as the lock value.
+ * @param y the lock to modify
+ * @param z the struct boolexp to use as the lock value.
  */
-#define SETLOCK(x,y)    { \
+#define SETLOCK(x,y,z)    { \
     PData mydat; \
     mydat.flags = PROP_LOKTYP; \
-    mydat.data.lok = y; \
-    set_property(x, MESGPROP_LOCK, &mydat); \
+    mydat.data.lok = z; \
+    set_property(x, y, &mydat); \
     ts_modifyobject(x); \
 }
 
@@ -331,14 +333,12 @@ extern char match_cmdname[BUFFER_LEN];
  * Also updates object modification timestamp.
  *
  * @param x the object to clear the lock on
+ * @param y the lock to clear
  */
-#define CLEARLOCK(x)    { \
-    PData mydat; \
-    mydat.flags = PROP_LOKTYP; \
-    mydat.data.lok = TRUE_BOOLEXP; \
-    set_property(x, MESGPROP_LOCK, &mydat); \
-    DBDIRTY(x); \
+#define CLEARLOCK(x,y)    { \
+    remove_property(x, y); \
     ts_modifyobject(x); \
+    DBDIRTY(x); \
 }
 
 /**

--- a/include/props.h
+++ b/include/props.h
@@ -1113,6 +1113,25 @@ void remove_property_list(dbref player, int all);
 void remove_property_nofetch(dbref player, const char *type);
 
 /**
+ * This helper function 'compiles' the lock and, if valid, sets the
+ * property on the propname.  Otherwise, an error is emitted to the user.
+ *
+ * The last parameter controls if messages should be displayed.
+ *
+ * @param descr The player's descriptor
+ * @param player The player receiving any messages
+ * @param object The object we are locking or unlocking
+ * @param propname The name of the prop to set
+ * @param proplabel This is used for messaging and is the type of lock.
+ *        The first letter should be capitalized.  For instance, "Lock",
+ *        "Ownership Lock", etc.
+ * @param keyvalue The lock itself or "" to clear the lock.
+ * @param silent boolean if true, do not display anything.
+ */
+int _set_lock(int descr, dbref player, dbref object, const char *propname,
+              const char *proplabel, const char *keyvalue, int silent);
+
+/**
  * This command is the underpinning of \@lock, \@flock, \@linklock and \@chlock.
  * Please note that part of this function's functionality relies on the
  * global 'match_args', so this is not really an API call.  This is
@@ -1128,10 +1147,9 @@ void remove_property_nofetch(dbref player, const char *type);
  * If there is an = but no string after the equals (i.e. '\@lock x='),
  * then it clears the lock
  *
- * Otherwise, the lock is 'compiled' and, if valid, set on the property
- * propname.  Otherwise, an error is emitted to the user.
+ * Otherwise, this hands off the actual lock-setting to _set_lock.
  *
- * @param descr Descriptor
+ * @param descr The player's descriptor
  * @param player The player doing the command
  * @param objname The name of the object we are locking or ""
  * @param propname The name of the prop to set

--- a/src/boolexp.c
+++ b/src/boolexp.c
@@ -881,7 +881,7 @@ test_lock(int descr, dbref player, dbref thing, const char *lockprop)
 {
     struct boolexp *lokptr;
 
-    lokptr = get_property_lock(thing, lockprop);
+    lokptr = GETLOCK(thing, lockprop);
     return (eval_boolexp(descr, player, lokptr, thing));
 }
 
@@ -907,7 +907,7 @@ test_lock_false_default(int descr, dbref player, dbref thing, const char *lockpr
 {
     struct boolexp *lok;
 
-    lok = get_property_lock(thing, lockprop);
+    lok = GETLOCK(thing, lockprop);
 
     if (lok == TRUE_BOOLEXP)
         return 0;

--- a/src/look.c
+++ b/src/look.c
@@ -763,25 +763,25 @@ do_examine(int descr, dbref player, const char *name, const char *dir)
     if (GETDESC(thing))
         notify(player, GETDESC(thing));
 
-    if (strcmp(temp = unparse_boolexp(player, GETLOCK(thing), 1), PROP_UNLOCKED_VAL))
+    if (strcmp(temp = unparse_boolexp(player, GETLOCK(thing, MESGPROP_LOCK), 1), PROP_UNLOCKED_VAL))
         notifyf(player, "Key: %s", temp);
 
-    if (strcmp(temp = unparse_boolexp(player, get_property_lock(thing, MESGPROP_LINKLOCK), 1), PROP_UNLOCKED_VAL))
+    if (strcmp(temp = unparse_boolexp(player, GETLOCK(thing, MESGPROP_LINKLOCK), 1), PROP_UNLOCKED_VAL))
         notifyf(player, "Link_OK Key: %s", temp);
 
-    if (strcmp(temp = unparse_boolexp(player, get_property_lock(thing, MESGPROP_CHLOCK), 1), PROP_UNLOCKED_VAL))
+    if (strcmp(temp = unparse_boolexp(player, GETLOCK(thing, MESGPROP_CHLOCK), 1), PROP_UNLOCKED_VAL))
         notifyf(player, "Chown_OK Key: %s", temp);
 
-    if (strcmp(temp = unparse_boolexp(player, get_property_lock(thing, MESGPROP_CONLOCK), 1), PROP_UNLOCKED_VAL))
+    if (strcmp(temp = unparse_boolexp(player, GETLOCK(thing, MESGPROP_CONLOCK), 1), PROP_UNLOCKED_VAL))
         notifyf(player, "Container Key: %s", temp);
 
-    if (strcmp(temp = unparse_boolexp(player, get_property_lock(thing, MESGPROP_FLOCK), 1), PROP_UNLOCKED_VAL))
+    if (strcmp(temp = unparse_boolexp(player, GETLOCK(thing, MESGPROP_FLOCK), 1), PROP_UNLOCKED_VAL))
         notifyf(player, "Force Key: %s", temp);
 
-    if (strcmp(temp = unparse_boolexp(player, get_property_lock(thing, MESGPROP_READLOCK), 1), PROP_UNLOCKED_VAL))
+    if (strcmp(temp = unparse_boolexp(player, GETLOCK(thing, MESGPROP_READLOCK), 1), PROP_UNLOCKED_VAL))
         notifyf(player, "Read Key: %s", temp);
 
-    if (strcmp(temp = unparse_boolexp(player, get_property_lock(thing, MESGPROP_OWNLOCK), 1), PROP_UNLOCKED_VAL))
+    if (strcmp(temp = unparse_boolexp(player, GETLOCK(thing, MESGPROP_OWNLOCK), 1), PROP_UNLOCKED_VAL))
         notifyf(player, "Ownership Key: %s", temp);
 
     if (GETSUCC(thing)) {

--- a/src/mfuns2.c
+++ b/src/mfuns2.c
@@ -324,7 +324,7 @@ mfn_testlock(MFUNARGS)
             ABORT_MPI("TESTLOCK", "Permission denied. (arg2)");
     }
 
-    lok = get_property_lock(obj, argv[1]);
+    lok = GETLOCK(obj, argv[1]);
 
     if (argc > 3 && lok == TRUE_BOOLEXP)
         return (argv[3]);

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -2417,48 +2417,13 @@ prim_recycle(PRIM_PROTOTYPE)
 }
 
 /**
- * Sets a lock (with the given key) on an object.
- *
- * Returns 0 if the key is not well-formed, otherwise 1.
- *
- * @private
- * @param descr the player's descriptor
- * @param player the player requesting the change
- * @param thing dbref of the target object
- * @param keyname string that represents the pass condition
- */
-static int
-setlockstr(int descr, dbref player, dbref thing, const char *keyname)
-{
-    /**
-     * @TODO Should this logic be exposed to the various lock
-     *       commands?
-     */
-    struct boolexp *key;
-
-    if (*keyname != '\0') {
-        key = parse_boolexp(descr, player, keyname, 0);
-        if (key == TRUE_BOOLEXP) {
-            return 0;
-        } else {
-            /* everything ok, do it */
-            SETLOCK(thing, key);
-            return 1;
-        }
-    } else {
-        CLEARLOCK(thing);
-        return 1;
-    }
-}
-
-/**
  * Implementation of MUF SETLOCKSTR
  *
  * Consumes a dbref and a string, sets the lock accordingly, and returns
  * a boolean representing success or failure.  Needs MUCKER level 4 to
  * bypass basic ownership checks.
  *
- * @see setlockstr
+ * @see _set_lock
  *
  * @param player the player running the MUF program
  * @param program the program being run
@@ -2485,7 +2450,7 @@ prim_setlockstr(PRIM_PROTOTYPE)
     if ((mlev < 4) && !permissions(ProgUID, ref))
         abort_interp("Permission denied.");
 
-    result = setlockstr(fr->descr, player, ref, DoNullInd(oper1->data.string));
+    result = _set_lock(fr->descr, player, ref, MESGPROP_LOCK, "Lock", DoNullInd(oper1->data.string), 1);
 
     CLEAR(oper1);
     CLEAR(oper2);
@@ -2526,7 +2491,7 @@ prim_getlockstr(PRIM_PROTOTYPE)
         abort_interp("Permission denied.");
 
     {
-        const char *tmpstr = (char *) unparse_boolexp(player, GETLOCK(ref), 0);
+        const char *tmpstr = (char *) unparse_boolexp(player, GETLOCK(ref, MESGPROP_LOCK), 0);
 
         CLEAR(oper1);
         PushString(tmpstr);

--- a/src/predicates.c
+++ b/src/predicates.c
@@ -154,7 +154,7 @@ could_doit(int descr, dbref player, dbref thing)
         dest = *(DBFETCH(thing)->sp.exit.dest);
 
         if (dest == NIL)
-            return (eval_boolexp(descr, player, GETLOCK(thing), thing));
+            return (eval_boolexp(descr, player, GETLOCK(thing, MESGPROP_LOCK), thing));
 
         if (Typeof(dest) == TYPE_PLAYER) {
             /* Check for additional restrictions related to player dests */
@@ -208,7 +208,7 @@ could_doit(int descr, dbref player, dbref thing)
     }
 
     /* Check the @lock on the thing, as a final test. */
-    return (eval_boolexp(descr, player, GETLOCK(thing), thing));
+    return (eval_boolexp(descr, player, GETLOCK(thing, MESGPROP_LOCK), thing));
 }
 
 /**

--- a/src/set.c
+++ b/src/set.c
@@ -1376,7 +1376,7 @@ do_unlock(int descr, dbref player, const char *name)
     dbref object;
 
     if ((object = match_controlled(descr, player, name)) != NOTHING) {
-        CLEARLOCK(object);
+        CLEARLOCK(object, MESGPROP_LOCK);
         notifyf_nolisten(player, "Unlocked.");
     }
 }


### PR DESCRIPTION
This attempts to combine the locking implementations used in the codebase.

**Reunification**

Most of the lock commands (e.g., `@lock`, `@ownlock`) use set_standard_lock for their implementation. `@unlock` and `SETPROPSTR` did not; this is now corrected.

**CLEARLOCK, GETLOCK, and SETLOCK**

These macros were used for the main object lock only; they are now extended to act on any type of lock.

CLEARLOCK now removes the property (instead of setting it to TRUE_BOOLEXP) as other mechanisms do. It also continues to update an object's modification time.

GETLOCK can now be used in all cases that get_property_lock was called directly. Is it redundant? Probably - but then so are  lot of other GET* macros.

SETLOCK is now used in the refactored \_set\_lock (discussed below). It also continues to update an object's modification time.

**\_set\_lock**

This helper function is now called by set_standard_lock and prim_setlockstr, with a "silent" argument to determine if messages are displayed to the user. Lock parsing errors continue to be displayed no matter what. I was hoping to use a smaller method signature, but them's the breaks.

**Thoughts**

I wonder if we should introduce `SETCHLOCK`, `SETCONLOCK`, `SETFLOCK`, `SETLINKLOCK`, `SETOWNLOCK`, and `SETREADLOCK` - since the standard messages have their own "set" aliases.

_Suggestions welcome._

