### PR TITLE
More cleanup and flag setting refactor - part 1.

### DIFF
--- a/include/db.h
+++ b/include/db.h
@@ -2328,9 +2328,8 @@ dbref remove_first(dbref first, dbref what);
  * Determines if a given player is unable to (re)set the given flag
  *
  * The 'business logic' here is actually fairly dense and not easily
- * summed up in a comment.  As this is a 'private' function, the
- * reader is encouraged to review the very well documented code for
- * details.
+ * summed up in a comment. The reader is encouraged to review the very
+ * well documented code for details.
  *
  * This is all pretty well documented in the MUCK's help files.
  *

--- a/include/db.h
+++ b/include/db.h
@@ -2325,6 +2325,30 @@ void register_object(dbref player, dbref location, const char *propdir, char *na
 dbref remove_first(dbref first, dbref what);
 
 /**
+ * Determines if a given player is unable to (re)set the given flag
+ *
+ * The 'business logic' here is actually fairly dense and not easily
+ * summed up in a comment.  As this is a 'private' function, the
+ * reader is encouraged to review the very well documented code for
+ * details.
+ *
+ * This is all pretty well documented in the MUCK's help files.
+ *
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
+ *
+ * @private
+ * @param player the effective aplayer we are checking permissions for
+ * @param mlev the effective mucker level we are checking permissions for
+ * @param thing the thing we want to interact with
+ * @param flag the flag we wish to interact with
+ * @param value whether the desired state is on or off
+ * @param error[out] error message, if any
+ * @return boolean 1 if restricted from setting flag, 0 if okay to set.
+ */
+int unable_to_set_flag(dbref player, int mlev, dbref thing, object_flag_type flag, bool value, char *error);
+
+/**
  * This reverses a dbref linked list
  *
  * Basically it changes all the links around so that what was last will

--- a/src/db.c
+++ b/src/db.c
@@ -2390,7 +2390,7 @@ str_to_flag(const char *flag_string)
     } else if (string_prefix("nucker", flag_string)) {
         return SMUCKER;
     } else if (string_prefix("overt", flag_string)) {
-        return (int)OVERT;
+        return OVERT;
     } else if (string_prefix("quell", flag_string)) {
         return QUELL;
     } else if (string_prefix("sticky", flag_string)

--- a/src/fbtime.c
+++ b/src/fbtime.c
@@ -343,7 +343,7 @@ timestr_long(long dtime)
  *
  * @param string the string to convert
  * @param format the string's format
- * @parm[out] error the error message, if any
+ * @param[out] error the error message, if any
  * @return the time in seconds
  */
 #ifndef WIN32

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -37,34 +37,12 @@
 #include "events.h"
 
 /**
- * TODO: These globals really probably shouldn't be globals.  I can only guess
- *       this is either some kind of primitive code re-use because all the
- *       functions use them, or it's some kind of an optimization to avoid
- *       local variables.  But it kills the thread safety and (IMO) makes the
- *       code harder to read/follow.
- */
-
-/**
  * @private
  * @var used to store the parameters passed into the primitives
  *      This seems to be used for conveinance, but makes this probably
- *      not threadsafe.
+ *      not threadsafe. Currently used in the abort_interp macro.
  */
 static struct inst *oper1, *oper2, *oper3, *oper4;
-
-/**
- * @private
- * @var to store the result which is not a local variable for some reason
- *      This makes things very not threadsafe.
- */
-static int tmp, result;
-static dbref ref;
-
-/**
- * @private
- * @var This breaks thread safety for fun.
- */
-static char buf[BUFFER_LEN];
 
 /**
  * Implementation of MUF ADDPENNIES
@@ -73,7 +51,7 @@ static char buf[BUFFER_LEN];
  * thing dbref.  Requires MUCKER level tp_addpennies_muf_mlev for players
  * and 4 for things.
  *
- * Needs MUCKER level 4 to bypass range checks for players.
+ * Needs MUCKER level 4 to have a player's penny total exceed tp_max_pennies.
  *
  * @param player the player running the MUF program
  * @param program the program being run
@@ -86,73 +64,56 @@ static char buf[BUFFER_LEN];
 void
 prim_addpennies(PRIM_PROTOTYPE)
 {
+    int result;
+    dbref ref;
+
     CHECKOP(2);
     oper1 = POP();
     oper2 = POP();
 
-    if (mlev < tp_addpennies_muf_mlev)
+    if (mlev < tp_addpennies_muf_mlev) {
         abort_interp("Permission Denied (mlev < tp_addpennies_muf_mlev)");
-
-    if (!valid_object(oper2))
-        abort_interp("Invalid object.");
-
-    if (oper1->type != PROG_INTEGER)
-        abort_interp("Non-integer argument (2)");
-
-    ref = oper2->data.objref;
-    if (Typeof(ref) == TYPE_PLAYER) {
-        result = GETVALUE(ref);
-
-        /**
-         * @TODO It makes sense that Wizard programs can bypass the limit for
-         *       pennies.  However, the negative checks may need to apply to
-         *       all programs.
-         */
-        if (mlev < 4) {
-            /* @TODO Not the right place for this, but we need more of this
-             *       "valid transaction" check happening for both giving
-             *       pennies and paying for commands.
-             */
-            if (oper1->data.number > 0) {
-                if (result > (result + oper1->data.number))
-                    abort_interp("Would roll over player's score.");
-
-                if ((result + oper1->data.number) > tp_max_pennies)
-                    abort_interp("Would exceed MAX_PENNIES.");
-            } else {
-                if (result < (result + oper1->data.number))
-                    abort_interp("Would roll over player's score.");
-
-                if ((result + oper1->data.number) < 0)
-                    abort_interp("Result would be negative.");
-            }
-        }
-
-        /**
-         * @TODO This line seems ineffective.
-         */
-        result += oper1->data.number;
-
-        SETVALUE(ref, GETVALUE(ref) + oper1->data.number);
-
-        /**
-         * @TODO Move this DBDIRTY and the next outside the if.
-         */
-        DBDIRTY(ref);
-    } else if (Typeof(ref) == TYPE_THING) {
-        if (mlev < 4)
-            abort_interp("Permission denied.");
-
-        SETVALUE(ref, (GETVALUE(ref) + oper1->data.number));
-
-        DBDIRTY(ref);
-    } else {
-        abort_interp("Invalid object type.");
     }
 
-    /**
-     * @TODO Move the previous two abort checks to the top with the others.
-     */
+    if (!valid_object(oper2) || (Typeof(oper2->data.objref) != TYPE_PLAYER && Typeof(oper2->data.objref) != TYPE_THING)) {
+        abort_interp("Invalid player or thing argument.");
+    }
+
+    if (oper1->type != PROG_INTEGER) {
+        abort_interp("Non-integer argument (2)");
+    }
+
+    ref = oper2->data.objref;
+
+    if (mlev < 4 && Typeof(ref) == TYPE_THING) {
+        abort_interp("Permission denied.");
+    }
+
+    result = GETVALUE(ref);
+
+    if (mlev < 4) {
+        if (oper1->data.number > 0) {
+            if (result > (result + oper1->data.number)) {
+                abort_interp("Would roll over player's score.");
+            }
+
+            if ((result + oper1->data.number) > tp_max_pennies) {
+                abort_interp("Would exceed MAX_PENNIES.");
+            }
+        } else {
+            if (result < (result + oper1->data.number)) {
+                abort_interp("Would roll over player's score.");
+            }
+
+            if ((result + oper1->data.number) < 0) {
+                abort_interp("Result would be negative.");
+            }
+        }
+    }
+
+    SETVALUE(ref, (GETVALUE(ref) + oper1->data.number));
+    DBDIRTY(ref);
+
     CLEAR(oper1);
     CLEAR(oper2);
 }
@@ -215,165 +176,177 @@ prim_addpennies(PRIM_PROTOTYPE)
 void
 prim_moveto(PRIM_PROTOTYPE)
 {
-    struct inst *oper1 = NULL, *oper2 = NULL, *oper3 = NULL, *oper4 = NULL;
+    struct inst *oper1 = NULL;  /* prevents re-entrancy issues! */
+    struct inst *oper2 = NULL;  /* prevents re-entrancy issues! */
+
+    /**
+     * @TODO Combine with other movement logic as possible.
+     */
 
     CHECKOP(2);
     oper1 = POP();
     oper2 = POP();
 
-    if (fr->level > tp_max_interp_recursion)
+    if (fr->level > tp_max_interp_recursion) {
         abort_interp("Interp call loops not allowed.");
+    }
 
     /* Needs to be an object, and object needs to be valid */
-    if (!(oper2->type == PROG_OBJECT && valid_object(oper2)))
+    if (!valid_object(oper2)) {
         abort_interp("Non-object argument. (2)");
+    }
 
     /* Needs to be an object, and object needs to be valid or HOME */
-    if (!(oper1->type == PROG_OBJECT && (valid_object(oper1)
-            || is_home(oper1))))
+    if (!valid_object(oper1) && !is_home(oper1)) {
         abort_interp("Non-object argument. (1)");
+    }
 
-    {
-        dbref victim, dest;
+    dbref victim, dest;
 
-        victim = oper2->data.objref;
-        dest = oper1->data.objref;
+    victim = oper2->data.objref;
+    dest = oper1->data.objref;
 
-        if (Typeof(dest) == TYPE_EXIT)
-            abort_interp("Destination argument is an exit.");
+    if (Typeof(dest) == TYPE_EXIT) {
+        abort_interp("Destination argument is an exit.");
+    }
 
-        if (Typeof(victim) == TYPE_EXIT && (mlev < 3))
-            abort_interp("Permission denied.");
+    if (Typeof(victim) == TYPE_EXIT && (mlev < 3)) {
+        abort_interp("Permission denied.");
+    }
 
-        if (!(FLAGS(victim) & JUMP_OK)
-            && !permissions(ProgUID, victim) && (mlev < 3))
-            abort_interp("Object can't be moved.");
+    if (!(FLAGS(victim) & JUMP_OK) && !permissions(ProgUID, victim) && (mlev < 3)) {
+        abort_interp("Object can't be moved.");
+    }
 
-        switch (Typeof(victim)) {
-            case TYPE_PLAYER:
-                if (Typeof(dest) != TYPE_ROOM
-                        && !(Typeof(dest) == TYPE_THING
-                        && (FLAGS(dest) & VEHICLE)))
-                    abort_interp("Bad destination.");
-                /* fall through */
+    switch (Typeof(victim)) {
+        case TYPE_PLAYER:
+            if (Typeof(dest) != TYPE_ROOM
+                    && !(Typeof(dest) == TYPE_THING && (FLAGS(dest) & VEHICLE))) {
+                abort_interp("Bad destination.");
+            }
+            /* fall through */
 
-            case TYPE_THING:
-                if (parent_loop_check(victim, dest))
-                    abort_interp("Things can't contain themselves.");
+        case TYPE_THING:
+            if (parent_loop_check(victim, dest)) {
+                abort_interp("Things can't contain themselves.");
+            }
 
-                if ((mlev < 3)) {
-                    if (!(FLAGS(LOCATION(victim)) & JUMP_OK)
-                            && !permissions(ProgUID, LOCATION(victim)))
-                        abort_interp("Source not JUMP_OK.");
-
-                    if (!is_home(oper1) && !(FLAGS(dest) & JUMP_OK)
-                            && !permissions(ProgUID, dest))
-                        abort_interp("Destination not JUMP_OK.");
-
-                    if (Typeof(dest) == TYPE_THING
-                            && LOCATION(victim) != LOCATION(dest))
-                        abort_interp("Not in same location as vehicle.");
-
-                    if (ISGUEST(victim) && (FLAGS(dest) & GUEST)
-                            && Typeof(dest) == TYPE_ROOM)
-                        abort_interp("Destination doesn't accept guests.");
+            if ((mlev < 3)) {
+                if (!(FLAGS(LOCATION(victim)) & JUMP_OK) && !permissions(ProgUID, LOCATION(victim))) {
+                    abort_interp("Source not JUMP_OK.");
                 }
 
-                if (Typeof(victim) == TYPE_PLAYER) {
-                    enter_room(fr->descr, victim, dest, program);
-                    break;
+                if (!is_home(oper1) && !(FLAGS(dest) & JUMP_OK) && !permissions(ProgUID, dest)) {
+                    abort_interp("Destination not JUMP_OK.");
                 }
 
-                /**
-                 * @TODO These two checks, should they only be for things?
-                 */
-                if (mlev < 3 && (FLAGS(victim) & VEHICLE) &&
-                        (FLAGS(dest) & VEHICLE) && Typeof(dest) != TYPE_THING)
-                    abort_interp("Destination doesn't accept vehicles.");
-
-                if (mlev < 3 && (FLAGS(victim) & ZOMBIE) &&
-                        (FLAGS(dest) & ZOMBIE) && Typeof(dest) != TYPE_THING)
-                    abort_interp("Destination doesn't accept zombies.");
-
-                ts_lastuseobject(victim);
-                /* fall through */
-
-            case TYPE_PROGRAM: {
-                dbref matchroom = NOTHING;
-
-                if (Typeof(dest) != TYPE_ROOM && Typeof(dest) != TYPE_PLAYER
-                        && Typeof(dest) != TYPE_THING)
-                    abort_interp("Bad destination.");
-
-                if ((mlev < 3)) {
-                    if (permissions(ProgUID, dest))
-                        matchroom = dest;
-
-                    if (permissions(ProgUID, LOCATION(victim)))
-                        matchroom = LOCATION(victim);
-
-                    if (matchroom != NOTHING && !(FLAGS(matchroom) & JUMP_OK)
-                                && !permissions(ProgUID, victim))
-                        abort_interp("Permission denied.");
+                if (Typeof(dest) == TYPE_THING && LOCATION(victim) != LOCATION(dest)) {
+                    abort_interp("Not in same location as vehicle.");
                 }
 
-                if (Typeof(victim) == TYPE_THING
-                        && (tp_secure_thing_movement
-                        || (FLAGS(victim) & ZOMBIE))) {
-                    enter_room(fr->descr, victim, dest, program);
-                } else {
-                    moveto(victim, dest);
+                if (ISGUEST(victim) && (FLAGS(dest) & GUEST) && Typeof(dest) == TYPE_ROOM) {
+                    abort_interp("Destination doesn't accept guests.");
                 }
+            }
+
+            if (Typeof(victim) == TYPE_PLAYER) {
+                enter_room(fr->descr, victim, dest, program);
                 break;
             }
 
-            case TYPE_EXIT:
-                if ((mlev < 3) && (!permissions(ProgUID, victim)
-                        || !permissions(ProgUID, dest)))
-                    abort_interp("Permission denied.");
+            if (mlev < 3 && (FLAGS(victim) & VEHICLE) &&
+                    (FLAGS(dest) & VEHICLE) && Typeof(dest) != TYPE_THING) {
+                abort_interp("Destination doesn't accept vehicles.");
+            }
 
-                if ((Typeof(dest) != TYPE_ROOM && Typeof(dest) != TYPE_THING
-                        && Typeof(dest) != TYPE_PLAYER) || dest == HOME)
-                    abort_interp("Bad destination object.");
+            if (mlev < 3 && (FLAGS(victim) & ZOMBIE) &&
+                    (FLAGS(dest) & ZOMBIE) && Typeof(dest) != TYPE_THING) {
+                abort_interp("Destination doesn't accept zombies.");
+            }
 
-                unset_source(victim);
-                set_source(victim, dest);
-                SetMLevel(victim, 0);
-                break;
+            ts_lastuseobject(victim);
+            /* fall through */
 
-            case TYPE_ROOM:
-                if (!tp_secure_thing_movement && Typeof(dest) != TYPE_ROOM)
-                    abort_interp("Bad destination.");
+        case TYPE_PROGRAM: {
+            dbref matchroom = NOTHING;
 
-                if (victim == GLOBAL_ENVIRONMENT)
-                    abort_interp("Permission denied.");
+            if (Typeof(dest) != TYPE_ROOM && Typeof(dest) != TYPE_PLAYER && Typeof(dest) != TYPE_THING) {
+                abort_interp("Bad destination.");
+            }
 
-                if (dest == HOME) {
-                    /* Allow the owner of the room or the owner of
-                       the room's location to reparent the room to
-                       #0 */
-                    if ((mlev < 3) && (!permissions(ProgUID, victim)
-                            && !permissions(ProgUID, LOCATION(victim))))
-                        abort_interp("Permission denied.");
-
-                    dest = GLOBAL_ENVIRONMENT;
-                } else {
-                    if ((mlev < 3) && (!permissions(ProgUID, victim)
-                            || !can_teleport_to(ProgUID, dest)))
-                        abort_interp("Permission denied.");
-
-                    if (parent_loop_check(victim, dest)) {
-                        abort_interp("Parent room would create a loop.");
-                    }
+            if ((mlev < 3)) {
+                if (permissions(ProgUID, dest)) {
+                    matchroom = dest;
                 }
 
-                ts_lastuseobject(victim);
-                moveto(victim, dest);
-                break;
+                if (permissions(ProgUID, LOCATION(victim))) {
+                    matchroom = LOCATION(victim);
+                }
 
-            default:
-                abort_interp("Invalid object type (1)");
+                if (matchroom != NOTHING && !(FLAGS(matchroom) & JUMP_OK)
+                            && !permissions(ProgUID, victim)) {
+                    abort_interp("Permission denied.");
+                }
+            }
+
+            if (Typeof(victim) == TYPE_THING
+                    && (tp_secure_thing_movement
+                    || (FLAGS(victim) & ZOMBIE))) {
+                enter_room(fr->descr, victim, dest, program);
+            } else {
+                moveto(victim, dest);
+            }
+            break;
         }
+
+        case TYPE_EXIT:
+            if ((mlev < 3) && (!permissions(ProgUID, victim) || !permissions(ProgUID, dest))) {
+                abort_interp("Permission denied.");
+            }
+
+            if ((Typeof(dest) != TYPE_ROOM && Typeof(dest) != TYPE_THING
+                    && Typeof(dest) != TYPE_PLAYER) || dest == HOME) {
+                abort_interp("Bad destination object.");
+            }
+
+            unset_source(victim);
+            set_source(victim, dest);
+            SetMLevel(victim, 0);
+            break;
+
+        case TYPE_ROOM:
+            if (!tp_secure_thing_movement && Typeof(dest) != TYPE_ROOM) {
+                abort_interp("Bad destination.");
+            }
+
+            if (victim == GLOBAL_ENVIRONMENT) {
+                abort_interp("Permission denied.");
+            }
+
+            if (dest == HOME) {
+                /* Allow the owner of the room or the owner of
+                    the room's location to reparent the room to
+                    #0 */
+                if ((mlev < 3) && (!permissions(ProgUID, victim)
+                        && !permissions(ProgUID, LOCATION(victim)))) {
+                    abort_interp("Permission denied.");
+                }
+
+                dest = GLOBAL_ENVIRONMENT;
+            } else {
+                if ((mlev < 3) && (!permissions(ProgUID, victim)
+                        || !can_teleport_to(ProgUID, dest))) {
+                    abort_interp("Permission denied.");
+                }
+
+                if (parent_loop_check(victim, dest)) {
+                    abort_interp("Parent room would create a loop.");
+                }
+            }
+
+            ts_lastuseobject(victim);
+            moveto(victim, dest);
+            break;
     }
 
     CLEAR(oper1);
@@ -398,32 +371,22 @@ prim_moveto(PRIM_PROTOTYPE)
 void
 prim_pennies(PRIM_PROTOTYPE)
 {
+    int result;
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
-        abort_interp("Invalid argument.");
-
-    if (mlev < tp_pennies_muf_mlev)
+    if (mlev < tp_pennies_muf_mlev) {
         abort_interp("Permission Denied (mlev < tp_pennies_muf_mlev)");
+    }
+
+    if (!valid_object(oper1) || (Typeof(oper1->data.objref) != TYPE_PLAYER && Typeof(oper1->data.objref) != TYPE_THING)) {
+        abort_interp("Invalid player or thing argument.");
+    }
 
     CHECKREMOTE(oper1->data.objref);
 
-    /**
-     * @TODO Move the type check to the top, and flatten this switch.
-     */
-    switch (Typeof(oper1->data.objref)) {
-        case TYPE_PLAYER:
-            result = GETVALUE(oper1->data.objref);
-            break;
-
-        case TYPE_THING:
-            result = GETVALUE(oper1->data.objref);
-            break;
-
-        default:
-            abort_interp("Invalid argument.");
-    }
+    result = GETVALUE(oper1->data.objref);
 
     CLEAR(oper1);
     PushInt(result);
@@ -446,11 +409,14 @@ prim_pennies(PRIM_PROTOTYPE)
 void
 prim_dbref(PRIM_PROTOTYPE)
 {
+    dbref ref;
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (oper1->type != PROG_INTEGER)
+    if (oper1->type != PROG_INTEGER) {
         abort_interp("Non-integer argument.");
+    }
 
     ref = (dbref) oper1->data.number;
 
@@ -476,29 +442,21 @@ prim_dbref(PRIM_PROTOTYPE)
 void
 prim_contents(PRIM_PROTOTYPE)
 {
+    dbref ref;
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
+    if (!valid_object(oper1)) {
         abort_interp("Invalid argument type.");
-
-    CHECKREMOTE(oper1->data.objref);
+    }
 
     ref = CONTENTS(oper1->data.objref);
+    CHECKREMOTE(ref);
 
-    while (mlev < 2 && ref != NOTHING && (FLAGS(ref) & DARK)
-            && !controls(ProgUID, ref))
+    while (mlev < 2 && ref != NOTHING && (FLAGS(ref) & DARK) && !controls(ProgUID, ref)) {
         ref = NEXTOBJ(ref);
-
-    /**
-     * @TODO Define all the cases when the lastuse timestamp and count
-     *       should be updated.
-     */
-    /*
-    if (Typeof(oper1->data.objref) != TYPE_PLAYER
-            && Typeof(oper1->data.objref) != TYPE_PROGRAM)
-        ts_lastuseobject(oper1->data.objref);
-    */
+    }
 
     CLEAR(oper1);
     PushObject(ref);
@@ -523,33 +481,23 @@ prim_contents(PRIM_PROTOTYPE)
 void
 prim_exits(PRIM_PROTOTYPE)
 {
+    dbref ref;
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
-        abort_interp("Invalid object.");
+    if (!valid_object(oper1) || Typeof(oper1->data.objref) == TYPE_PROGRAM || Typeof(oper1->data.objref) == TYPE_EXIT) {
+        abort_interp("Invalid player, thing, or room object.");
+    }
 
     ref = oper1->data.objref;
     CHECKREMOTE(ref);
 
-    if ((mlev < 3) && !permissions(ProgUID, ref))
+    if ((mlev < 3) && !permissions(ProgUID, ref)) {
         abort_interp("Permission denied.");
-
-    /**
-     * @TODO Move type check to the top, and flatten this switch.
-     */
-    switch (Typeof(ref)) {
-        case TYPE_ROOM:
-        case TYPE_THING:
-            /* ts_lastuseobject(ref); */
-
-        case TYPE_PLAYER:
-            ref = EXITS(ref);
-            break;
-
-        default:
-            abort_interp("Invalid object.");
     }
+
+    ref = EXITS(ref);
 
     CLEAR(oper1);
     PushObject(ref);
@@ -573,11 +521,14 @@ prim_exits(PRIM_PROTOTYPE)
 void
 prim_next(PRIM_PROTOTYPE)
 {
+    dbref ref;
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
+    if (!valid_object(oper1)) {
         abort_interp("Invalid object.");
+    }
 
     CHECKREMOTE(oper1->data.objref);
 
@@ -585,8 +536,9 @@ prim_next(PRIM_PROTOTYPE)
 
     while (mlev < 2 && ref != NOTHING && Typeof(ref) != TYPE_EXIT
             && ((FLAGS(ref) & DARK) || Typeof(ref) == TYPE_ROOM)
-            && !controls(ProgUID, ref))
+            && !controls(ProgUID, ref)) {
         ref = NEXTOBJ(ref);
+    }
 
     CLEAR(oper1);
     PushObject(ref);
@@ -610,21 +562,21 @@ prim_next(PRIM_PROTOTYPE)
 void
 prim_nextowned(PRIM_PROTOTYPE)
 {
-    dbref ownr;
+    dbref ref, ownr;
 
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
+    if (!valid_object(oper1)) {
         abort_interp("Invalid object.");
-    if (mlev < 2)
+    }
+
+    if (mlev < 2) {
         abort_interp("Permission denied.");
+    }
 
     ref = oper1->data.objref;
 
-    /**
-     * @TODO This should never abort, since mlev >= 2.
-     */
     CHECKREMOTE(ref);
 
     ownr = OWNER(ref);
@@ -635,8 +587,9 @@ prim_nextowned(PRIM_PROTOTYPE)
         ref++;
     }
 
-    while (ref < db_top && (OWNER(ref) != ownr || ref == ownr))
+    while (ref < db_top && (OWNER(ref) != ownr || ref == ownr)) {
         ref++;
+    }
 
     if (ref >= db_top) {
         ref = NOTHING;
@@ -663,25 +616,22 @@ prim_nextowned(PRIM_PROTOTYPE)
 void
 prim_name(PRIM_PROTOTYPE)
 {
+    dbref ref;
+    char buf[BUFFER_LEN];
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (oper1->type != PROG_OBJECT)
+    if (!valid_object(oper1)) {
         abort_interp("Invalid argument type.");
+    }
 
     ref = oper1->data.objref;
-    if (!ObjExists(ref))
-        abort_interp("Invalid object.");
 
     if (Typeof(ref) == TYPE_GARBAGE) {
         strcpyn(buf, sizeof(buf), "<garbage>");
     } else {
         CHECKREMOTE(ref);
-
-        /*
-        if ((Typeof(ref) != TYPE_PLAYER) && (Typeof(ref) != TYPE_PROGRAM))
-           ts_lastuseobject(ref);
-        */
 
         if (NAME(ref)) {
             strcpyn(buf, sizeof(buf), NAME(ref));
@@ -713,65 +663,72 @@ prim_name(PRIM_PROTOTYPE)
 void
 prim_setname(PRIM_PROTOTYPE)
 {
+    dbref ref;
+    char buf[BUFFER_LEN];
     char *password;
+
+    /**
+     * @TODO Combine with logic in do_name as possible.
+     */
 
     CHECKOP(2);
     oper1 = POP();
     oper2 = POP();
 
-    if (!valid_object(oper2))
+    if (!valid_object(oper2)) {
         abort_interp("Invalid argument type (1)");
+    }
 
-    if (oper1->type != PROG_STRING)
+    if (oper1->type != PROG_STRING) {
         abort_interp("Non-string argument (2)");
+    }
 
     ref = oper2->data.objref;
-    if ((mlev < 4) && !permissions(ProgUID, ref))
+    if ((mlev < 4) && !permissions(ProgUID, ref)) {
         abort_interp("Permission denied.");
+    }
 
-    {
-        const char *b = DoNullInd(oper1->data.string);
+    const char *b = DoNullInd(oper1->data.string);
 
-        if (Typeof(ref) == TYPE_PLAYER) {
-            strcpyn(buf, sizeof(buf), b);
-            b = buf;
+    if (Typeof(ref) == TYPE_PLAYER) {
+        strcpyn(buf, sizeof(buf), b);
+        b = buf;
 
-            if (mlev < 4) {
-                abort_interp("Permission denied.");
-            }
-
-            /* split off password */
-            for (password = buf; *password && !isspace(*password); password++) ;
-
-            if (*password) {
-                *password++ = '\0';     /* terminate name */
-                skip_whitespace_var(&password);
-            }
-
-            /* check for null password */
-            if (!*password) {
-                abort_interp("Player namechange requires password.");
-            } else if (!check_password(ref, password)) {
-                abort_interp("Incorrect password.");
-            } else if (strcasecmp(b, NAME(ref)) && !ok_object_name(b, TYPE_PLAYER)) {
-                abort_interp("You can't give a player that name.");
-            }
-
-            /* everything ok, notify */
-            log_status("NAME CHANGE (MUF): %s(#%d) to %s", NAME(ref), ref, b);
-
-            delete_player(ref);
-            change_player_name(ref, b);
-            add_player(ref);
-        } else {
-            if (!ok_object_name(b, Typeof(ref))) {
-                abort_interp("Invalid name.");
-            }
-
-            free((void *) NAME(ref));
-            NAME(ref) = alloc_string(b);
-            ts_modifyobject(ref);
+        if (mlev < 4) {
+            abort_interp("Permission denied.");
         }
+
+        /* split off password */
+        for (password = buf; *password && !isspace(*password); password++) {}
+
+        if (*password) {
+            *password++ = '\0';     /* terminate name */
+            skip_whitespace_var(&password);
+        }
+
+        /* check for null password */
+        if (!*password) {
+            abort_interp("Player namechange requires password.");
+        } else if (!check_password(ref, password)) {
+            abort_interp("Incorrect password.");
+        } else if (strcasecmp(b, NAME(ref)) && !ok_object_name(b, TYPE_PLAYER)) {
+            abort_interp("You can't give a player that name.");
+        }
+
+        /* everything ok, notify */
+        log_status("NAME CHANGE (MUF): %s(#%d) to %s", NAME(ref), ref, b);
+
+        delete_player(ref);
+        change_player_name(ref, b);
+        add_player(ref);
+    } else {
+        if (!ok_object_name(b, Typeof(ref))) {
+            abort_interp("Invalid name.");
+        }
+
+        free((void *) NAME(ref));
+        NAME(ref) = alloc_string(b);
+        ts_modifyobject(ref);
     }
 
     CLEAR(oper1);
@@ -796,12 +753,14 @@ void
 prim_pmatch(PRIM_PROTOTYPE)
 {
     dbref ref;
+    char buf[BUFFER_LEN];
 
     CHECKOP(1);
     oper1 = POP();
 
-    if (oper1->type != PROG_STRING)
+    if (oper1->type != PROG_STRING) {
         abort_interp("Non-string argument.");
+    }
 
     strip_ansi(buf, DoNullInd(oper1->data.string));
 
@@ -810,6 +769,7 @@ prim_pmatch(PRIM_PROTOTYPE)
     } else {
         ref = lookup_player(buf);
     }
+
     CLEAR(oper1);
     PushObject(ref);
 }
@@ -833,48 +793,47 @@ prim_pmatch(PRIM_PROTOTYPE)
 void
 prim_match(PRIM_PROTOTYPE)
 {
-    struct inst *oper1 = NULL, *oper2 = NULL, *oper3 = NULL, *oper4 = NULL;
+    struct inst *oper1 = NULL;  /* prevents re-entrancy issues! */
     dbref ref;
-    char buf2[BUFFER_LEN];
 
     CHECKOP(1);
     oper1 = POP();
 
-    if (oper1->type != PROG_STRING)
+    if (oper1->type != PROG_STRING) {
         abort_interp("Non-string argument.");
-    {
-        char tmppp[BUFFER_LEN];
-        struct match_data md;
-
-        (void) strcpyn(buf, sizeof(buf), match_args);
-        (void) strcpyn(tmppp, sizeof(tmppp), match_cmdname);
-
-        strip_ansi(buf2, DoNullInd(oper1->data.string));
-
-        init_match(fr->descr, player, buf2, NOTYPE, &md);
-
-        if (buf2[0] == REGISTERED_TOKEN) {
-            match_registered(&md);
-        } else {
-            match_all_exits(&md);
-            match_neighbor(&md);
-            match_possession(&md);
-            match_me(&md);
-            match_here(&md);
-            match_home(&md);
-            match_nil(&md);
-        }
-
-        if (Wizard(ProgUID) || (mlev >= 4)) {
-            match_absolute(&md);
-            match_player(&md);
-        }
-
-        ref = match_result(&md);
-
-        (void) strcpyn(match_args, sizeof(match_args), buf);
-        (void) strcpyn(match_cmdname, sizeof(match_cmdname), tmppp);
     }
+
+    char buf[BUFFER_LEN], buf2[BUFFER_LEN], tmppp[BUFFER_LEN];
+    struct match_data md;
+
+    (void) strcpyn(buf, sizeof(buf), match_args);
+    (void) strcpyn(tmppp, sizeof(tmppp), match_cmdname);
+
+    strip_ansi(buf2, DoNullInd(oper1->data.string));
+
+    init_match(fr->descr, player, buf2, NOTYPE, &md);
+
+    if (buf2[0] == REGISTERED_TOKEN) {
+        match_registered(&md);
+    } else {
+        match_all_exits(&md);
+        match_neighbor(&md);
+        match_possession(&md);
+        match_me(&md);
+        match_here(&md);
+        match_home(&md);
+        match_nil(&md);
+    }
+
+    if (Wizard(ProgUID) || (mlev >= 4)) {
+        match_absolute(&md);
+        match_player(&md);
+    }
+
+    ref = match_result(&md);
+
+    (void) strcpyn(match_args, sizeof(match_args), buf);
+    (void) strcpyn(match_cmdname, sizeof(match_cmdname), tmppp);
 
     CLEAR(oper1);
     PushObject(ref);
@@ -900,41 +859,40 @@ prim_match(PRIM_PROTOTYPE)
 void
 prim_rmatch(PRIM_PROTOTYPE)
 {
-    struct inst *oper1 = NULL, *oper2 = NULL, *oper3 = NULL, *oper4 = NULL;
+    struct inst *oper1 = NULL;  /* prevents re-entrancy issues! */
+    struct inst *oper2 = NULL;  /* prevents re-entrancy issues! */
     dbref ref;
 
     CHECKOP(2);
     oper1 = POP();
     oper2 = POP();
 
-    if (oper1->type != PROG_STRING)
+    if (oper1->type != PROG_STRING) {
         abort_interp("Invalid argument (2)");
+    }
 
-    if (oper2->type != PROG_OBJECT
-        || !ObjExists(oper2->data.objref)
-        || Typeof(oper2->data.objref) == TYPE_PROGRAM
-        || Typeof(oper2->data.objref) == TYPE_EXIT)
+    if (!valid_object(oper2) || Typeof(oper2->data.objref) == TYPE_PROGRAM || Typeof(oper2->data.objref) == TYPE_EXIT) {
         abort_interp("Invalid argument (1)");
+    }
 
     CHECKREMOTE(oper2->data.objref);
 
-    {
-        char tmppp[BUFFER_LEN];
-        struct match_data md;
+    char buf[BUFFER_LEN], buf2[BUFFER_LEN], tmppp[BUFFER_LEN];
+    struct match_data md;
 
-        (void) strcpyn(buf, sizeof(buf), match_args);
-        (void) strcpyn(tmppp, sizeof(tmppp), match_cmdname);
+    (void) strcpyn(buf, sizeof(buf), match_args);
+    (void) strcpyn(tmppp, sizeof(tmppp), match_cmdname);
 
-        init_match(fr->descr, player, DoNullInd(oper1->data.string),
-                TYPE_THING, &md);
+    strip_ansi(buf2, DoNullInd(oper1->data.string));
 
-        match_rmatch(oper2->data.objref, &md);
+    init_match(fr->descr, player, buf2, TYPE_THING, &md);
 
-        ref = match_result(&md);
+    match_rmatch(oper2->data.objref, &md);
 
-        (void) strcpyn(match_args, sizeof(match_args), buf);
-        (void) strcpyn(match_cmdname, sizeof(match_cmdname), tmppp);
-    }
+    ref = match_result(&md);
+
+    (void) strcpyn(match_args, sizeof(match_args), buf);
+    (void) strcpyn(match_cmdname, sizeof(match_cmdname), tmppp);
 
     CLEAR(oper1);
     CLEAR(oper2);
@@ -964,25 +922,30 @@ prim_rmatch(PRIM_PROTOTYPE)
 void
 prim_copyobj(PRIM_PROTOTYPE)
 {
+    dbref ref;
     char error[SMALL_BUFFER_LEN] = "";
 
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
+    if (!valid_object(oper1)) {
         abort_interp("Invalid object.");
+    }
 
     CHECKREMOTE(oper1->data.objref);
 
-    if ((mlev < 3) && (fr->already_created))
+    if ((mlev < 3) && (fr->already_created)) {
         abort_interp("An object was already created this program run.");
+    }
 
     ref = oper1->data.objref;
-    if (Typeof(ref) != TYPE_THING)
+    if (Typeof(ref) != TYPE_THING) {
         abort_interp("Invalid object type.");
+    }
 
-    if ((mlev < 3) && !permissions(ProgUID, ref))
+    if ((mlev < 3) && !permissions(ProgUID, ref)) {
         abort_interp("Permission denied.");
+    }
 
     fr->already_created++;
 
@@ -1020,7 +983,7 @@ prim_copyobj(PRIM_PROTOTYPE)
  *    - ZOMBIE flags on things if effective user is maked ZOMBIE.
  *
  * No program is able to:
- *    - reset the VEHICLE flag of a basic vehicle with polayers in it
+ *    - reset the VEHICLE flag of a basic vehicle with players in it
  *    - interact with the OVERT flag on objects that aren't a thing or room
  *    - interact with the YIELD flag on objects that aren't a thing or room
  *
@@ -1037,8 +1000,10 @@ prim_copyobj(PRIM_PROTOTYPE)
 void
 prim_set(PRIM_PROTOTYPE)
 {
+    dbref ref;
     object_flag_type tmp;
     bool negated;
+    char error[SMALL_BUFFER_LEN] = "";
 
     CHECKOP(2);
     oper1 = POP();
@@ -1072,36 +1037,11 @@ prim_set(PRIM_PROTOTYPE)
         abort_interp("Unrecognized flag.");
     }
 
-    /**
-     * @TODO Shall we harmonize these checks with the restricted function?
-     *       @see restricted
-     */
-    if (((mlev < 4) && ((tmp == DARK && ((Typeof(ref) == TYPE_PLAYER)
-            || (!tp_exit_darking && Typeof(ref) == TYPE_EXIT)
-            || (!tp_thing_darking && Typeof(ref) == TYPE_THING)))
-            || ((tmp == ZOMBIE) && (Typeof(ref) == TYPE_THING)
-                && (FLAGS(ProgUID) & ZOMBIE))
-            || ((tmp == ZOMBIE) && (Typeof(ref) == TYPE_PLAYER))
-            || (tmp == BUILDER) || (tmp == YIELD) || ((unsigned) tmp == OVERT)
-            || (tmp == GUEST)))
-            || (tmp == WIZARD) || (tmp == QUELL) || (tmp == INTERACTIVE)
-            || ((tmp == ABODE) && (Typeof(ref) == TYPE_PROGRAM))
-            || (tmp == MUCKER) || (tmp == SMUCKER) || (tmp == XFORCIBLE)) {
-        abort_interp("Permission denied.");
-    }
-
-    if (((tmp == YIELD) || ((unsigned) tmp == OVERT)) &&
-        (Typeof(ref) != TYPE_THING && Typeof(ref) != TYPE_ROOM)) {
-        abort_interp("Permission denied.");
-    }
-
-    if (result && Typeof(ref) == TYPE_THING && tmp == VEHICLE) {
-        dbref obj = CONTENTS(ref);
-
-        for (; obj != NOTHING; obj = NEXTOBJ(obj)) {
-            if (Typeof(obj) == TYPE_PLAYER) {
-                abort_interp("That vehicle still has players in it!");
-            }
+    if (unable_to_set_flag(ProgUID, mlev, ref, tmp, !negated, error)) {
+        if (*error) {
+            abort_interp(error);
+        } else {
+            abort_interp("Permission denied.");
         }
     }
 
@@ -1138,14 +1078,18 @@ prim_set(PRIM_PROTOTYPE)
 void
 prim_mlevel(PRIM_PROTOTYPE)
 {
+    int result;
+    dbref ref;
+
     CHECKOP(1);
     oper1 = POP();
 
     if (oper1->data.objref == NOTHING) {
         result = mlev;
     } else {
-        if (!valid_object(oper1))
+        if (!valid_object(oper1)) {
             abort_interp("Invalid object.");
+        }
 
         ref = oper1->data.objref;
 
@@ -1178,6 +1122,9 @@ prim_mlevel(PRIM_PROTOTYPE)
 void
 prim_flagp(PRIM_PROTOTYPE)
 {
+    int result;
+    dbref ref;
+
     CHECKOP(2);
     oper1 = POP();
     oper2 = POP();
@@ -1219,16 +1166,17 @@ prim_flagp(PRIM_PROTOTYPE)
 void
 prim_playerp(PRIM_PROTOTYPE)
 {
+    int result;
+    dbref ref;
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (oper1->type != PROG_OBJECT)
+    if (oper1->type != PROG_OBJECT) {
         abort_interp("Invalid argument type.");
+    }
 
-    /**
-     * @TODO HOME is defined as a room. It eventually returns 0.
-     */
-    if (!valid_object(oper1) && !is_home(oper1)) {
+    if (!valid_object(oper1)) {
         result = 0;
     } else {
         ref = oper1->data.objref;
@@ -1260,16 +1208,17 @@ prim_playerp(PRIM_PROTOTYPE)
 void
 prim_thingp(PRIM_PROTOTYPE)
 {
+    int result;
+    dbref ref;
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (oper1->type != PROG_OBJECT)
+    if (oper1->type != PROG_OBJECT) {
         abort_interp("Invalid argument type.");
+    }
 
-    /**
-     * @TODO HOME is defined as a room. It eventually returns 0.
-     */
-    if (!valid_object(oper1) && !is_home(oper1)) {
+    if (!valid_object(oper1)) {
         result = 0;
     } else {
         ref = oper1->data.objref;
@@ -1300,11 +1249,15 @@ prim_thingp(PRIM_PROTOTYPE)
 void
 prim_roomp(PRIM_PROTOTYPE)
 {
+    int result;
+    dbref ref;
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (oper1->type != PROG_OBJECT)
+    if (oper1->type != PROG_OBJECT) {
         abort_interp("Invalid argument type.");
+    }
 
     if (!valid_object(oper1) && !is_home(oper1)) {
         result = 0;
@@ -1338,16 +1291,17 @@ prim_roomp(PRIM_PROTOTYPE)
 void
 prim_programp(PRIM_PROTOTYPE)
 {
+    int result;
+    dbref ref;
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (oper1->type != PROG_OBJECT)
+    if (oper1->type != PROG_OBJECT) {
         abort_interp("Invalid argument type.");
+    }
 
-    /**
-     * @TODO HOME is defined as a room. It eventually returns 0.
-     */
-    if (!valid_object(oper1) && !is_home(oper1)) {
+    if (!valid_object(oper1)) {
         result = 0;
     } else {
         ref = oper1->data.objref;
@@ -1379,16 +1333,17 @@ prim_programp(PRIM_PROTOTYPE)
 void
 prim_exitp(PRIM_PROTOTYPE)
 {
+    int result;
+    dbref ref;
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (oper1->type != PROG_OBJECT)
+    if (oper1->type != PROG_OBJECT) {
         abort_interp("Invalid argument type.");
+    }
 
-    /**
-     * @TODO HOME is defined as a room. It eventually returns 0.
-     */
-    if (!valid_object(oper1) && !is_home(oper1)) {
+    if (!valid_object(oper1)) {
         result = 0;
     } else {
         ref = oper1->data.objref;
@@ -1418,6 +1373,8 @@ prim_exitp(PRIM_PROTOTYPE)
 void
 prim_okp(PRIM_PROTOTYPE)
 {
+    int result;
+
     CHECKOP(1);
     oper1 = POP();
 
@@ -1444,11 +1401,14 @@ prim_okp(PRIM_PROTOTYPE)
 void
 prim_location(PRIM_PROTOTYPE)
 {
+    dbref ref;
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
+    if (!valid_object(oper1)) {
         abort_interp("Invalid object.");
+    }
 
     CHECKREMOTE(oper1->data.objref);
 
@@ -1475,10 +1435,14 @@ prim_location(PRIM_PROTOTYPE)
 void
 prim_owner(PRIM_PROTOTYPE)
 {
+    dbref ref;
+
     CHECKOP(1);
     oper1 = POP();
-    if (!valid_object(oper1))
+
+    if (!valid_object(oper1)) {
         abort_interp("Invalid object.");
+    }
 
     CHECKREMOTE(oper1->data.objref);
 
@@ -1508,15 +1472,19 @@ prim_owner(PRIM_PROTOTYPE)
 void
 prim_controls(PRIM_PROTOTYPE)
 {
+    int result;
+
     CHECKOP(2);
     oper1 = POP();
     oper2 = POP();
 
-    if (!valid_object(oper1))
+    if (!valid_object(oper1)) {
         abort_interp("Invalid object. (2)");
+    }
 
-    if (!valid_object(oper2))
+    if (!valid_object(oper2)) {
         abort_interp("Invalid object. (1)");
+    }
 
     CHECKREMOTE(oper1->data.objref);
 
@@ -1546,11 +1514,14 @@ prim_controls(PRIM_PROTOTYPE)
 void
 prim_getlink(PRIM_PROTOTYPE)
 {
+    dbref ref;
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
+    if (!valid_object(oper1)) {
         abort_interp("Invalid object.");
+    }
 
     CHECKREMOTE(oper1->data.objref);
 
@@ -1559,12 +1530,12 @@ prim_getlink(PRIM_PROTOTYPE)
      *       link of a program as the home of its owner.  Does this
      *       make sense?
      */
-    if (Typeof(oper1->data.objref) == TYPE_PROGRAM)
+    if (Typeof(oper1->data.objref) == TYPE_PROGRAM) {
         abort_interp("Illegal object referenced.");
+    }
 
     /**
-     * @TODO Seems like this "link resolution" logic would be useful
-     *       as a standalone function?
+     * @TODO Combine with other link resolution logic as possible.
      */
     switch (Typeof(oper1->data.objref)) {
         case TYPE_EXIT:
@@ -1613,30 +1584,22 @@ void
 prim_getlinks(PRIM_PROTOTYPE)
 {
     int count;
-    dbref my_obj;
+    dbref ref, my_obj;
 
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
+    if (!valid_object(oper1)) {
         abort_interp("Invalid object.");
+    }
 
     CHECKREMOTE(oper1->data.objref);
 
-    if (Typeof(oper1->data.objref) == TYPE_PROGRAM)
+    if (Typeof(oper1->data.objref) == TYPE_PROGRAM) {
         abort_interp("Illegal object referenced.");
+    }
 
     my_obj = oper1->data.objref;
-
-    /**
-     * @TODO Move this to the bottom for consistency.
-     */
-    CLEAR(oper1);
-
-    /**
-     * @TODO I don't understand the need for this.
-     */
-    nargs = 0;
 
     switch (Typeof(my_obj)) {
         case TYPE_EXIT:
@@ -1648,10 +1611,6 @@ prim_getlinks(PRIM_PROTOTYPE)
                 PushObject((DBFETCH(my_obj)->sp.exit.dest)[i]);
             }
 
-            /**
-             * @TODO We only need one instance of this, outside the switch.
-             */
-            PushInt(count);
             break;
 
         case TYPE_PLAYER:
@@ -1661,7 +1620,6 @@ prim_getlinks(PRIM_PROTOTYPE)
             count = 1;
 
             PushObject(ref);
-            PushInt(count);
             break;
 
         case TYPE_THING:
@@ -1672,7 +1630,6 @@ prim_getlinks(PRIM_PROTOTYPE)
             count = 1;
 
             PushObject(ref);
-            PushInt(count);
             break;
 
         case TYPE_ROOM:
@@ -1680,20 +1637,20 @@ prim_getlinks(PRIM_PROTOTYPE)
 
             if (ref != NOTHING) {
                 count = 0;
-                PushInt(count);
             } else {
                 CHECKOFLOW(2);
                 count = 1;
                 PushObject(ref);
-                PushInt(count);
             }
+
             break;
 
         default:
             count = 0;
-            PushInt(count);
             break;
     }
+
+    PushInt(count);
 }
 
 /**
@@ -1723,43 +1680,43 @@ static int
 prog_can_link_to(int mlev, dbref who, object_flag_type what_type, dbref where)
 {
     /* Can always link to HOME */
-    if (where == HOME)
+    if (where == HOME) {
         return 1;
+    }
 
     /* Exits can be linked to NIL */
-    if (what_type == TYPE_EXIT && where == NIL)
+    if (what_type == TYPE_EXIT && where == NIL) {
         return 1;
+    }
 
     /* Can't link to an invalid or recycled dbref */
-    if (!OkObj(where))
+    if (!OkObj(where)) {
         return 0;
+    }
 
     /* Players can only be linked to rooms */
-    if (what_type == TYPE_PLAYER && Typeof(where) != TYPE_ROOM)
+    if (what_type == TYPE_PLAYER && Typeof(where) != TYPE_ROOM) {
         return 0;
+    }
 
     /* Rooms can only be linked to things or other rooms */
-    if (what_type == TYPE_ROOM
-        && Typeof(where) != TYPE_THING && Typeof(where) != TYPE_ROOM)
+    if (what_type == TYPE_ROOM && Typeof(where) != TYPE_THING && Typeof(where) != TYPE_ROOM) {
         return 0;
+    }
 
     /* Things cannot be linked to exits or programs */
-    if (what_type == TYPE_THING
-        && (Typeof(where) == TYPE_EXIT || Typeof(where) == TYPE_PROGRAM))
+    if (what_type == TYPE_THING && (Typeof(where) == TYPE_EXIT || Typeof(where) == TYPE_PROGRAM)) {
         return 0;
+    }
 
     /* Programs cannot be linked */
-    if (what_type == TYPE_PROGRAM)
+    if (what_type == TYPE_PROGRAM) {
         return 0;
+    }
 
     /* Effective mucker level must be 3 or more, source must have permission,
        or target must be publicly linkable with its linklock passed */
 
-    /**
-     * @TODO Show we add a function argument for fr->descr so test_lock
-     *       dosesn't need to use NOTHING?  This would go for can_link_to
-     *       in predicates.c as well.
-     */
     return mlev > 3 || permissions(who, where) || (Linkable(where) &&
             test_lock(NOTHING, who, where, MESGPROP_LINKLOCK));
 }
@@ -1787,68 +1744,67 @@ prog_can_link_to(int mlev, dbref who, object_flag_type what_type, dbref where)
 void
 prim_setlink(PRIM_PROTOTYPE)
 {
+    dbref ref;
+
     CHECKOP(2);
     oper1 = POP();              /* dbref: destination */
     oper2 = POP();              /* dbref: source */
 
-    if ((oper1->type != PROG_OBJECT) || (oper2->type != PROG_OBJECT))
-        abort_interp("setlink requires two dbrefs.");
+    if (!valid_object(oper1)) {
+        abort_interp("Invalid object. (2)");
+    }
 
-    if (!valid_object(oper2))
+    if (!valid_object(oper2)) {
         abort_interp("Invalid object. (1)");
+    }
 
     ref = oper2->data.objref;
 
     /**
-     * @TODO Centralize the setlink logic so it can be used elewhere.
+     * @TODO Combine with other link setting logic as possible.
      */
     if (oper1->data.objref == NOTHING) {
-        /**
-         * @TODO Move this check above the if, removing others.
-         */
-        if ((mlev < 4) && !permissions(ProgUID, ref))
+        if ((mlev < 4) && !permissions(ProgUID, ref)) {
             abort_interp("Permission denied.");
+        }
 
-        switch (Typeof(ref)) {
-            case TYPE_EXIT:
-                DBSTORE(ref, sp.exit.ndest, 0);
-                free(DBFETCH(ref)->sp.exit.dest);
-                DBSTORE(ref, sp.exit.dest, NULL);
+        if (Typeof(ref) != TYPE_EXIT && Typeof(ref) != TYPE_ROOM) {
+            abort_interp("Invalid object. (1)");
+        }
 
-                if (MLevRaw(ref))
-                    SetMLevel(ref, 0);
+        if (Typeof(ref) == TYPE_EXIT) {
+            DBSTORE(ref, sp.exit.ndest, 0);
+            free(DBFETCH(ref)->sp.exit.dest);
+            DBSTORE(ref, sp.exit.dest, NULL);
 
-                break;
-
-            case TYPE_ROOM:
-                DBSTORE(ref, sp.room.dropto, NOTHING);
-                break;
-
-            default:
-                abort_interp("Invalid object. (1)");
+            if (MLevRaw(ref)) {
+                SetMLevel(ref, 0);
+            }
+        } else {
+            DBSTORE(ref, sp.room.dropto, NOTHING);
         }
     } else {
-        if (oper1->data.objref != HOME && oper1->data.objref != NIL
-                && !valid_object(oper1))
-            abort_interp("Invalid object. (2)");
-
-        if (Typeof(ref) == TYPE_PROGRAM)
+        if (Typeof(ref) == TYPE_PROGRAM) {
             abort_interp("Program objects are not linkable. (1)");
+        }
 
-        if (!prog_can_link_to(mlev, ProgUID, Typeof(ref), oper1->data.objref))
+        if (!prog_can_link_to(mlev, ProgUID, Typeof(ref), oper1->data.objref)) {
             abort_interp("Can't link source to destination.");
+        }
+
+        if ((mlev < 4) && !permissions(ProgUID, ref)) {
+                    abort_interp("Permission denied.");
+        }
 
         switch (Typeof(ref)) {
             case TYPE_EXIT:
-                if ((mlev < 4) && !permissions(ProgUID, ref))
-                    abort_interp("Permission denied.");
-
-                if (DBFETCH(ref)->sp.exit.ndest != 0
-                        && (DBFETCH(ref)->sp.exit.dest)[0] != NIL)
+                if (DBFETCH(ref)->sp.exit.ndest != 0 && (DBFETCH(ref)->sp.exit.dest)[0] != NIL) {
                     abort_interp("Exit is already linked.");
+                }
 
-                if (exit_loop_check(ref, oper1->data.objref))
+                if (exit_loop_check(ref, oper1->data.objref)) {
                     abort_interp("Link would cause a loop.");
+                }
 
                 DBFETCH(ref)->sp.exit.ndest = 1;
                 DBFETCH(ref)->sp.exit.dest = malloc(sizeof(dbref));
@@ -1857,34 +1813,28 @@ prim_setlink(PRIM_PROTOTYPE)
                 break;
 
             case TYPE_PLAYER:
-                if ((mlev < 4) && !permissions(ProgUID, ref))
-                    abort_interp("Permission denied.");
-
-                if (oper1->data.objref == HOME)
+                if (oper1->data.objref == HOME) {
                     abort_interp("Cannot link player to HOME.");
+                }
 
                 PLAYER_SET_HOME(ref, oper1->data.objref);
                 DBDIRTY(ref);
                 break;
 
             case TYPE_THING:
-                if ((mlev < 4) && !permissions(ProgUID, ref))
-                    abort_interp("Permission denied.");
-
-                if (oper1->data.objref == HOME)
+                if (oper1->data.objref == HOME) {
                     abort_interp("Cannot link thing to HOME.");
+                }
 
-                if (parent_loop_check(ref, oper1->data.objref))
+                if (parent_loop_check(ref, oper1->data.objref)) {
                     abort_interp("That would cause a parent paradox.");
+                }
 
                 THING_SET_HOME(ref, oper1->data.objref);
                 DBDIRTY(ref);
                 break;
 
             case TYPE_ROOM:
-                if ((mlev < 4) && !permissions(ProgUID, ref))
-                    abort_interp("Permission denied.");
-
                 DBFETCH(ref)->sp.room.dropto = oper1->data.objref;
                 DBDIRTY(ref);
                 break;
@@ -1918,48 +1868,42 @@ prim_setlink(PRIM_PROTOTYPE)
 void
 prim_setown(PRIM_PROTOTYPE)
 {
+    dbref ref;
+
+    /**
+     * @TODO Combine with logic in do_chown as possible.
+     */
+
     CHECKOP(2);
     oper1 = POP();              /* dbref: new owner */
     oper2 = POP();              /* dbref: what */
 
-    if (!valid_object(oper2))
+    if (!valid_object(oper2) || Typeof(oper2->data.objref) == TYPE_PLAYER) {
         abort_interp("Invalid argument (1)");
+    }
 
-    if (!valid_player(oper1))
+    if (!valid_player(oper1)) {
         abort_interp("Invalid argument (2)");
+    }
 
     ref = oper2->data.objref;
-    if ((mlev < 4) && oper1->data.objref != player)
-        abort_interp("Permission denied. (2)");
 
-    if ((mlev < 4) && (!(FLAGS(ref) & CHOWN_OK) ||
-            !test_lock(fr->descr, player, ref, MESGPROP_CHLOCK)))
-        abort_interp("Permission denied. (1)");
+    if (mlev < 4) {
+        if (oper1->data.objref != player) {
+            abort_interp("Permission denied. (2)");
+        }
 
-    switch (Typeof(ref)) {
-        case TYPE_ROOM:
-            if ((mlev < 4) && LOCATION(player) != ref)
-                abort_interp("Permission denied: not in room. (1)");
+        if (!(FLAGS(ref) & CHOWN_OK) || !test_lock(fr->descr, player, ref, MESGPROP_CHLOCK)) {
+            abort_interp("Permission denied. (1)");
+        }
 
-            break;
+        if (Typeof(ref) == TYPE_ROOM && LOCATION(player) != ref) {
+            abort_interp("Permission denied: not in room. (1)");
+        }
 
-        case TYPE_THING:
-            if ((mlev < 4) && LOCATION(ref) != player)
-                abort_interp("Permission denied: object not carried. (1)");
-            break;
-
-        case TYPE_PLAYER:
-            abort_interp("Permission denied: cannot set owner of player. (1)");
-
-        case TYPE_EXIT:
-        case TYPE_PROGRAM:
-            break;
-
-        /**
-         * @TODO This is caught in the valid_object check at the top.
-         */
-        case TYPE_GARBAGE:
-            abort_interp("Permission denied: who would want to own garbage? (1)");
+        if (Typeof(ref) == TYPE_THING && LOCATION(ref) != player) {
+            abort_interp("Permission denied: object not carried. (1)");
+        }
     }
 
     OWNER(ref) = OWNER(oper1->data.objref);
@@ -1990,39 +1934,41 @@ prim_setown(PRIM_PROTOTYPE)
 void
 prim_newobject(PRIM_PROTOTYPE)
 {
+    dbref ref;
     char error[SMALL_BUFFER_LEN] = "";
 
     CHECKOP(2);
     oper1 = POP();              /* string: name */
     oper2 = POP();              /* dbref: location */
 
-    if ((mlev < 3) && (fr->already_created))
+    if ((mlev < 3) && (fr->already_created)) {
         abort_interp("An object was already created this program run.");
+    }
 
     CHECKOFLOW(1);
 
     ref = oper2->data.objref;
-    if (!valid_object(oper2) || !(valid_player(oper2)
-            || (Typeof(ref) == TYPE_ROOM)))
-        abort_interp("Invalid argument (1)");
+    if (!valid_object(oper2) || (Typeof(oper2->data.objref) != TYPE_PLAYER && Typeof(oper2->data.objref) == TYPE_ROOM)) {
+        abort_interp("Invalid player or room object (1)");
+    }
 
-    if (oper1->type != PROG_STRING)
+    if (oper1->type != PROG_STRING) {
         abort_interp("Invalid argument (2)");
+    }
 
     CHECKREMOTE(ref);
 
-    if ((mlev < 3) && !permissions(ProgUID, ref))
+    if ((mlev < 3) && !permissions(ProgUID, ref)) {
         abort_interp("Permission denied.");
+    }
 
     fr->already_created++;
 
-    {
-        const char *b = DoNullInd(oper1->data.string);
+    const char *b = DoNullInd(oper1->data.string);
 
-        ref = create_thing(ProgUID, b, oper2->data.objref, error);
-        if (ref == NOTHING) {
-            abort_interp(error);
-        }
+    ref = create_thing(ProgUID, b, oper2->data.objref, error);
+    if (ref == NOTHING) {
+        abort_interp(error);
     }
 
     CLEAR(oper1);
@@ -2051,51 +1997,56 @@ prim_newobject(PRIM_PROTOTYPE)
 void
 prim_newroom(PRIM_PROTOTYPE)
 {
+    dbref ref;
     char error[SMALL_BUFFER_LEN] = "";
 
     CHECKOP(2);
     oper1 = POP();              /* string: name */
     oper2 = POP();              /* dbref: location */
 
-    if ((mlev < 3) && (fr->already_created))
+    if ((mlev < 3) && (fr->already_created)) {
         abort_interp("An object was already created this program run.");
+    }
 
     CHECKOFLOW(1);
 
     ref = oper2->data.objref;
-    if (ref != NOTHING && (!valid_object(oper2) || Typeof(ref) != TYPE_ROOM))
+    if (ref != NOTHING && (!valid_object(oper2) || Typeof(ref) != TYPE_ROOM)) {
         abort_interp("Invalid argument (1)");
+    }
 
-    if (oper1->type != PROG_STRING)
+    if (oper1->type != PROG_STRING) {
         abort_interp("Invalid argument (2)");
+    }
 
-    if ((mlev < 3) && !permissions(ProgUID, ref))
+    if ((mlev < 3) && !permissions(ProgUID, ref)) {
         abort_interp("Permission denied.");
+    }
 
     fr->already_created++;
 
-    {
-        const char *b = DoNullInd(oper1->data.string);
+    const char *b = DoNullInd(oper1->data.string);
 
-        if (ref == NOTHING) {
-            ref = LOCATION(LOCATION(player));
-    
-            while ((ref != NOTHING) && !(FLAGS(ref) & ABODE))
-                ref = LOCATION(ref);
-    
-            if (ref == NOTHING)
-                ref = tp_default_room_parent;
+    if (ref == NOTHING) {
+        ref = LOCATION(LOCATION(player));
+
+        while ((ref != NOTHING) && !(FLAGS(ref) & ABODE)) {
+            ref = LOCATION(ref);
         }
 
-        ref = create_room(ProgUID, b, ref, error);
         if (ref == NOTHING) {
-            abort_interp(error);
+            ref = tp_default_room_parent;
         }
-
-        CLEAR(oper1);
-        CLEAR(oper2);
-        PushObject(ref);
     }
+
+    ref = create_room(ProgUID, b, ref, error);
+    if (ref == NOTHING) {
+        abort_interp(error);
+    }
+
+    CLEAR(oper1);
+    CLEAR(oper2);
+    PushObject(ref);
 }
 
 /**
@@ -2118,46 +2069,42 @@ prim_newroom(PRIM_PROTOTYPE)
 void
 prim_newexit(PRIM_PROTOTYPE)
 {
+    dbref ref;
     char error[SMALL_BUFFER_LEN] = "";
+
     CHECKOP(2);
     oper1 = POP();              /* string: name */
     oper2 = POP();              /* dbref: location */
 
-    if (mlev < 3)
+    if (mlev < 3) {
         abort_interp("Requires Mucker Level 3.");
+    }
 
     CHECKOFLOW(1);
 
-    ref = oper2->data.objref;
-    if (!valid_object(oper2) ||
-        ((!valid_player(oper2)) && (Typeof(ref) != TYPE_ROOM)
-            && (Typeof(ref) != TYPE_THING)))
+    if (!valid_object(oper2) || Typeof(oper2->data.objref) == TYPE_EXIT || Typeof(oper2->data.objref) == TYPE_PROGRAM) {
         abort_interp("Invalid argument (1)");
+    }
 
-    if (oper1->type != PROG_STRING)
+    if (oper1->type != PROG_STRING) {
         abort_interp("Invalid argument (2)");
+    }
 
-    /**
-     * @TODO This should never abort, since mlev >= 2.
-     */
+    ref = oper2->data.objref;
     CHECKREMOTE(ref);
 
-    if ((mlev < 4) && !permissions(ProgUID, ref))
+    if ((mlev < 4) && !permissions(ProgUID, ref)) {
         abort_interp("Permission denied.");
-
-    {
-        const char *b = DoNullInd(oper1->data.string);
-
-        ref = create_action(ProgUID, oper1->data.string->data,
-                oper2->data.objref, error);
-        if (ref == NOTHING) {
-            abort_interp(error);
-        }
-
-        CLEAR(oper1);
-        CLEAR(oper2);
-        PushObject(ref);
     }
+
+    ref = create_action(ProgUID, oper1->data.string->data, oper2->data.objref, error);
+    if (ref == NOTHING) {
+        abort_interp(error);
+    }
+
+    CLEAR(oper1);
+    CLEAR(oper2);
+    PushObject(ref);
 }
 
 /**
@@ -2182,30 +2129,25 @@ prim_lockedp(PRIM_PROTOTYPE)
 {
     struct inst *oper1 = NULL;  /* prevents re-entrancy issues! */
     struct inst *oper2 = NULL;  /* prevents re-entrancy issues! */
+    int result;
 
     CHECKOP(2);
     oper1 = POP();              /* objdbref */
     oper2 = POP();              /* player dbref */
 
-    if (fr->level > tp_max_interp_recursion)
+    if (fr->level > tp_max_interp_recursion) {
         abort_interp("Interp call loops not allowed.");
+    }
 
-    /**
-     * @TODO This appears to be a redundant check.
-     */
-    if (!valid_object(oper2))
-        abort_interp("invalid object (1).");
-
-    /**
-     * @TODO Argument can be a thing, too.  Change the message.
-     */
-    if (!valid_player(oper2) && Typeof(oper2->data.objref) != TYPE_THING)
-        abort_interp("Non-player argument (1).");
+    if (!valid_object(oper2) || (Typeof(oper2->data.objref) != TYPE_PLAYER && Typeof(oper2->data.objref) == TYPE_THING)) {
+        abort_interp("Invalid player or thing argument. (1)");
+    }
 
     CHECKREMOTE(oper2->data.objref);
 
-    if (!valid_object(oper1))
-        abort_interp("invalid object (2).");
+    if (!valid_object(oper1)) {
+        abort_interp("Invalid object (2).");
+    }
 
     CHECKREMOTE(oper1->data.objref);
 
@@ -2240,28 +2182,32 @@ prim_lockedp(PRIM_PROTOTYPE)
 void
 prim_recycle(PRIM_PROTOTYPE)
 {
+    int result;
+
+    /**
+     * @TODO Combine with logic in do_recycle as possible.
+     */
+
     CHECKOP(1);
     oper1 = POP();              /* object dbref to recycle */
 
-    /**
-     * @TODO This seems to be a redundant check.
-     */
-    if (oper1->type != PROG_OBJECT)
-        abort_interp("Non-object argument (1).");
-
-    if (!valid_object(oper1))
+    if (!valid_object(oper1)) {
         abort_interp("Invalid object (1).");
+    }
 
     result = oper1->data.objref;
 
-    if ((mlev < 3) || ((mlev < 4) && !permissions(ProgUID, result)))
+    if ((mlev < 3) || ((mlev < 4) && !permissions(ProgUID, result))) {
         abort_interp("Permission denied.");
+    }
 
-    if (result == GLOBAL_ENVIRONMENT)
+    if (result == GLOBAL_ENVIRONMENT) {
         abort_interp("Cannot recycle the global environment.");
+    }
 
-    if (Typeof(result) == TYPE_PLAYER)
+    if (Typeof(result) == TYPE_PLAYER) {
         abort_interp("Cannot recycle a player.");
+    }
 
     for (struct tune_entry *tent = tune_list; tent->name; tent++) {
         if (tent->type == TP_TYPE_DBREF && result == *tent->currentval.d) {
@@ -2269,15 +2215,19 @@ prim_recycle(PRIM_PROTOTYPE)
         }
     }
 
-    if (result == program)
+    if (result == program) {
         abort_interp("Cannot recycle currently running program.");
+    }
 
-    for (int ii = 0; ii < fr->caller.top; ii++)
-        if (fr->caller.st[ii] == result)
+    for (int ii = 0; ii < fr->caller.top; ii++) {
+        if (fr->caller.st[ii] == result) {
             abort_interp("Cannot recycle active program.");
+        }
+    }
 
-    if (Typeof(result) == TYPE_EXIT)
+    if (Typeof(result) == TYPE_EXIT) {
         unset_source(result);
+    }
 
     CLEAR(oper1);
     recycle(fr->descr, player, result);
@@ -2303,19 +2253,25 @@ prim_recycle(PRIM_PROTOTYPE)
 void
 prim_setlockstr(PRIM_PROTOTYPE)
 {
+    int result;
+    dbref ref;
+
     CHECKOP(2);
     oper1 = POP();
     oper2 = POP();
 
-    if (!valid_object(oper2))
+    if (!valid_object(oper2)) {
         abort_interp("Invalid argument type (1)");
+    }
 
-    if (oper1->type != PROG_STRING)
+    if (oper1->type != PROG_STRING) {
         abort_interp("Non-string argument (2)");
+    }
 
     ref = oper2->data.objref;
-    if ((mlev < 4) && !permissions(ProgUID, ref))
+    if ((mlev < 4) && !permissions(ProgUID, ref)) {
         abort_interp("Permission denied.");
+    }
 
     result = _set_lock(fr->descr, player, ref, MESGPROP_LOCK, "Lock", DoNullInd(oper1->data.string), 1);
 
@@ -2345,24 +2301,26 @@ prim_setlockstr(PRIM_PROTOTYPE)
 void
 prim_getlockstr(PRIM_PROTOTYPE)
 {
+    dbref ref;
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
+    if (!valid_object(oper1)) {
         abort_interp("Invalid argument type");
+    }
 
     ref = oper1->data.objref;
     CHECKREMOTE(ref);
 
-    if ((mlev < 3) && !permissions(ProgUID, ref))
+    if ((mlev < 3) && !permissions(ProgUID, ref)) {
         abort_interp("Permission denied.");
-
-    {
-        const char *tmpstr = (char *) unparse_boolexp(player, GETLOCK(ref, MESGPROP_LOCK), 0);
-
-        CLEAR(oper1);
-        PushString(tmpstr);
     }
+
+    const char *tmpstr = (char *) unparse_boolexp(player, GETLOCK(ref, MESGPROP_LOCK), 0);
+
+    CLEAR(oper1);
+    PushString(tmpstr);
 }
 
 /**
@@ -2389,11 +2347,13 @@ prim_part_pmatch(PRIM_PROTOTYPE)
     CHECKOP(1);
     oper1 = POP();
 
-    if (oper1->type != PROG_STRING)
-        abort_interp("Non-string argument.");
-
-    if (mlev < 3)
+    if (mlev < 3) {
         abort_interp("Permission denied.  Requires Mucker Level 3.");
+    }
+
+    if (oper1->type != PROG_STRING) {
+        abort_interp("Non-string argument.");
+    }
 
     ref = partial_pmatch(DoNullInd(oper1->data.string));
 
@@ -2418,39 +2378,25 @@ prim_part_pmatch(PRIM_PROTOTYPE)
 void
 prim_checkpassword(PRIM_PROTOTYPE)
 {
-    char *ptr;
+    int result;
 
     CHECKOP(2);
     oper2 = POP();
     oper1 = POP();
 
-    if (mlev < 4)
+    if (mlev < 4) {
         abort_interp("Permission denied.  Requires Wizbit.");
-
-    if (oper1->type != PROG_OBJECT)
-        abort_interp("Player dbref expected. (1)");
-
-    ref = oper1->data.objref;
-
-    /**
-     * @TODO The NOTHING parts of this check are confusing.
-     */
-    if ((ref != NOTHING && !valid_player(oper1)) || ref == NOTHING)
-        abort_interp("Player dbref expected. (1)");
-
-    if (oper2->type != PROG_STRING)
-        abort_interp("Password string expected. (2)");
-
-    ptr = DoNullInd(oper2->data.string);
-
-    /**
-     * @TODO NOTHING should be caught before this point.
-     */
-    if (ref != NOTHING) {
-        result = check_password(ref, ptr);
-    } else {
-        result = 0;
     }
+
+    if (!valid_player(oper1)) {
+        abort_interp("Player dbref expected. (1)");
+    }
+
+    if (oper2->type != PROG_STRING) {
+        abort_interp("Password string expected. (2)");
+    }
+
+    result = check_password(oper1->data.objref, DoNullInd(oper2->data.string));
 
     CLEAR(oper1);
     CLEAR(oper2);
@@ -2464,7 +2410,7 @@ prim_checkpassword(PRIM_PROTOTYPE)
  * the first player/thing to the second.  Requires MUCKER level
  * tp_movepennies_muf_mlev for players and 4 for things.
  *
- * Needs MUCKER level 4 to bypass range checks for players.
+ * Needs MUCKER level 4 to to have a player's penny total exceed tp_max_pennies.
  *
  * @param player the player running the MUF program
  * @param program the program being run
@@ -2477,61 +2423,59 @@ prim_checkpassword(PRIM_PROTOTYPE)
 void
 prim_movepennies(PRIM_PROTOTYPE)
 {
-    dbref ref2;
+    dbref ref, ref2;
 
     CHECKOP(3);
     oper1 = POP();
     oper2 = POP();
     oper3 = POP();
 
-    if (mlev < tp_movepennies_muf_mlev)
-        abort_interp("Permission Denied (mlev < tp_movepennies_muf_mlev)");
+    if (mlev < tp_movepennies_muf_mlev) {
+        abort_interp("Permission denied (mlev < tp_movepennies_muf_mlev)");
+    }
 
-    if (!valid_object(oper3))
-        abort_interp("Invalid object. (1)");
+    if (!valid_object(oper3) || (Typeof(oper3->data.objref) != TYPE_PLAYER || Typeof(oper3->data.objref) == TYPE_THING)) {
+        abort_interp("Invalid player or thing argument (1)");
+    }
 
-    if (!valid_object(oper2))
-        abort_interp("Invalid object. (2)");
+    if (!valid_object(oper2) || (Typeof(oper2->data.objref) != TYPE_PLAYER || Typeof(oper2->data.objref) == TYPE_THING)) {
+        abort_interp("Invalid player or thing argument (2)");
+    }
 
-    if (oper1->type != PROG_INTEGER)
-        abort_interp("Non-integer argument (3)");
+    if (oper1->type != PROG_INTEGER || oper1->data.number < 0) {
+        abort_interp("Argument must be a non-negative integer. (3)");
+    }
 
-    if (oper1->data.number < 0)
-        abort_interp("Invalid argument. (3)");
+    if (mlev < 4 && Typeof(oper3->data.objref) == TYPE_THING) {
+        abort_interp("Permission denied. (2)");
+    }
 
     ref = oper3->data.objref;
     ref2 = oper2->data.objref;
 
-    /**
-     * @TODO See prim_addpennies for comments about this if block.
-     */
-    if (mlev < 4) {
-        if (Typeof(ref) == TYPE_PLAYER) {
-            if (GETVALUE(ref) < (GETVALUE(ref) - oper1->data.number))
+    if (Typeof(ref) == TYPE_PLAYER) {
+        if (mlev < 4) {
+            if (GETVALUE(ref) < (GETVALUE(ref) - oper1->data.number)) {
                 abort_interp("Would roll over player's score. (1)");
+            }
 
-            if ((GETVALUE(ref) - oper1->data.number) < 0)
+            if ((GETVALUE(ref) - oper1->data.number) < 0) {
                 abort_interp("Result would be negative. (1)");
-        } else {
-            abort_interp("Permission denied. (2)");
-        }
+            }
 
-        if (Typeof(ref2) == TYPE_PLAYER) {
-            if (GETVALUE(ref2) > (GETVALUE(ref2) + oper1->data.number))
+            if (GETVALUE(ref2) > (GETVALUE(ref2) + oper1->data.number)) {
                 abort_interp("Would roll over player's score. (2)");
+            }
 
-            if ((GETVALUE(ref2) + oper1->data.number) > tp_max_pennies)
+            if ((GETVALUE(ref2) + oper1->data.number) > tp_max_pennies) {
                 abort_interp("Would exceed MAX_PENNIES. (2)");
-        } else {
-            abort_interp("Permission denied. (2)");
+            }
         }
     }
 
-    /**
-     * @TODO No aborting if either dbref is a room, exit, or program?
-     */
     SETVALUE(ref, GETVALUE(ref) - oper1->data.number);
     DBDIRTY(ref);
+
     SETVALUE(ref2, GETVALUE(ref2) + oper1->data.number);
     DBDIRTY(ref2);
 
@@ -2562,6 +2506,7 @@ prim_movepennies(PRIM_PROTOTYPE)
 void
 prim_findnext(PRIM_PROTOTYPE)
 {
+    char buf[BUFFER_LEN];
     struct flgchkdat check;
     dbref who, item, ref;
     const char *name;
@@ -2572,35 +2517,29 @@ prim_findnext(PRIM_PROTOTYPE)
     oper2 = POP();              /* ref:owner */
     oper1 = POP();              /* ref:currobj */
 
-    if (oper4->type != PROG_STRING)
+    if (oper4->type != PROG_STRING) {
         abort_interp("Expected string argument. (4)");
+    }
 
-    if (oper3->type != PROG_STRING)
+    if (oper3->type != PROG_STRING) {
         abort_interp("Expected string argument. (3)");
+    }
 
-    if (!valid_player(oper2) && (oper2->data.objref != NOTHING))
+    if (!valid_player(oper2)) {
         abort_interp("Expected player argument. (2)");
+    }
 
-    /**
-     * @TODO Can the next three checks be combined into:
-     *           if (!valid_object(oper1) && oper1->type != NOTHING)
-     */
-    if (oper1->type != PROG_OBJECT)
-        abort_interp("Expected dbref argument. (1)");
-
-    if (!OkRef(oper1->data.objref))
-        abort_interp("Bad object. (1)");
-
-    if (oper1->data.objref != NOTHING
-            && Typeof(oper1->data.objref) == TYPE_GARBAGE)
-        abort_interp("Garbage object. (1)");
+    if (!valid_object(oper1) && oper1->data.objref != NOTHING) {
+        abort_interp("Invalid dbref argument. (1)");
+    }
 
     item = oper1->data.objref;
     who = oper2->data.objref;
     name = DoNullInd(oper3->data.string);
 
-    if (mlev < 2)
+    if (mlev < 2) {
         abort_interp("Permission denied.  Requires at least Mucker Level 2.");
+    }
 
     if (mlev < 3) {
         if (who == NOTHING) {
@@ -2663,8 +2602,9 @@ prim_nextentrance(PRIM_PROTOTYPE)
     int foundref = 0;
     int count;
 
-    if (mlev < 3)
+    if (mlev < 3) {
         abort_interp("Permission denied.  Requires Mucker Level 3.");
+    }
 
     CHECKOP(2);
     oper2 = POP();
@@ -2673,14 +2613,17 @@ prim_nextentrance(PRIM_PROTOTYPE)
     linkref = oper1->data.objref;
     ref = oper2->data.objref;
 
-    if (!valid_object(oper1) && (linkref != NOTHING) && (linkref != HOME))
+    if (!valid_object(oper1) && (linkref != NOTHING) && (linkref != HOME)) {
         abort_interp("Invalid link reference object (2)");
+    }
 
-    if (!valid_object(oper2) && ref != NOTHING)
+    if (!valid_object(oper2) && ref != NOTHING) {
         abort_interp("Invalid reference object (1)");
+    }
 
-    if (linkref == HOME)
+    if (linkref == HOME) {
         linkref = PLAYER_HOME(player);
+    }
 
     (void) ref++;
 
@@ -2690,37 +2633,48 @@ prim_nextentrance(PRIM_PROTOTYPE)
         if (valid_object(oper2)) {
             switch (Typeof(ref)) {
                 case TYPE_PLAYER:
-                    if (PLAYER_HOME(ref) == linkref)
+                    if (PLAYER_HOME(ref) == linkref) {
                         foundref = 1;
+                    }
+
                     break;
 
                 case TYPE_ROOM:
-                    if (DBFETCH(ref)->sp.room.dropto == linkref)
+                    if (DBFETCH(ref)->sp.room.dropto == linkref) {
                         foundref = 1;
+                    }
+
                     break;
 
                 case TYPE_THING:
-                    if (THING_HOME(ref) == linkref)
+                    if (THING_HOME(ref) == linkref) {
                         foundref = 1;
+                    }
+
                     break;
 
                 case TYPE_EXIT:
                     count = DBFETCH(ref)->sp.exit.ndest;
 
                     for (int i = 0; i < count; i++) {
-                        if (DBFETCH(ref)->sp.exit.dest[i] == linkref)
+                        if (DBFETCH(ref)->sp.exit.dest[i] == linkref) {
                             foundref = 1;
+                            break;
+                        }
                     }
+
                     break;
             }
 
-            if (foundref)
+            if (foundref) {
                 break;
+            }
         }
     }
 
-    if (!foundref)
+    if (!foundref) {
         ref = NOTHING;
+    }
 
     CLEAR(oper1);
     CLEAR(oper2);
@@ -2752,14 +2706,17 @@ prim_newplayer(PRIM_PROTOTYPE)
     oper1 = POP();
     oper2 = POP();
 
-    if (mlev < 4)
+    if (mlev < 4) {
         abort_interp("Permission denied.  Requires Wizbit.");
+    }
 
-    if (oper1->type != PROG_STRING)
+    if (oper1->type != PROG_STRING) {
         abort_interp("Non-string argument. (1)");
+    }
 
-    if (oper2->type != PROG_STRING)
+    if (oper2->type != PROG_STRING) {
         abort_interp("Non-string argument. (2)");
+    }
 
     name = DoNullInd(oper2->data.string);
     password = DoNullInd(oper1->data.string);
@@ -2807,23 +2764,23 @@ prim_copyplayer(PRIM_PROTOTYPE)
     oper2 = POP();
     oper3 = POP();
 
-    if (mlev < 4)
+    if (mlev < 4) {
         abort_interp("Permission denied.  Requires Wizbit.");
+    }
 
-    if (oper1->type != PROG_STRING)
+    if (oper1->type != PROG_STRING) {
         abort_interp("Non-string argument. (3)");
+    }
 
-    if (oper2->type != PROG_STRING)
+    if (oper2->type != PROG_STRING) {
         abort_interp("Non-string argument. (2)");
+    }
+
+    if (!valid_player(oper3)) {
+        abort_interp("Player dbref expected. (1)");
+    }
 
     ref = oper3->data.objref;
-
-    if ((ref != NOTHING && !valid_player(oper3)) || ref == NOTHING)
-        abort_interp("Player dbref expected. (1)");
-
-    /**
-     * @TODO This should never abort, since mlev >= 2.
-     */
     CHECKREMOTE(ref);
 
     name = DoNullInd(oper2->data.string);
@@ -2882,29 +2839,34 @@ prim_toadplayer(PRIM_PROTOTYPE)
     dbref victim;
     dbref recipient;
 
+    /**
+     * @TODO Combine with logic in do_toad as possible.
+     */
+
     CHECKOP(2);
     oper1 = POP();
     oper2 = POP();
 
-    if (mlev < 4)
+    if (mlev < 4) {
         abort_interp("Permission denied.  Requires Wizbit.");
+    }
 
-    if (force_level)
+    if (force_level) {
         abort_interp("Cannot be forced.");
+    }
 
     victim = oper1->data.objref;
 
-    if (!valid_player(oper1))
+    if (!valid_player(oper1)) {
         abort_interp("Player dbref expected for player to be toaded (2)");
+    }
 
     recipient = oper2->data.objref;
 
-    if (!valid_player(oper2))
+    if (!valid_player(oper2)) {
         abort_interp("Player dbref expected for recipient (1)");
+    }
 
-    /**
-     * @TODO These should never abort, since mlev >= 2.
-     */
     CHECKREMOTE(victim);
     CHECKREMOTE(recipient);
 
@@ -2963,16 +2925,12 @@ prim_objmem(PRIM_PROTOTYPE)
     CHECKOP(1);
     oper1 = POP();
 
-    if (oper1->type != PROG_OBJECT)
-        abort_interp("Argument must be a dbref.");
-
-    ref = oper1->data.objref;
-
-    if (!ObjExists(ref))
+    if (!valid_object(oper1)) {
         abort_interp("Invalid object.");
+    }
 
+    i = size_object(oper1->data.objref, 0);
     CLEAR(oper1);
-    i = size_object(ref, 0);
     PushInt(i);
 }
 
@@ -2993,24 +2951,19 @@ prim_objmem(PRIM_PROTOTYPE)
 void
 prim_instances(PRIM_PROTOTYPE)
 {
-    unsigned short a = 0;
-    int b = 0;
+    int i;
 
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
-        abort_interp("Invalid object.");
+    if (!valid_object(oper1) || Typeof(oper1->data.objref) != TYPE_PROGRAM) {
+        abort_interp("Invalid program object.");
+    }
 
-    ref = oper1->data.objref;
-    if (Typeof(ref) != TYPE_PROGRAM)
-        abort_interp("Object must be a program.");
+    i = PROGRAM_INSTANCES(oper1->data.objref);
 
     CLEAR(oper1);
-
-    a = PROGRAM_INSTANCES(ref);
-    b = a;
-    PushInt(b);
+    PushInt(i);
 }
 
 /**
@@ -3031,18 +2984,17 @@ void
 prim_compiledp(PRIM_PROTOTYPE)
 {
     int i = 0;
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
-        abort_interp("Invalid object.");
+    if (!valid_object(oper1) || Typeof(oper1->data.objref) != TYPE_PROGRAM) {
+        abort_interp("Invalid program object.");
+    }
 
-    ref = oper1->data.objref;
-    if (Typeof(ref) != TYPE_PROGRAM)
-        abort_interp("Object must be a program.");
+    i = PROGRAM_SIZ(oper1->data.objref);
 
     CLEAR(oper1);
-    i = PROGRAM_SIZ(ref);
     PushInt(i);
 }
 
@@ -3068,46 +3020,40 @@ prim_compiledp(PRIM_PROTOTYPE)
 void
 prim_newpassword(PRIM_PROTOTYPE)
 {
-    char *ptr2;
-    char pad_char[] = "";
+    dbref ref;
 
     CHECKOP(2);
     oper1 = POP();
     oper2 = POP();
 
-    if (mlev < 4)
+    if (mlev < 4) {
         abort_interp("Permission denied.  Requires Wizbit.");
+    }
 
-    if (oper1->type != PROG_STRING)
+    if (oper1->type != PROG_STRING) {
         abort_interp("Password string expected. (2)");
+    }
 
-    if (oper2->type != PROG_OBJECT)
+    if (!valid_player(oper2)) {
         abort_interp("Player dbref expected. (1)");
+    }
 
-    if (!oper1->data.string || !ok_password(oper1->data.string->data))
+    if (!oper1->data.string || !ok_password(oper1->data.string->data)) {
         abort_interp("Invalid password. (2)");
+    }
 
-    /**
-     * @TODO Change to: ptr2 = DoNullInd(oper1->data.string);
-     */
-    ptr2 = oper1->data.string ? oper1->data.string->data : pad_char;
     ref = oper2->data.objref;
-    if (!valid_player(oper2))
-        abort_interp("Player dbref expected. (1)");
-
-    /**
-     * @TODO This should never abort, since mlev >= 2.
-     */
     CHECKREMOTE(ref);
 
 #ifdef GOD_PRIV
-    if (God(ref))
+    if (God(ref)) {
         abort_interp("God cannot be newpassworded.");
-    if (!God(player) && TrueWizard(ref) && (player != ref))
+    } else if (TrueWizard(ref) && (player != ref)) {
         abort_interp("Only God can change a wizards password");
+    }
 #endif
 
-    set_password(ref, ptr2);
+    set_password(ref, DoNullInd(oper1->data.string));
 
     CLEAR(oper1);
     CLEAR(oper2);
@@ -3136,13 +3082,15 @@ prim_newprogram(PRIM_PROTOTYPE)
     CHECKOP(1);
     oper1 = POP();
 
-    if (mlev < 4)
+    if (mlev < 4) {
         abort_interp("Permission denied.  Requires Wizbit.");
+    }
 
-    if (oper1->type != PROG_STRING)
+    if (oper1->type != PROG_STRING) {
        abort_interp("Expected string argument.");
+    }
 
-    char *b = DoNullInd(oper1->data.string);
+    const char *b = DoNullInd(oper1->data.string);
 
     newprog = create_program(ProgUID, b, error);
     if (newprog == NOTHING) {
@@ -3182,24 +3130,23 @@ prim_compile(PRIM_PROTOTYPE)
     oper2 = POP();
     oper1 = POP();
 
-    if (mlev < 4)
+    if (mlev < 4) {
         abort_interp("Permission denied.  Requires Wizbit.");
+    }
 
-    /**
-     * @TODO Combine these two checks.
-     */
-    if (!valid_object(oper1))
-        abort_interp("No program dbref given. (1)");
+    if (!valid_object(oper1) || Typeof(oper1->data.objref) != TYPE_PROGRAM) {
+        abort_interp("Invalid program argument. (1)");
+    }
+
+    if (oper2->type != PROG_INTEGER) {
+        abort_interp("No boolean integer given. (2)");
+    }
 
     ref = oper1->data.objref;
-    if (Typeof(ref) != TYPE_PROGRAM)
-        abort_interp("No program dbref given. (1)");
 
-    if (oper2->type != PROG_INTEGER)
-        abort_interp("No boolean integer given. (2)");
-
-    if (PROGRAM_INSTANCES(ref) > 0)
+    if (PROGRAM_INSTANCES(ref) > 0) {
         abort_interp("That program is currently in use.");
+    }
 
     tmpline = PROGRAM_FIRST(ref);
     PROGRAM_SET_FIRST(ref, read_program(ref));
@@ -3238,21 +3185,19 @@ prim_uncompile(PRIM_PROTOTYPE)
     CHECKOP(1);
     oper1 = POP();
 
-    if (mlev < 4)
+    if (mlev < 4) {
         abort_interp("Permission denied.  Requires Wizbit.");
+    }
 
-    /**
-     * @TODO Combine these two checks.
-     */
-    if (!valid_object(oper1))
-        abort_interp("No program dbref given.");
+    if (!valid_object(oper1) || Typeof(oper1->data.objref) != TYPE_PROGRAM) {
+        abort_interp("Invalid program argument. (1)");
+    }
 
     ref = oper1->data.objref;
-    if (Typeof(ref) != TYPE_PROGRAM)
-        abort_interp("No program dbref given.");
 
-    if (PROGRAM_INSTANCES(ref) > 0)
+    if (PROGRAM_INSTANCES(ref) > 0) {
         abort_interp("That program is currently in use.");
+    }
 
     uncompile_program(ref);
 
@@ -3283,14 +3228,16 @@ prim_getpids(PRIM_PROTOTYPE)
     CHECKOP(1);
     oper1 = POP();
 
-    if (mlev < 3)
+    if (mlev < 3) {
         abort_interp("Permission denied.  Requires Mucker Level 3.");
+    }
 
-    if (oper1->type != PROG_OBJECT)
+    if (oper1->type != PROG_OBJECT) {
         abort_interp("Non-object argument (1)");
+    }
 
     /**
-     * @TODO Consider modifying this function to handle the running program.
+     * @TODO Consider modifying this function to handle the running pid.
      */
     nw = get_pids(oper1->data.objref, fr->pinning);
 
@@ -3332,28 +3279,33 @@ prim_getpidinfo(PRIM_PROTOTYPE)
 {
     struct inst temp1, temp2;
     stk_array *nu;
-    double cpu;
-    time_t etime;
 
     CHECKOP(1);
     oper1 = POP();
 
-    if (oper1->type != PROG_INTEGER)
+    if (oper1->type != PROG_INTEGER) {
         abort_interp("Non-integer argument (1)");
+    }
 
-    if (mlev < 3 && oper1->data.number != fr->pid)
+    if (mlev < 3 && oper1->data.number != fr->pid) {
         abort_interp("Permission denied.  Requires Mucker Level 3.");
+    }
 
     if (oper1->data.number == fr->pid) {
-        if ((nu = new_array_dictionary(fr->pinning)) == NULL)
+        double cpu;
+        time_t etime;
+
+        if ((nu = new_array_dictionary(fr->pinning)) == NULL) {
             abort_interp("Out of memory");
+        }
 
         if ((etime = time(NULL) - fr->started) > 0) {
             cpu = ((fr->totaltime.tv_sec +
                     (fr->totaltime.tv_usec / 1000000.0)) * 100.0) / etime;
 
-            if (cpu > 100.0)
+            if (cpu > 100.0) {
                 cpu = 100.0;
+            }
         } else
             cpu = 0.0;
 
@@ -3362,19 +3314,12 @@ prim_getpidinfo(PRIM_PROTOTYPE)
         array_set_strkey_fltval(&nu, "CPU", cpu);
         array_set_strkey_intval(&nu, "DESCR", fr->descr);
 
-        /**
-         * @TODO Keep the array_set_* calls together.
-         */
         temp1.type = PROG_STRING;
         temp1.data.string = alloc_prog_string("FILTERS");
         temp2.type = PROG_ARRAY;
         temp2.data.array = new_array_packed(0, fr->pinning);
 
         array_setitem(&nu, &temp1, &temp2);
-
-        CLEAR(&temp1);
-        CLEAR(&temp2);
-
         array_set_strkey_intval(&nu, "INSTCNT", fr->instcnt);
         array_set_strkey_intval(&nu, "MLEVEL", mlev);
         array_set_strkey_intval(&nu, "NEXTRUN", 0);
@@ -3384,6 +3329,9 @@ prim_getpidinfo(PRIM_PROTOTYPE)
         array_set_strkey_strval(&nu, "SUBTYPE", "");
         array_set_strkey_refval(&nu, "TRIG", fr->trig);
         array_set_strkey_strval(&nu, "TYPE", "MUF");
+
+        CLEAR(&temp1);
+        CLEAR(&temp2);
     } else
         /**
          * @TODO Consider modifying this function to handle the running pid.
@@ -3413,31 +3361,35 @@ prim_getpidinfo(PRIM_PROTOTYPE)
 void
 prim_contents_array(PRIM_PROTOTYPE)
 {
+    dbref ref;
     stk_array *nw;
     int count = 0;
 
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
+    if (!valid_object(oper1)) {
         abort_interp("Invalid dbref (1)");
+    }
 
     ref = oper1->data.objref;
     if ((Typeof(ref) == TYPE_PROGRAM) || (Typeof(ref) == TYPE_EXIT)) {
+        CLEAR(oper1);
         PushArrayRaw(new_array_packed(0, fr->pinning));
         return;
     }
 
     CHECKREMOTE(oper1->data.objref);
 
-    for (ref = CONTENTS(oper1->data.objref); ObjExists(ref); ref = NEXTOBJ(ref))
+    for (ref = CONTENTS(oper1->data.objref); ObjExists(ref); ref = NEXTOBJ(ref)) {
         count++;
+    }
 
     nw = new_array_packed(count, fr->pinning);
 
-    for (ref = CONTENTS(oper1->data.objref), count = 0; ObjExists(ref);
-             ref = NEXTOBJ(ref))
+    for (ref = CONTENTS(oper1->data.objref), count = 0; ObjExists(ref); ref = NEXTOBJ(ref)) {
         array_set_intkey_refval(&nw, count++, ref);
+    }
 
     CLEAR(oper1);
     PushArrayRaw(nw);
@@ -3462,34 +3414,38 @@ prim_contents_array(PRIM_PROTOTYPE)
 void
 prim_exits_array(PRIM_PROTOTYPE)
 {
+    dbref ref;
     stk_array *nw;
     int count = 0;
 
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
+    if ((mlev < 3) && !permissions(ProgUID, oper1->data.objref)) {
+        abort_interp("Permission denied.");
+    }
+
+    if (!valid_object(oper1)) {
         abort_interp("Invalid dbref (1)");
+    }
 
     ref = oper1->data.objref;
     CHECKREMOTE(oper1->data.objref);
-
-    if ((mlev < 3) && !permissions(ProgUID, ref))
-        abort_interp("Permission denied.");
 
     if ((Typeof(ref) == TYPE_PROGRAM) || (Typeof(ref) == TYPE_EXIT)) {
         PushArrayRaw(new_array_packed(0, fr->pinning));
         return;
     }
 
-    for (ref = EXITS(oper1->data.objref); ObjExists(ref); ref = NEXTOBJ(ref))
+    for (ref = EXITS(oper1->data.objref); ObjExists(ref); ref = NEXTOBJ(ref)) {
         count++;
+    }
 
     nw = new_array_packed(count, fr->pinning);
 
-    for (ref = EXITS(oper1->data.objref), count = 0; ObjExists(ref);
-            ref = NEXTOBJ(ref))
+    for (ref = EXITS(oper1->data.objref), count = 0; ObjExists(ref); ref = NEXTOBJ(ref)) {
         array_set_intkey_refval(&nw, count++, ref);
+    }
 
     CLEAR(oper1);
     PushArrayRaw(nw);
@@ -3508,27 +3464,29 @@ array_getlinks(dbref obj, int pinned)
     stk_array *nw = new_array_packed(0, pinned);
     int count = 0;
 
-    if (ObjExists(obj)) {
-        switch (Typeof(obj)) {
-            case TYPE_ROOM:
-                array_set_intkey_refval(&nw, count++,
-                        DBFETCH(obj)->sp.room.dropto);
-                break;
+    if (!ObjExists(obj)) {
+        return nw;
+    }
 
-            case TYPE_THING:
-                array_set_intkey_refval(&nw, count++, THING_HOME(obj));
-                break;
+    switch (Typeof(obj)) {
+        case TYPE_ROOM:
+            array_set_intkey_refval(&nw, count++, DBFETCH(obj)->sp.room.dropto);
+            break;
 
-            case TYPE_PLAYER:
-                array_set_intkey_refval(&nw, count++, PLAYER_HOME(obj));
-                break;
+        case TYPE_THING:
+            array_set_intkey_refval(&nw, count++, THING_HOME(obj));
+            break;
 
-            case TYPE_EXIT:
-                for (count = 0; count < (DBFETCH(obj)->sp.exit.ndest); count++)
-                    array_set_intkey_refval(&nw, count,
-                            (DBFETCH(obj)->sp.exit.dest)[count]);
-                break;
-        }
+        case TYPE_PLAYER:
+            array_set_intkey_refval(&nw, count++, PLAYER_HOME(obj));
+            break;
+
+        case TYPE_EXIT:
+            for (count = 0; count < (DBFETCH(obj)->sp.exit.ndest); count++) {
+                array_set_intkey_refval(&nw, count, (DBFETCH(obj)->sp.exit.dest)[count]);
+            }
+
+            break;
     }
 
     return nw;
@@ -3555,11 +3513,14 @@ array_getlinks(dbref obj, int pinned)
 void
 prim_getlinks_array(PRIM_PROTOTYPE)
 {
+    dbref ref;
+
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
+    if (!valid_object(oper1)) {
         abort_interp("Invalid object dbref. (1)");
+    }
 
     ref = oper1->data.objref;
     CHECKREMOTE(oper1->data.objref);
@@ -3585,17 +3546,20 @@ prim_getlinks_array(PRIM_PROTOTYPE)
 void
 prim_entrances_array(PRIM_PROTOTYPE)
 {
-    /**
-     * @TODO NEXTENTRANCE requires MUCKER levl 3. Should this?
-     */
+    dbref ref;
     stk_array *nw;
     int count = 0;
 
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1))
+    if (mlev < 3) {
+        abort_interp("Permission denied.  Requires Mucker Level 3.");
+    }
+
+    if (!valid_object(oper1)) {
         abort_interp("Invalid object dbref. (1)");
+    }
 
     ref = oper1->data.objref;
     nw = new_array_packed(0, fr->pinning);
@@ -3604,31 +3568,32 @@ prim_entrances_array(PRIM_PROTOTYPE)
         switch (Typeof(i)) {
             case TYPE_EXIT:
                 for (dbref j = DBFETCH(i)->sp.exit.ndest; j--;) {
-                    if (DBFETCH(i)->sp.exit.dest[j] == ref)
+                    if (DBFETCH(i)->sp.exit.dest[j] == ref) {
                         array_set_intkey_refval(&nw, count++, i);
+                    }
                 }
+
                 break;
 
             case TYPE_PLAYER:
-                if (PLAYER_HOME(i) == ref)
+                if (PLAYER_HOME(i) == ref) {
                     array_set_intkey_refval(&nw, count++, i);
+                }
+
                 break;
 
             case TYPE_THING:
-                if (THING_HOME(i) == ref)
+                if (THING_HOME(i) == ref) {
                     array_set_intkey_refval(&nw, count++, i);
+                }
+
                 break;
 
             case TYPE_ROOM:
-                if (DBFETCH(i)->sp.room.dropto == ref)
+                if (DBFETCH(i)->sp.room.dropto == ref) {
                     array_set_intkey_refval(&nw, count++, i);
-                break;
+                }
 
-            /**
-             * @TODO These two cases are unnecessary.
-             */
-            case TYPE_PROGRAM:
-            case TYPE_GARBAGE:
                 break;
         }
     }
@@ -3657,6 +3622,7 @@ prim_entrances_array(PRIM_PROTOTYPE)
 void
 prim_program_getlines(PRIM_PROTOTYPE)
 {
+    dbref ref;
     stk_array *ary;
     int start, end;
 
@@ -3665,91 +3631,97 @@ prim_program_getlines(PRIM_PROTOTYPE)
     oper2 = POP();
     oper1 = POP();
 
-    if (!valid_object(oper1))
-        abort_interp("Invalid object dbref. (1)");
+    if (!valid_object(oper1) || Typeof(oper1->data.objref) != TYPE_PROGRAM) {
+        abort_interp("Invalid pRogram dbref. (1)");
+    }
 
-    if (oper2->type != PROG_INTEGER)
+    if (oper2->type != PROG_INTEGER) {
         abort_interp("Expected integer. (2)");
+    }
 
-    if (oper3->type != PROG_INTEGER)
+    if (oper3->type != PROG_INTEGER) {
         abort_interp("Expected integer. (3)");
+    }
 
     ref = oper1->data.objref;
     start = oper2->data.number;
     end = oper3->data.number;
 
-    if (Typeof(ref) != TYPE_PROGRAM)
-        abort_interp("Non-program object. (1)");
-
-    if (mlev < 4 && !controls(ProgUID, ref) && !(FLAGS(ref) & VEHICLE))
+    if (mlev < 4 && !controls(ProgUID, ref) && !(FLAGS(ref) & VEHICLE)) {
         abort_interp("Permission denied.");
+    }
 
-    if (start < 0 || end < 0)
+    if (start < 0 || end < 0) {
         abort_interp("Line indexes must be non-negative.");
+    }
 
-    if (start == 0)
+    if (start == 0) {
         start = 1;
+    }
 
-    if (end && start > end)
+    if (end && start > end) {
         abort_interp("Illogical line range.");
+    }
 
     CLEAR(oper1);
     CLEAR(oper2);
     CLEAR(oper3);
 
-    {
-        /* we make two passes over our linked list's data,
-         * first we figure out how many lines are
-         * actually there. This is so we only allocate
-         * our array once, rather re-allocating 4000 times
-         * for a 4000-line program listing, while avoiding
-         * letting calls like '#xxx 1 999999 program_getlines'
-         * taking up tones of memory.
-         */
-        int i, count;
-        /* current line we're iterating over */
-        struct line *curr;
-        /* first line in the program */
-        struct line *first;
-        /* starting line in our segment of the program */
-        struct line *segment;
+    /* we make two passes over our linked list's data,
+        * first we figure out how many lines are
+        * actually there. This is so we only allocate
+        * our array once, rather re-allocating 4000 times
+        * for a 4000-line program listing, while avoiding
+        * letting calls like '#xxx 1 999999 program_getlines'
+        * taking up tones of memory.
+        */
+    int i, count;
+    /* current line we're iterating over */
+    struct line *curr;
+    /* first line in the program */
+    struct line *first;
+    /* starting line in our segment of the program */
+    struct line *segment;
 
-        curr = first = read_program(ref);
+    curr = first = read_program(ref);
 
-        /* find our line */
-        for (i = 1; curr && i < start; i++)
-            curr = curr->next;
-
-        if (!curr) {
-            /* alright, we have no data! */
-            free_prog_text(first);
-            PushArrayRaw(new_array_packed(0, fr->pinning));
-            return;
-        }
-
-        segment = curr;         /* we need to keep this line */
-
-        /* continue our looping */
-        for (; curr && (!end || i < end); i++)
-            curr = curr->next;
-
-        count = i - start + 1;
-
-        if (!curr)              /* back up if needed */
-            count--;
-
-        ary = new_array_packed(count, fr->pinning);
-
-        /*
-         * so we count down from the number of lines we have,
-         * and set our array appropriatly.
-         */
-        for (curr = segment, i = 0; count--; i++, curr = curr->next) {
-            array_set_intkey_strval(&ary, i, curr->this_line);
-        }
-
-        free_prog_text(first);
+    /* find our line */
+    for (i = 1; curr && i < start; i++) {
+        curr = curr->next;
     }
+
+    if (!curr) {
+        /* alright, we have no data! */
+        free_prog_text(first);
+        PushArrayRaw(new_array_packed(0, fr->pinning));
+        return;
+    }
+
+    segment = curr;         /* we need to keep this line */
+
+    /* continue our looping */
+    for (; curr && (!end || i < end); i++) {
+        curr = curr->next;
+    }
+
+    count = i - start + 1;
+
+    if (!curr) {            /* back up if needed */
+        count--;
+    }
+
+    ary = new_array_packed(count, fr->pinning);
+
+    /*
+        * so we count down from the number of lines we have,
+        * and set our array appropriatly.
+        */
+    for (curr = segment, i = 0; count--; i++, curr = curr->next) {
+        array_set_intkey_strval(&ary, i, curr->this_line);
+    }
+
+    free_prog_text(first);
+
     PushArrayRaw(ary);
 }
 
@@ -3782,35 +3754,37 @@ prim_program_setlines(PRIM_PROTOTYPE)
     oper2 = POP();              /* list:Lines */
     oper1 = POP();              /* ref:Program */
 
-    if (mlev < 4)
+    if (mlev < 4) {
         abort_interp("Mucker level 4 or greater required.");
+    }
 
-    if (oper1->type != PROG_OBJECT)
+    if (oper1->type != PROG_OBJECT) {
         abort_interp("Non-object argument. (1)");
+    }
 
-    if (oper2->type != PROG_ARRAY)
+    if (oper2->type != PROG_ARRAY) {
         abort_interp("Non-array argument. (2)");
+    }
 
-    /**
-     * @TODO Combine the next two checks.
-     */
-    if (!valid_object(oper1))
-        abort_interp("Invalid object. (1)");
+    if (!valid_object(oper1) || Typeof(oper1->data.objref) != TYPE_PROGRAM) {
+        abort_interp("Invalid program object. (1)");
+    }
 
-    if (Typeof(oper1->data.objref) != TYPE_PROGRAM)
-        abort_interp("Non-program object. (1)");
-
-    if (oper2->data.array && (oper2->data.array->type != ARRAY_PACKED))
+    if (oper2->data.array && (oper2->data.array->type != ARRAY_PACKED)) {
         abort_interp("Array list type required. (2)");
+    }
 
-    if (!array_is_homogenous(oper2->data.array, PROG_STRING))
+    if (!array_is_homogenous(oper2->data.array, PROG_STRING)) {
         abort_interp("Argument not an array of strings. (2)");
+    }
 
-    if (!controls(ProgUID, oper1->data.objref))
+    if (!controls(ProgUID, oper1->data.objref)) {
         abort_interp("Permission denied.");
+    }
 
-    if (FLAGS(oper1->data.objref) & INTERNAL)
+    if (FLAGS(oper1->data.objref) & INTERNAL) {
         abort_interp("Program already being edited.");
+    }
 
     if (array_first(oper2->data.array, &idx)) {
         do {
@@ -3823,19 +3797,17 @@ prim_program_setlines(PRIM_PROTOTYPE)
             if (prev) {
                 prev->next = ln;
                 ln->prev = prev;
-            } else
+            } else {
                 lines = ln;
+            }
 
             prev = ln;
-        }
-        while (array_next(oper2->data.array, &idx));
+        } while (array_next(oper2->data.array, &idx));
     }
 
     write_program(lines, oper1->data.objref);
-    unparse_object(player, oper1->data.objref, unparse_buf,
-            sizeof(unparse_buf));
-    log_status("PROGRAM SAVED: %s by %s(%d)", unparse_buf,
-            NAME(player), player);
+    unparse_object(player, oper1->data.objref, unparse_buf, sizeof(unparse_buf));
+    log_status("PROGRAM SAVED: %s by %s(%d)", unparse_buf, NAME(player), player);
 
     if (tp_log_programs)
         log_program_text(lines, player, oper1->data.objref);
@@ -3878,25 +3850,33 @@ prim_setlinks_array(PRIM_PROTOTYPE)
     oper2 = POP();              /* arr:Destination(s) */
     oper1 = POP();              /* ref:Source */
 
-    if (oper1->type != PROG_OBJECT)
-        abort_interp("Non-object argument. (1)");
-    if (oper2->type != PROG_ARRAY)
-        abort_interp("Non-array argument. (3)");
+    if (oper1->type != PROG_OBJECT) {
+        abort_interp("Non-object argument. (2)");
+    }
 
-    if (!array_is_homogenous(oper2->data.array, PROG_OBJECT))
+    if (oper2->type != PROG_ARRAY) {
+        abort_interp("Non-array argument. (1)");
+    }
+
+    if (!array_is_homogenous(oper2->data.array, PROG_OBJECT)) {
         abort_interp("Argument not an array of dbrefs. (2)");
+    }
 
-    if (!valid_object(oper1))
+    if (!valid_object(oper1)) {
         abort_interp("Invalid object. (1)");
+    }
 
-    if ((mlev < 4) && !permissions(ProgUID, oper1->data.objref))
+    if ((mlev < 4) && !permissions(ProgUID, oper1->data.objref)) {
         abort_interp("Permission denied. (1)");
+    }
 
-    if ((dest_count = (size_t)array_count(oper2->data.array)) >= MAX_LINKS)
+    if ((dest_count = (size_t)array_count(oper2->data.array)) >= MAX_LINKS) {
         abort_interp("Too many destinations. (2)");
+    }
 
-    if ((dest_count > 1) && (Typeof(oper1->data.objref) != TYPE_EXIT))
-        abort_interp("Only exit may be linked to multiple destinations.");
+    if ((dest_count > 1) && (Typeof(oper1->data.objref) != TYPE_EXIT)) {
+        abort_interp("Only exits may be linked to multiple destinations.");
+    }
 
     what = oper1->data.objref;
     arr = oper2->data.array;
@@ -3909,19 +3889,20 @@ prim_setlinks_array(PRIM_PROTOTYPE)
             dbref where = val->data.objref;
 
             if ((where != HOME) && (where != NIL) && !valid_object(val)) {
-                    CLEAR(&idx);
+                CLEAR(&idx);
                 abort_interp("Invalid object. (2)");
             }
 
             if (!prog_can_link_to(mlev, ProgUID, Typeof(what), where)) {
-                    CLEAR(&idx);
+                CLEAR(&idx);
                 abort_interp("Can't link source to destination. (2)");
             }
 
             switch (Typeof(what)) {
                 case TYPE_EXIT:
-                    if (where == NIL)
+                    if (where == NIL) {
                         break;
+                    }
 
                     switch (Typeof(where)) {
                         case TYPE_PLAYER:
@@ -3929,8 +3910,8 @@ prim_setlinks_array(PRIM_PROTOTYPE)
                         case TYPE_PROGRAM:
                             if (found_prp != 0) {
                                 CLEAR(&idx);
-                               abort_interp("Only one player, room, or "
-                                       "program destination allowed.");
+                                abort_interp("Only one player, room, or "
+                                        "program destination allowed.");
                             }
 
                             found_prp = 1;
@@ -3982,8 +3963,9 @@ prim_setlinks_array(PRIM_PROTOTYPE)
     }
 
     if (Typeof(what) == TYPE_EXIT) {
-        if (MLevRaw(what))
+        if (MLevRaw(what)) {
             SetMLevel(what, 0);
+        }
 
         free(DBFETCH(what)->sp.exit.dest);
     }
@@ -4017,10 +3999,10 @@ prim_setlinks_array(PRIM_PROTOTYPE)
                     unsigned int i = 0;
 
                     do {
-                        if (i < dest_count)
+                        if (i < dest_count) {
                             dests[i++] = array_getitem(arr, &idx)->data.objref;
-                    }
-                    while (array_next(arr, &idx));
+                        }
+                    }  while (array_next(arr, &idx));
                 }
 
                 DBSTORE(what, sp.exit.ndest, dest_count);
@@ -4030,24 +4012,21 @@ prim_setlinks_array(PRIM_PROTOTYPE)
 
             case TYPE_ROOM:
                 if (array_first(arr, &idx)) {
-                    DBSTORE(what, sp.room.dropto,
-                            array_getitem(arr, &idx)->data.objref);
+                    DBSTORE(what, sp.room.dropto, array_getitem(arr, &idx)->data.objref);
                     CLEAR(&idx);
                 }
                 break;
 
             case TYPE_PLAYER:
                 if (array_first(arr, &idx)) {
-                    PLAYER_SET_HOME(what,
-                            array_getitem(arr, &idx)->data.objref);
+                    PLAYER_SET_HOME(what, array_getitem(arr, &idx)->data.objref);
                     CLEAR(&idx);
                 }
                 break;
 
             case TYPE_THING:
                 if (array_first(arr, &idx)) {
-                    THING_SET_HOME(what,
-                            array_getitem(arr, &idx)->data.objref);
+                    THING_SET_HOME(what, array_getitem(arr, &idx)->data.objref);
                     CLEAR(&idx);
                 }
                 break;
@@ -4080,6 +4059,8 @@ prim_setlinks_array(PRIM_PROTOTYPE)
 void
 prim_supplicant(PRIM_PROTOTYPE)
 {
+    dbref ref;
+
     CHECKOP(0);
 
     ref = fr->supplicant;
@@ -4105,29 +4086,32 @@ prim_supplicant(PRIM_PROTOTYPE)
 void
 prim_pname_history(PRIM_PROTOTYPE)
 {
+    dbref ref;
     stk_array *nu;
     struct inst temp1, temp2;
     PropPtr propadr, pptr;
-    char propname[BUFFER_LEN];
 
     CHECKOP(1);
     oper1 = POP();
 
-    if (mlev < 4)
+    if (mlev < 4) {
         abort_interp("Permission denied.  Requires Wizbit.");
+    }
 
-    if (!valid_player(oper1))
+    if (!valid_player(oper1)) {
         abort_interp("Non-player argument (1).");
+    }
 
-    if ((nu = new_array_dictionary(fr->pinning)) == NULL)
+    if ((nu = new_array_dictionary(fr->pinning)) == NULL) {
         abort_interp("Out of memory");
+    }
 
     ref = oper1->data.objref;
 
     if (tp_pname_history_reporting) {
+        char propname[BUFFER_LEN];
         propadr = first_prop(ref, PNAME_HISTORY_PROPDIR, &pptr, propname,
                 sizeof(propname));
-
 
         while (propadr) {
             temp1.type = PROG_STRING;
@@ -4144,9 +4128,8 @@ prim_pname_history(PRIM_PROTOTYPE)
         }
     }
 
-    /**
-     * @TODO CLEAR(oper1);
-     */
+    CLEAR(oper1);
+
     PushArrayRaw(nu);
 }
 
@@ -4175,8 +4158,9 @@ void prim_dump(PRIM_PROTOTYPE)
 {
     int result;
 
-    if (mlev < 4)
+    if (mlev < 4) {
         abort_interp("Permission denied.  Requires Wizbit.");
+    }
 
 #ifndef DISKBASE
     /* Are we already dumping? */
@@ -4192,4 +4176,3 @@ void prim_dump(PRIM_PROTOTYPE)
     result = 1;
     PushInt(result);
 }
-

--- a/src/p_error.c
+++ b/src/p_error.c
@@ -197,7 +197,7 @@ prim_clear_error(PRIM_PROTOTYPE)
         }
     } else {
         char buf[BUFFER_LEN];
-        snprintf(buf, sizeof(buf), DoNullInd(oper1->data.string));
+        snprintf(buf, sizeof(buf), "%s", DoNullInd(oper1->data.string));
 
         for (int i = 0; i < ERROR_NUM; i++) {
             if (!strcasecmp(buf, err_defs[i].error_name)) {
@@ -262,7 +262,7 @@ prim_set_error(PRIM_PROTOTYPE)
         }
     } else {
         char buf[BUFFER_LEN];
-        snprintf(buf, sizeof(buf), DoNullInd(oper1->data.string));
+        snprintf(buf, sizeof(buf), "%s", DoNullInd(oper1->data.string));
 
         for (int i = 0; i < ERROR_NUM; i++) {
             if (!strcasecmp(buf, err_defs[i].error_name)) {
@@ -324,7 +324,7 @@ prim_is_set(PRIM_PROTOTYPE)
         }
     } else {
         char buf[BUFFER_LEN];
-        snprintf(buf, sizeof(buf), DoNullInd(oper1->data.string));
+        snprintf(buf, sizeof(buf), "%s", DoNullInd(oper1->data.string));
 
         for (int i = 0; i < ERROR_NUM; i++) {
             if (!strcasecmp(buf, err_defs[i].error_name)) {
@@ -384,7 +384,7 @@ prim_error_str(PRIM_PROTOTYPE)
         }
     } else {
         char buf[BUFFER_LEN];
-        snprintf(buf, sizeof(buf), DoNullInd(oper1->data.string));
+        snprintf(buf, sizeof(buf), "%s", DoNullInd(oper1->data.string));
 
         for (int i = 0; i < ERROR_NUM; i++) {
             if (!strcasecmp(buf, err_defs[i].error_name)) {
@@ -498,7 +498,7 @@ prim_error_bit(PRIM_PROTOTYPE)
 
     if (oper1->data.string) {
         char buf[BUFFER_LEN];
-        snprintf(buf, sizeof(buf), oper1->data.string->data);
+        snprintf(buf, sizeof(buf), "%s", oper1->data.string->data);
 
         for (int i = 0; i < ERROR_NUM; i++) {
             if (!strcasecmp(buf, err_defs[i].error_name)) {

--- a/src/set.c
+++ b/src/set.c
@@ -516,9 +516,8 @@ do_chown(int descr, dbref player, const char *name, const char *newowner)
  * Determines if a given player is unable to (re)set the given flag
  *
  * The 'business logic' here is actually fairly dense and not easily
- * summed up in a comment.  As this is a 'private' function, the
- * reader is encouraged to review the very well documented code for
- * details.
+ * summed up in a comment. The reader is encouraged to review the very
+ * well documented code for details.
  *
  * This is all pretty well documented in the MUCK's help files.
  *

--- a/src/set.c
+++ b/src/set.c
@@ -513,7 +513,7 @@ do_chown(int descr, dbref player, const char *name, const char *newowner)
 }
 
 /**
- * Determines if a given player is restricted from setting a given flag
+ * Determines if a given player is unable to (re)set the given flag
  *
  * The 'business logic' here is actually fairly dense and not easily
  * summed up in a comment.  As this is a 'private' function, the
@@ -522,75 +522,151 @@ do_chown(int descr, dbref player, const char *name, const char *newowner)
  *
  * This is all pretty well documented in the MUCK's help files.
  *
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
+ *
  * @private
- * @param player the player we are checking permissions for
- * @param thing the thing we want to set the flag on
- * @param flag the flag we wish to set.
+ * @param player the effective aplayer we are checking permissions for
+ * @param mlev the effective mucker level we are checking permissions for
+ * @param thing the thing we want to interact with
+ * @param flag the flag we wish to interact with
+ * @param value whether the desired state is on or off
+ * @param error[out] error message, if any
  * @return boolean 1 if restricted from setting flag, 0 if okay to set.
  */
-static int
-restricted(dbref player, dbref thing, object_flag_type flag)
+int
+unable_to_set_flag(dbref player, int mlev, dbref thing, object_flag_type flag, bool value, char *error)
 {
+    if (force_level && (
+            flag == WIZARD
+            || (flag == XFORCIBLE && Typeof(thing) != TYPE_EXIT)
+            || (flag & MUCKER)
+            || (flag & SMUCKER)
+    )) {
+        snprintf(error, SMALL_BUFFER_LEN, "That flag cannot be forced.");
+        return 1;
+    }
+
+    /* Non-wizards can only set their own programs M0. */
+    if (!value && (flag & (MUCKER | SMUCKER))) {
+        if (!Wizard(OWNER(player))) {
+            if ((OWNER(player) != OWNER(thing)) || (Typeof(thing) != TYPE_PROGRAM)) {
+                snprintf(error, SMALL_BUFFER_LEN, "Permission denied. (You can't set that M0)");
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    /* Non-wizards can only set their programs up to their own mucker level. */
+    if (flag & (MUCKER | SMUCKER)) {
+        unsigned short requested_mlevel = (((flag & MUCKER ? 2 : 0) + (flag & SMUCKER ? 1 : 0)));
+        if (!Wizard(OWNER(player))) {
+            if ((OWNER(player) != OWNER(thing)) || (Typeof(thing) != TYPE_PROGRAM)
+                || (MLevRaw(player) < requested_mlevel)) {
+                snprintf(error, SMALL_BUFFER_LEN, "Permission denied. (You can't set that M%d)", requested_mlevel);
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
     switch (flag) {
         case ABODE:
             /* Trying to set a program AUTOSTART requires TrueWizard */
             return (!TrueWizard(OWNER(player)) && (Typeof(thing) == TYPE_PROGRAM));
+
         case GUEST:
             /* Guest operations require a wizard */
             return (!(Wizard(OWNER(player))));
+
         case YIELD:
-            /* Mucking with the env-chain matching requires TrueWizard */
-            return (!(Wizard(OWNER(player))));
         case OVERT:
             /* Mucking with the env-chain matching requires TrueWizard */
-            return (!(Wizard(OWNER(player))));
+            if (!(Wizard(OWNER(player)))) {
+                return 1;
+            }
+
+            /* ...and only for makes sense for things or rooms. */
+            if (Typeof(thing) != TYPE_THING && Typeof(thing) != TYPE_ROOM) {
+                return 1;
+            }
+
+            return 0;
+
         case ZOMBIE:
             /* Restricting a player from using zombies requires a wizard. */
-            if (Typeof(thing) == TYPE_PLAYER)
+            if (Typeof(thing) == TYPE_PLAYER) {
                 return (!(Wizard(OWNER(player))));
+            }
+
             /* If a player's set Zombie, he's restricted from using them...
              * unless he's a wizard, in which case he can do whatever.
              */
-            if ((Typeof(thing) == TYPE_THING) && (FLAGS(OWNER(player)) & ZOMBIE))
+            if ((Typeof(thing) == TYPE_THING) && (FLAGS(OWNER(player)) & ZOMBIE)) {
                 return (!(Wizard(OWNER(player))));
+            }
 
-            return (0);
+            return 0;
+
         case VEHICLE:
             /* Restricting a player from using vehicles requires a wizard. */
-            if (Typeof(thing) == TYPE_PLAYER)
+            if (Typeof(thing) == TYPE_PLAYER){
                 return (!(Wizard(OWNER(player))));
+            }
+
+            /* Can only set things !V if they have no players in them. */
+            if (!value && Typeof(thing) == TYPE_THING) {
+                dbref obj = CONTENTS(thing);
+
+                for (; obj != NOTHING; obj = NEXTOBJ(obj)) {
+                    if (Typeof(obj) == TYPE_PLAYER) {
+                        snprintf(error, SMALL_BUFFER_LEN, "That vehicle still has players in it!");
+                        return 1;
+                    }
+                }
+            }
 
             /* If only wizards can create vehicles... */
             if (tp_wiz_vehicles) {
                 /* then only a wizard can create a vehicle. :) */
-                if (Typeof(thing) == TYPE_THING)
+                if (Typeof(thing) == TYPE_THING) {
                     return (!(Wizard(OWNER(player))));
+                }
             } else {
                 /* But, if vehicles aren't restricted to wizards, then
                  * players who have not been restricted can do so
                  */
-                if ((Typeof(thing) == TYPE_THING) && (FLAGS(player) & VEHICLE))
+                if ((Typeof(thing) == TYPE_THING) && (FLAGS(player) & VEHICLE)) {
                     return (!(Wizard(OWNER(player))));
+                }
             }
 
             return (0);
+
         case DARK:
             /* Dark can be set on a Program or Room by anyone. */
             if (!Wizard(OWNER(player))) {
                 /* Setting a player dark requires a wizard. */
-                if (Typeof(thing) == TYPE_PLAYER)
-                    return (1);
+                if (Typeof(thing) == TYPE_PLAYER) {
+                    return 1;
+                }
 
                 /* If exit darking is restricted, it requires a wizard. */
-                if (!tp_exit_darking && Typeof(thing) == TYPE_EXIT)
-                    return (1);
+                if (!tp_exit_darking && Typeof(thing) == TYPE_EXIT) {
+                    return 1;
+                }
 
                 /* If thing darking is restricted, it requires a wizard. */
-                if (!tp_thing_darking && Typeof(thing) == TYPE_THING)
-                    return (1);
+                if (!tp_thing_darking && Typeof(thing) == TYPE_THING) {
+                    return 1;
+                }
             }
 
-            return (0);
+            return 0;
+
         case QUELL:
 #ifdef GOD_PRIV
             /* Only God (or God's stuff) can quell or unquell another wizard. */
@@ -600,53 +676,27 @@ restricted(dbref player, dbref thing, object_flag_type flag)
             /* You cannot quell or unquell another wizard. */
             return (TrueWizard(thing) && (thing != player) && (Typeof(thing) == TYPE_PLAYER));
 #endif
-        /* The following three cases aren't used, as far as I can tell, but
-         * for consistency's sake let's make sure they reflect the documented
-         * behaviors:
-         */
-        case MUCKER:
-            /* Setting a program M2 is limited to players of at least M2. */
-            if (Typeof(thing) == TYPE_PROGRAM)
-                return (MLevel(OWNER(player)) < 2);
 
-            /* Setting anything else M2 takes a wizard. */
-            return (!Wizard(OWNER(player)));
-        case SMUCKER:
-            /* Setting a program M1 is limited to players of at least M1. */
-            if (Typeof(thing) == TYPE_PROGRAM)
-                return (MLevel(OWNER(player)) < 1);
-
-            /* Setting anything else M1 takes a wizard. */
-            return (!Wizard(OWNER(player)));
-        case (SMUCKER | MUCKER):
-            /* Setting a program M3 is limited to players of at least M3. */
-
-            if (Typeof(thing) == TYPE_PROGRAM)
-                return (MLevel(OWNER(player)) < 3);
-
-            /* Setting anything else M3 takes a wizard. */
-            return (!Wizard(OWNER(player)));
         case BUILDER:
-            /* Setting a program Bound causes any function called therein to be
-             * put in preempt mode, regardless of the mode it had before.
-             * Since this is just a convenience for atomic-functionwriters,
-             * why is it limited to only a Wizard? -winged
-             */
-            /* That's a very good question! Let's limit it to players of at
-             * least M2 instead. -aidanPB
-             */
-            if (Typeof(thing) == TYPE_PROGRAM)
-                return (MLevel(OWNER(player)) < 2);
+            /* Setting a program BOUND reguires M2. */
+            if (Typeof(thing) == TYPE_PROGRAM) {
+                return (mlev < 2);
+            }
 
             /* Setting a player Builder or a room Bound is limited to a Wizard. */
             return (!Wizard(OWNER(player)));
+
         case WIZARD:
             /* To do anything with a Wizard flag requires a Wizard. */
             if (Wizard(OWNER(player))) {
+                /* check for stupid wizard */
+                if (!value && thing == player) {
+                    snprintf(error, SMALL_BUFFER_LEN, "You cannot make yourself mortal.");
+                    return 1;
+                }
+
 #ifdef GOD_PRIV
-                /* ...but only God can make a player a Wizard, or re-mort
-                 * one.
-                 */
+                /* Only God can make a player a Wizard, or re-mort one. */
                 return ((Typeof(thing) == TYPE_PLAYER) && !God(player));
 #else
                 /* We don't want someone setting themselves !W, to prevent
@@ -654,8 +704,13 @@ restricted(dbref player, dbref thing, object_flag_type flag)
                  */
                 return ((Typeof(thing) == TYPE_PLAYER && thing == OWNER(player)));
 #endif
-            } else
+            } else {
                 return 1;
+            }
+
+        case XFORCIBLE:
+            return (!Wizard(OWNER(player)) && Typeof(thing) == TYPE_EXIT);
+
         default:
             /* No other flags are restricted. */
             return 0;
@@ -688,6 +743,7 @@ do_set(int descr, dbref player, const char *name, const char *flag)
     dbref thing;
     const char *p;
     object_flag_type f;
+    char error[SMALL_BUFFER_LEN] = "";
 
     /* find thing */
     if ((thing = match_controlled(descr, player, name)) == NOTHING)
@@ -787,200 +843,68 @@ do_set(int descr, dbref player, const char *name, const char *flag)
         return;
     }
 
+    bool negated = (*flag == NOT_TOKEN);
 
     if (ISGUEST(player) &&
-           (!Wizard(player) || *flag != NOT_TOKEN || !string_prefix("GUEST", p))) {
+           (!Wizard(player) || !negated || !string_prefix("GUEST", p))) {
         notifyf_nolisten(player, "Guests are not allowed to @set.");
         return;
     }
 
-    /* identify flag */
-
-    /*
-     * @TODO: This gnarly 'if' statement should probably be a function that
-     * takes a flag string and converts it to a flag.  The exception
-     * being the MUCKER flags which are a little tricky.
-     *
-     * So if (matches MUCKER bits) run existing code, else
-     * flag = get_flag_from_string( ... )
-     *
-     * The SET prim should use the same function because this logic is
-     * currently duplicated over there.
-     */
     if (*p == '\0') {
         notify(player, "You must specify a flag to set.");
         return;
-    } else if ((!strcasecmp("0", p) || !strcasecmp("M0", p)) ||
-               ((string_prefix("MUCKER", p)) && (*flag == NOT_TOKEN))) {
-        if (!Wizard(OWNER(player))) {
-            if ((OWNER(player) != OWNER(thing)) || (Typeof(thing) != TYPE_PROGRAM)) {
-                notify(player, "Permission denied. (You can't clear that mucker flag)");
-                return;
-            }
-        }
+    }
 
-        if (force_level) {
-            notify(player, "Can't set this flag from an @force or {force}.");
-            return;
-        }
-
-        SetMLevel(thing, 0);
-        notify(player, "Mucker level set.");
-        return;
-    } else if (!strcasecmp("1", p) || !strcasecmp("M1", p)) {
-        if (!Wizard(OWNER(player))) {
-            if ((OWNER(player) != OWNER(thing)) || (Typeof(thing) != TYPE_PROGRAM)
-                || (MLevRaw(player) < 1)) {
-                notify(player, "Permission denied. (You may not set that M1)");
-                return;
-            }
-        }
-
-        if (force_level) {
-            notify(player, "Can't set this flag from an @force or {force}.");
-            return;
-        }
-
-        SetMLevel(thing, 1);
-        notify(player, "Mucker level set.");
-        return;
-    } else if ((!strcasecmp("2", p) || !strcasecmp("M2", p)) ||
-                ((string_prefix("MUCKER", p)) && (*flag != NOT_TOKEN))) {
-        if (!Wizard(OWNER(player))) {
-            if ((OWNER(player) != OWNER(thing)) || (Typeof(thing) != TYPE_PROGRAM)
-                || (MLevRaw(player) < 2)) {
-                notify(player, "Permission denied. (You may not set that M2)");
-                return;
-            }
-        }
-
-        if (force_level) {
-            notify(player, "Can't set this flag from an @force or {force}.");
-            return;
-        }
-
-        SetMLevel(thing, 2);
-        notify(player, "Mucker level set.");
-        return;
-    } else if (!strcasecmp("3", p) || !strcasecmp("M3", p)) {
-        if (!Wizard(OWNER(player))) {
-            if ((OWNER(player) != OWNER(thing)) || (Typeof(thing) != TYPE_PROGRAM)
-                || (MLevRaw(player) < 3)) {
-                notify(player, "Permission denied. (You may not set that M3)");
-                return;
-            }
-        }
-
-        if (force_level) {
-            notify(player, "Can't set this flag from an @force or {force}.");
-            return;
-        }
-
-        SetMLevel(thing, 3);
-        notify(player, "Mucker level set.");
-        return;
-    } else if (!strcasecmp("4", p) || !strcasecmp("M4", p)) {
+    if (!strcmp("4", p) || !strcasecmp("M4", p)) {
         notify(player, "To set Mucker Level 4, set the Wizard bit and another Mucker bit.");
         return;
-    } else if (string_prefix("WIZARD", p)) {
-        if (force_level) {
-            notify(player, "Can't set this flag from an @force or {force}.");
-            return;
-        }
+    }
 
-        f = WIZARD;
-    } else if (string_prefix("ZOMBIE", p)) {
-        f = ZOMBIE;
-    } else if (string_prefix("VEHICLE", p)
-                || string_prefix("VIEWABLE", p)) {
-        if (*flag == NOT_TOKEN && Typeof(thing) == TYPE_THING) {
-            dbref obj = CONTENTS(thing);
-
-            for (; obj != NOTHING; obj = NEXTOBJ(obj)) {
-                if (Typeof(obj) == TYPE_PLAYER) {
-                    notify(player, "That vehicle still has players in it!");
-                    return;
-                }
-            }
-        }
-
-        f = VEHICLE;
-    } else if (string_prefix("LINK_OK", p)) {
-        f = LINK_OK;
-    } else if (string_prefix("XFORCIBLE", p) || string_prefix("XPRESS", p)) {
-        if (force_level) {
-            notify(player, "Can't set this flag from an @force or {force}.");
-            return;
-        }
-
-        if (Typeof(thing) == TYPE_EXIT) {
-            if (!Wizard(OWNER(player))) {
-                notify(player,
-                       "Permission denied. (Only a Wizard may set the M-level of an exit)");
-                return;
-            }
-        }
-
-        f = XFORCIBLE;
-    } else if (string_prefix("KILL_OK", p)) {
-        f = KILL_OK;
-    } else if ((string_prefix("DARK", p)) || (string_prefix("DEBUG", p))) {
-        f = DARK;
-    } else if ((string_prefix("STICKY", p)) || (string_prefix("SETUID", p)) ||
-                (string_prefix("SILENT", p))) {
-        f = STICKY;
-    } else if (string_prefix("QUELL", p)) {
-        f = QUELL;
-    } else if (string_prefix("BUILDER", p) || string_prefix("BOUND", p)) {
-        f = BUILDER;
-    } else if (string_prefix("CHOWN_OK", p) || string_prefix("COLOR", p)) {
-        f = CHOWN_OK;
-    } else if (string_prefix("JUMP_OK", p)) {
-        f = JUMP_OK;
-    } else if (string_prefix("GUEST", p)) {
-        f = GUEST;
-    } else if (string_prefix("HAVEN", p) || string_prefix("HARDUID", p)) {
-        f = HAVEN;
-    } else if ((string_prefix("ABODE", p)) ||
-               (string_prefix("AUTOSTART", p)) || (string_prefix("ABATE", p))) {
-        f = ABODE;
-    } else if (string_prefix("YIELD", p)) {
-        f = YIELD;
-    } else if (string_prefix("OVERT", p)) {
-        f = OVERT;
+    if ((!strcasecmp("0", p) || !strcasecmp("M0", p)) ||
+               ((string_prefix("MUCKER", p)) && (negated))) {
+        f = MUCKER | SMUCKER;
+        negated = true;
+    } else if (!strcasecmp("1", p) || !strcasecmp("M1", p)) {
+        f = SMUCKER;
+    } else if ((!strcasecmp("2", p) || !strcasecmp("M2", p)) ||
+                ((string_prefix("MUCKER", p)) && (!negated))) {
+        f = MUCKER;
+    } else if (!strcasecmp("3", p) || !strcasecmp("M3", p)) {
+        f = MUCKER | SMUCKER;
     } else {
-        notify(player, "I don't recognize that flag.");
+        f = str_to_flag(p);
+        if (!f || string_prefix("TRUEWIZARD", p) || string_prefix("NUCKER", p)) {
+            notify(player, "I don't recognize that flag.");
+            return;
+        }
+    }
+
+    if (unable_to_set_flag(player, MLevel(OWNER(player)), thing, f, !negated, error)) {
+        if (*error) {
+            notify(player, error);
+        } else {
+            notify(player, "Permission denied. (restricted flag)");
+        }
+
         return;
     }
 
-    /* check for restricted flag */
-    if (restricted(player, thing, f)) {
-        notify(player, "Permission denied. (restricted flag)");
-        return;
+    if ((f & MUCKER) || (f & SMUCKER)) {
+        FLAGS(thing) &= ~(MUCKER | SMUCKER);
     }
 
-    /* check for stupid wizard */
-    if (f == WIZARD && *flag == NOT_TOKEN && thing == player) {
-        notify(player, "You cannot make yourself mortal.");
-        return;
-    }
-
-    /* else everything is ok, do the set */
-    if (*flag == NOT_TOKEN) {
-        /* reset the flag */
-        ts_modifyobject(thing);
+    if (negated) {
         FLAGS(thing) &= ~f;
-        DBDIRTY(thing);
-
-        notify(player, "Flag reset.");
     } else {
-        /* set the flag */
-        ts_modifyobject(thing);
         FLAGS(thing) |= f;
-        DBDIRTY(thing);
-
-        notify(player, "Flag set.");
     }
+
+    notifyf(player, "%s %s.", ((f & MUCKER) || (f & SMUCKER)) ? "Mucker level" : "Flag",
+            negated ? "reset" : "set");
+
+    ts_modifyobject(thing);
+    DBDIRTY(thing);
 }
 
 /**


### PR DESCRIPTION
This addresses p_db.c issues by refactoring sanity checks, moving variables to required scope, and moves to brace-required style for control flow. Please let me know if any of this has unexpectedly modified the logic.

**More errors about errors**

Recent use of snprintf for error messages (and a few stack items) should no longer produce a warning.

**Consistency Crusade** (let me know if these don't make sense to do)
- `ENTRANCES_ARRAY` now requires mlev 3, since `NEXTENTRANCE` does.
- `RMATCH` now strips ansi, since `MATCH` does.

**Need Input**
- Asking for the link of program objects gives an error. A previous maintainer suggested that programs would be implicitly linked to their owner. I could extend that to say that this "home" would be set at creation, and only modifiable through the `@chown` process. Is this a good idea?
- `CONTENTS` can return a different object for mlev 1 (no dark or non-controlled object). It doesn't seem that `CONTENTS_ARRAY` has this restriction. Should it only return a limited array for mlev 1?

**The stage is `SET`**

This PR features the start of a flag-setting refactor. This may have ended up as mostly moving code around, but there were a LOT of iterations and testing involved. Please check to see I haven't inadvertently prevented or allowed something that I shouldn't have.

Both `SET` and `@set` now call the "unable_to_set_flag" function, which takes the old restricted() function and adds some checks that hadn't been addressed in both processes. Specifically:
- `@set` should now ensure that the OVERT and YIELD flags are only (re)set on players and things.
- `SET` should now respect the force restrictions for interacting with MUCKER/NUCKER bits and should not allow wizards to make themselves mortal.

Interaction between players/programs and MUCKER/NUCKER bits were carefully considered with this refactor, but I may have missed something. Please review and test this logic.

**Still TODO**
- Unifying name-set, owner-set, recycling, link-resolution, and link-set logic between primitives and server commands sounds like a good idea.
- Documenting the use of the object timestamp functions should lead to a better understanding of when and why these are, or should be, used. I'll add an Issue for this soon.