### PR TITLE
Fix for buffer overflow issue #728

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -123,7 +123,17 @@ check_password(dbref player, const char *password)
         }
     }
 
-    if (!strcmp(pword, processed))
+    /*
+     * There was a bug where the password hash was causing a buffer
+     * overflow.  Some compilers apparently cover this up or smooth
+     * this over in some fashion which means it is an inconsistent
+     * overflow.
+     *
+     * By matching by the length of 'processed', we'll be able to
+     * support any old "too long" hashes that may have slipped into
+     * the system.
+     */
+    if (!strncmp(pword, processed, strlen(processed)))
         return 1;
 
     return 0;


### PR DESCRIPTION
This resolves #728 

This works without an issue with my compiler, which is why I didn't catch it.  Since some folks may be already running this version with the password problem, and thus have 128 character instead of 127 character passwords, I made sure the password check mechanism will check based on the length of the hash.