### PR TITLE
Fix lib-editor's "invalid line" error logic.

### DIFF
--- a/dbs/starterdb/muf/18.m
+++ b/dbs/starterdb/muf/18.m
@@ -97,7 +97,7 @@ $include $lib/strings
     then then then
  
     (max line)
-    dup 1 < if pop 1
+    dup 1 < if pop pop 1
     else
         swap 1 + over over
         > if swap then pop

--- a/include/p_db.h
+++ b/include/p_db.h
@@ -969,10 +969,9 @@ void prim_newprogram(PRIM_PROTOTYPE);
 /**
  * Implementation of MUF CONTENTS_ARRAY
  *
- * Consumes a dbref, and returns an array of its contents.  Requires
- * remote-read permissions when applicable.
- *
- * Unlike prim_contents, this has no MUCKER level 1 restrictions.
+ * Consumes a dbref, and returns an array of its contents. Only returns
+ * controlled non-DARK objects for MUCKER level 1. Requires remote-read
+ * permissions when applicable.
  *
  * @param player the player running the MUF program
  * @param program the program being run

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -451,8 +451,8 @@ prim_contents(PRIM_PROTOTYPE)
         abort_interp("Invalid argument type.");
     }
 
+    CHECKREMOTE(oper1->data.objref);
     ref = CONTENTS(oper1->data.objref);
-    CHECKREMOTE(ref);
 
     while (mlev < 2 && ref != NOTHING && (FLAGS(ref) & DARK) && !controls(ProgUID, ref)) {
         ref = NEXTOBJ(ref);
@@ -3345,10 +3345,9 @@ prim_getpidinfo(PRIM_PROTOTYPE)
 /**
  * Implementation of MUF CONTENTS_ARRAY
  *
- * Consumes a dbref, and returns an array of its contents.  Requires
- * remote-read permissions when applicable.
- *
- * Unlike prim_contents, this has no MUCKER level 1 restrictions.
+ * Consumes a dbref, and returns an array of its contents. Only returns
+ * controlled non-DARK objects for MUCKER level 1. Requires remote-read
+ * permissions when applicable.
  *
  * @param player the player running the MUF program
  * @param program the program being run
@@ -3382,12 +3381,20 @@ prim_contents_array(PRIM_PROTOTYPE)
     CHECKREMOTE(oper1->data.objref);
 
     for (ref = CONTENTS(oper1->data.objref); ObjExists(ref); ref = NEXTOBJ(ref)) {
+        if (mlev < 2 && ref != NOTHING && (FLAGS(ref) & DARK) && !controls(ProgUID, ref)) {
+            continue;
+        }
+
         count++;
     }
 
     nw = new_array_packed(count, fr->pinning);
 
     for (ref = CONTENTS(oper1->data.objref), count = 0; ObjExists(ref); ref = NEXTOBJ(ref)) {
+        if (mlev < 2 && ref != NOTHING && (FLAGS(ref) & DARK) && !controls(ProgUID, ref)) {
+            continue;
+        }
+
         array_set_intkey_refval(&nw, count++, ref);
     }
 


### PR DESCRIPTION
I think this one line fix is all that is needed. lib-editor already had the error logic, but seemed to not clear enough off the stack.

This seems like it works, but please test any uncommon lsedit command patterns if desired.

I'll update fuzzball-muf if this is approved.

Would close #610.