### PR TITLE
Refactor stats logic to use a common function.

### DIFF
--- a/include/db.h
+++ b/include/db.h
@@ -1860,6 +1860,50 @@ extern dbref db_top;
 extern int recyclable;
 
 /**
+ * Clear a DB object
+ *
+ * This will take a ref and zero out the object, making it suitable for
+ * use (or reuse, in the case of recycled garbage).
+ *
+ * This does NOT clear out memory, so you SHOULD NOT use clear out an
+ * object with allocated memory -- this should only be used with objects
+ * that are brand new (i.e. freshly allocated) or that have been totally
+ * cleaned out already (garbage).
+ *
+ * Flags must be initialized after this is called.  Also, type-specific
+ * fields must also be initialized.  The object is not set dirty by this.
+ *
+ * @param i the dbref of the object to clear out.
+ */
+void db_clear_object(dbref i);
+
+/**
+ * Clones a thing.
+ *
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
+ *
+ * @param thing the thing to clone
+ * @param player the player for determining the cloned thing's home
+ * @param copy_hidden_props if true, this copies hidden properties
+ * @param[out] error why the create failed
+ * @return the dbref of the cloned thing, or NOTHING if it failed.
+ */
+dbref clone_thing(dbref thing, dbref player, int copy_hidden_props, char *error);
+
+/**
+ * Helper function to collect object statistics.
+ *
+ * Populates the stats array with counts of owned objects: total, rooms, exits,
+ * things, programs, players, and garbage.
+ *
+ * @param player the player running the command
+ * @param ref the player dbref to query (or NOTHING for MUCK-wide stats)
+ * @param stats output array for the statistics
+ */
+void collect_dbstats(dbref player, dbref ref, int stats[7]);
+
+/**
  * Determine if 'who' controls object 'what'
  *
  * The logic here is relatively simple.  If 'what' is invalid, return
@@ -1967,38 +2011,6 @@ dbref create_room(dbref player, const char *name, dbref parent, char *error);
  * @return the dbref of the new thing, or NOTHING if it failed.
  */
 dbref create_thing(dbref player, const char *name, dbref location, char *error);
-
-/**
- * Clones a thing.
- *
- * Uses an error parameter to communicate the reason for failure. This
- * should be at least SMALL_BUFFER_LEN in size.
- *
- * @param thing the thing to clone
- * @param player the player for determining the cloned thing's home
- * @param copy_hidden_props if true, this copies hidden properties
- * @param[out] error why the create failed
- * @return the dbref of the cloned thing, or NOTHING if it failed.
- */
-dbref clone_thing(dbref thing, dbref player, int copy_hidden_props, char *error);
-
-/**
- * Clear a DB object
- *
- * This will take a ref and zero out the object, making it suitable for
- * use (or reuse, in the case of recycled garbage).
- *
- * This does NOT clear out memory, so you SHOULD NOT use clear out an
- * object with allocated memory -- this should only be used with objects
- * that are brand new (i.e. freshly allocated) or that have been totally
- * cleaned out already (garbage).
- *
- * Flags must be initialized after this is called.  Also, type-specific
- * fields must also be initialized.  The object is not set dirty by this.
- *
- * @param i the dbref of the object to clear out.
- */
-void db_clear_object(dbref i);
 
 /**
  * Free the memory for the whole database

--- a/src/db.c
+++ b/src/db.c
@@ -2462,3 +2462,38 @@ has_flag(dbref ref, const char *flag)
 
     return result;
 }
+
+/**
+ * Helper function to collect object statistics.
+ *
+ * Populates the stats array with counts of owned objects: total, rooms, exits,
+ * things, programs, players, and garbage.
+ *
+ * @param player the player running the command
+ * @param ref the player dbref to query (or NOTHING for MUCK-wide stats)
+ * @param stats output array for the statistics
+ */
+void
+collect_dbstats(dbref player, dbref ref, int stats[7])
+{
+    int types[6] = {
+        TYPE_ROOM, TYPE_EXIT, TYPE_THING, TYPE_PROGRAM, TYPE_PLAYER, TYPE_GARBAGE
+    };
+
+    for (int i = 0; i < 7; i++) {
+        stats[i] = 0;
+    }
+
+    for (dbref i = 0; i < db_top; i++) {
+        if (ref == NOTHING || OWNER(i) == ref) {
+            for (int t = 0, n = ARRAYSIZE(types); t < n; t++) {
+                if (Typeof(i) == types[t]) {
+                    stats[t+1]++;
+                    stats[0]++;
+                    break;
+                }
+            }
+        }
+    }
+}
+

--- a/src/p_misc.c
+++ b/src/p_misc.c
@@ -837,6 +837,7 @@ void
 prim_stats(PRIM_PROTOTYPE)
 {
     dbref ref;
+    int stats[7];
 
     CHECKOP(1);
     oper1 = POP();
@@ -847,32 +848,15 @@ prim_stats(PRIM_PROTOTYPE)
 
     ref = oper1->data.objref;
 
-    if (mlev < 3 && OWNER(ref) != player) {
+    if (mlev < 3 && ref != NOTHING && OWNER(ref) != player) {
         abort_interp("Requires Mucker Level 3.");
     }
 
+    collect_dbstats(player, ref, stats);
+
     CLEAR(oper1);
 
-    int types[6] = {
-        TYPE_ROOM, TYPE_EXIT, TYPE_THING, TYPE_PLAYER, TYPE_PROGRAM, TYPE_GARBAGE
-    };
-
-    int stats[7] = {0}; /* 0 is the total, 1-6 map to the types array. */
-
-    for (dbref i = 0; i < db_top; i++) {
-        if (ref == NOTHING || OWNER(i) == ref) {
-            for (int t = 0, n = ARRAYSIZE(types); t < n; t++) {
-                if (Typeof(i) == types[t]) {
-                    stats[t+1]++;
-                    stats[0]++;
-                    break;
-                }
-            }
-        }
-    }
-
     int n = ARRAYSIZE(stats);
-
     CHECKOFLOW(n);
     for (int i = 0; i < n; i++) {
         PushInt(stats[i]);
@@ -900,6 +884,7 @@ void
 prim_stats_array(PRIM_PROTOTYPE)
 {
     dbref ref;
+    int stats[7];
 
     CHECKOP(1);
     oper1 = POP();
@@ -910,34 +895,17 @@ prim_stats_array(PRIM_PROTOTYPE)
 
     ref = oper1->data.objref;
 
-    if (mlev < 3 && OWNER(ref) != player) {
+    if (mlev < 3 && ref != NOTHING && OWNER(ref) != player) {
         abort_interp("Requires Mucker Level 3.");
     }
 
+    collect_dbstats(player, ref, stats);
+
     CLEAR(oper1);
-
-    int types[6] = {
-        TYPE_ROOM, TYPE_EXIT, TYPE_THING, TYPE_PLAYER, TYPE_PROGRAM, TYPE_GARBAGE
-    };
-
-    int stats[7] = {0}; /* 0 is the total, 1-6 map to the types array. */
-
-    for (dbref i = 0; i < db_top; i++) {
-        if (ref == NOTHING || OWNER(i) == ref) {
-            for (int t = 0, n = ARRAYSIZE(types); t < n; t++) {
-                if (Typeof(i) == types[t]) {
-                    stats[t+1]++;
-                    stats[0]++;
-                    break;
-                }
-            }
-        }
-    }
 
     stk_array *nu = new_array_packed(0, fr->pinning);
 
     int n = ARRAYSIZE(stats);
-
     for (int i = n-1; i >= 0; i--) {
         array_set_intkey_intval(&nu, n-i-1, stats[i]);
     }


### PR DESCRIPTION
This PR collects the main logic from `STATS`, `STATS_ARRAY`, and `@stats` into a common function `collect_dbstats`.

The builtin version of `@stats` gave information on old, propchanged, and proploaded objects (an unlisted feature) - but even starterdb overrides this command.

If there's a need to keep those, I can exempt `@stats` from this refactor. I could see a future `@debug diskbase` subcommand though (and `@find =@=count` seems to work for the other)
