### PR TITLE
Clean up older timed-read logic.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.7"
-
 services:
   fbmuck:
     build:


### PR DESCRIPTION
With fb6.0a33, TREAD was re-coded as an in-server macro.

```
TREAD ( i -- s i )
  
  Acts like a timed READ call.  If the user does not provide input within
the given number of seconds, the READ call will time-out and return a
false boolean, otherwise it returns a true boolean and the string value
entered.  This is implemented as an in-server macro as follows:
    "__tread" timer_start { "TIMER.__tread" "READ" }list event_waitfor
    swap pop "READ" strcmp if "" 0 else read 1 "__tread" timer_stop then
```
    
The older logic was never removed. This PR does that.

It also removes "version" from docker-compose.yml since that is apparently deprecated.