### PR TITLE
#751 Fix crash patch provided by PointsDragon

### DIFF
--- a/src/p_db.c
+++ b/src/p_db.c
@@ -1259,7 +1259,10 @@ prim_roomp(PRIM_PROTOTYPE)
         abort_interp("Invalid argument type.");
     }
 
-    if (!valid_object(oper1) && !is_home(oper1)) {
+    if (is_home(oper1)) {
+        /* HOME per doc explicitly returns 1 */
+        result = 1;
+    } else if (!valid_object(oper1)) {
         result = 0;
     } else {
         ref = oper1->data.objref;


### PR DESCRIPTION
UPDATE: This PR just has PointsDragons' patch, sorry for the previous one that had some other stuff in it :)

@dbenoy @charlesreiss @ketnar @skylerbunny @wyld-sw Hey guys -- trying to ping folks that are running MUCKs that may or may not be running FB 7 :)

You will probably want to apply this patch to your code-bases.  It's a fairly simple one and it hardens a MUF prim that can cause a segfault.  If you choose instead to use the latest FB 7 after this gets merged, I highly recommend running in a test MUCK as we've done a few refactors that I don't think have seen a lot of use yet so it's a good idea to smoke test it.

Thank you all and let me know if you have any questions :)