### PR TITLE
Removes legacy defines, adds {flag?} help, implements PREFIX_ inserver defines

### DIFF
--- a/docs/mpihelp.html
+++ b/docs/mpihelp.html
@@ -97,6 +97,7 @@
 <h3>F's</h3>
 <ul>
     <li><a href="#filter">filter</a></li>
+    <li><a href="#flag?">flag?</a></li>
     <li><a href="#flags">flags</a></li>
     <li><a href="#fold">fold</a></li>
     <li><a href="#for">for</a></li>
@@ -1539,6 +1540,7 @@ items delimited by that string, otherwise it assumes a carriage return.
     <li><a href="#created">created</a></li>
     <li><a href="#dbeq">dbeq</a></li>
     <li><a href="#exits">exits</a></li>
+    <li><a href="#flag?">flag?</a></li>
     <li><a href="#flags">flags</a></li>
     <li><a href="#force">force</a></li>
     <li><a href="#fullname">fullname</a></li>
@@ -1583,6 +1585,23 @@ must be in the vicinity, or controlled by the owner of the trigger object.
 is an exit, then the full name of the exit is given, including all the ;
 aliases.  The object must be in the immediate vicinity, or be controlled
 by the owner of the trigger object.
+<!-- HTML_TOPICEND -->
+
+
+<h3 id="flag?">{flag?:obj,flag}
+<br>
+</h3>
+  Returns the state of the flag on the given object. 1 = on; 0 = off.
+The ! token may be used before the name of a flag to negate the check and
+check for the absence of the flag. Returns 0 for nrecognized flags.
+
+<p>
+  You can check the &quot;interactive&quot; flag to see if a player is currently in
+a program's READ, or if they are in the MUF editor.
+
+The &quot;Truewizard&quot; flag will check for a W flag with or without the QUELL set.
+The &quot;Mucker&quot; flag returns the most significant bit of the mucker level and
+the &quot;Nucker&quot; flag returns the least significant bit.
 <!-- HTML_TOPICEND -->
 
 

--- a/docs/mpihelp.txt
+++ b/docs/mpihelp.txt
@@ -59,8 +59,8 @@ E's
   eq     eval   eval!  exec   exec!  exits  
 
 F's
-  filter     flags      fold       for        force      foreach    ftime
-  fullname   func       
+  filter     flag?      flags      fold       for        force      foreach
+  ftime      fullname   func       
 
 G's
   ge  gt  
@@ -1087,10 +1087,10 @@ items delimited by that string, otherwise it assumes a carriage return.
 Database Related Functions|Database|DBFuncs
 Database Related Functions
 
-contains   contents   controls   created    dbeq       exits      flags
-force      fullname   holds      istype     lastused   links      loc
-locked     modified   money      name       nearby     owner      ref
-testlock   type       usecount   
+contains   contents   controls   created    dbeq       exits      flag?
+flags      force      fullname   holds      istype     lastused   links
+loc        locked     modified   money      name       nearby     owner
+ref        testlock   type       usecount   
 
 ~----------------------------------------------------------------------------
 ~
@@ -1114,6 +1114,20 @@ FULLNAME
 is an exit, then the full name of the exit is given, including all the ;
 aliases.  The object must be in the immediate vicinity, or be controlled
 by the owner of the trigger object.
+~
+~
+FLAG?
+{flag?:obj,flag}
+  Returns the state of the flag on the given object. 1 = on; 0 = off.
+The ! token may be used before the name of a flag to negate the check and
+check for the absence of the flag. Returns 0 for nrecognized flags.
+
+  You can check the "interactive" flag to see if a player is currently in
+a program's READ, or if they are in the MUF editor.
+
+The "Truewizard" flag will check for a W flag with or without the QUELL set.
+The "Mucker" flag returns the most significant bit of the mucker level and
+the "Nucker" flag returns the least significant bit.
 ~
 ~
 OWNER

--- a/include/config.h
+++ b/include/config.h
@@ -275,37 +275,6 @@ typedef int dbref;  /**< Type wrapper for dbref - must support negatives */
 # include "crt_malloc.h"
 #endif	
 
-/******************************************************************/
-/* System configuration stuff... Figure out who and what we are.  */
-/******************************************************************/
-
-#ifdef __linux__
-/** Standard define if Linux */
-# define SYSV
-#endif
-
-#if defined(sun) || defined(__sun)
-/** I miss Sun */
-# define SUN_OS
-# ifndef _POSIX_SOURCE
-/** Make sure we've got this set */
-#  define _POSIX_SOURCE
-# endif
-#endif
-
-#if defined(ultrix) || defined(__ultrix) || defined(__ultrix__)
-/** Does anyone still use this?  Probably not. */
-# define ULTRIX
-#endif
-
-#ifdef _AIX
-/** Does anyone still use this?  Probably not. */
-# define AIX
-/** AIX is no fun */
-# define NO_MEMORY_COMMAND
-# include <sys/select.h>
-#endif
-
 /*
  * Windows compile environment.
  */

--- a/src/compile.c
+++ b/src/compile.c
@@ -15,6 +15,7 @@
 
 #include "config.h"
 
+#include "color.h"
 #include "commands.h"
 #include "compile.h"
 #include "db.h"
@@ -716,6 +717,16 @@ include_internal_defs(COMPSTATE * cstat)
     insert_intdef(cstat, "sorttype_nocase_descend", SORTTYPE_NOCASE_DESCEND);
     insert_intdef(cstat, "sorttype_shuffle", SORTTYPE_SHUFFLE);
     insert_def(cstat, "notify_except", "1 swap notify_exclude");
+
+    insert_def(cstat, "prefix_good",
+        "\"" ANSI_FG_GREEN ANSI_BOLD "<*> " ANSI_RESET "\" swap strcat"
+    );
+    insert_def(cstat, "prefix_warn",
+        "\"" ANSI_FG_YELLOW ANSI_BOLD "<?> " ANSI_RESET "\" swap strcat"
+    );
+    insert_def(cstat, "prefix_bad",
+        "\"" ANSI_FG_RED ANSI_BOLD "<!> " ANSI_RESET "\" swap strcat"
+    );
 
     /* Make defines for compatability to removed primitives */
     insert_def(cstat, "desc", "\"" MESGPROP_DESC "\" getpropstr");

--- a/src/interface.c
+++ b/src/interface.c
@@ -2467,31 +2467,6 @@ shutdownsock(struct descriptor_data *d)
     log_status("CONCOUNT: There are now %d open connections.", ndescriptors);
 }
 
-/*
- * The idea here is to make sure O_NONBLOCK is set no matter which operating
- * system we are on.
- *
- * This seems somewhat out of place, just randomly injected here.  Might be
- * more of a config thing?
- *
- * @TODO Why do we include WIN32 in this block?  In make_nonblocking,
- *       we use a #ifdef for WIN32 ... why not just *not* use O_NONBLOCK
- *       in that block?  It will reduce some of the complexity here.
- */
-#ifdef WIN32
-# define O_NONBLOCK 1
-#else
-# if !defined(O_NONBLOCK) || defined(ULTRIX)
-#  ifdef FNDELAY /* SUN OS */
-#   define O_NONBLOCK FNDELAY
-#  else
-#   ifdef O_NDELAY /* SyseVil */
-#    define O_NONBLOCK O_NDELAY
-#   endif
-#  endif
-# endif
-#endif
-
 /**
  * Make a socket non-blocking
  *
@@ -2502,16 +2477,17 @@ static void
 make_nonblocking(int s)
 {
 #ifdef WIN32
-    unsigned long val = O_NONBLOCK;
+    unsigned long val = 1;
 
     if (ioctlsocket(s, FIONBIO, &val) == SOCKET_ERROR) {
         perror("make_nonblocking: ioctlsocket");
-        panic("O_NONBLOCK ioctlsocket failed");
+        panic("ioctlsocket failed");
     }
 #else
-    if (fcntl(s, F_SETFL, O_NONBLOCK) == -1) {
+    int flags = fcntl(s, F_GETFL, 0);
+    if (flags == -1 || fcntl(s, F_SETFL, flags | O_NONBLOCK) == -1) {
         perror("make_nonblocking: fcntl");
-        panic("O_NONBLOCK fcntl failed");
+        panic("fcntl failed");
     }
 #endif
 }
@@ -6832,26 +6808,7 @@ main(int argc, char **argv)
             setbuf(stdout, NULL);
 
             /* Disassociate from Process Group */
-#  ifdef _POSIX_SOURCE
             setsid();
-#  else
-#   ifdef SYSV
-            setpgrp(); /* The SysV way */
-#   else
-            setpgid(0, getpid()); /* The POSIX way. */
-#   endif /* SYSV */
-
-#   ifdef  TIOCNOTTY /* we can force this, POSIX / BSD */
-            {
-                int fd;
-
-                if ((fd = open("/dev/tty", O_RDWR)) >= 0) {
-                    ioctl(fd, TIOCNOTTY, NULL); /* lose controll TTY */
-                    close(fd);
-                }
-            }
-#   endif /* TIOCNOTTY */
-#  endif /* !_POSIX_SOURCE */
         }
 #endif /* WIN32 */
 

--- a/src/mpihelp.raw
+++ b/src/mpihelp.raw
@@ -919,6 +919,20 @@ aliases.  The object must be in the immediate vicinity, or be controlled
 by the owner of the trigger object.
 ~
 ~
+FLAG?
+{flag?:obj,flag}
+  Returns the state of the flag on the given object. 1 = on; 0 = off.
+The ! token may be used before the name of a flag to negate the check and
+check for the absence of the flag. Returns 0 for unrecognized flags.
+
+  You can check the "interactive" flag to see if a player is currently in
+a program's READ, or if they are in the MUF editor.
+
+The "Truewizard" flag will check for a W flag with or without the QUELL set.
+The "Mucker" flag returns the most significant bit of the mucker level and
+the "Nucker" flag returns the least significant bit.
+~
+~
 OWNER
 {owner:obj}
     Returns the owner of the given object.  The object must be in the

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -137,17 +137,8 @@ static void hostprune(void) {
  * @param s the socket to set nonblocking
  */
 static void make_nonblocking(int s) {
-#if !defined(O_NONBLOCK) || defined(ULTRIX)
-# ifdef FNDELAY     /* SUN OS */
-#  define O_NONBLOCK FNDELAY
-# else
-#  ifdef O_NDELAY   /* SyseVil */
-#   define O_NONBLOCK O_NDELAY
-#  endif            /* O_NDELAY */
-# endif             /* FNDELAY */ 
-#endif
-
-    if (fcntl(s, F_SETFL, O_NONBLOCK) == -1) {
+    int flags = fcntl(s, F_GETFL, 0);
+    if (flags == -1 || fcntl(s, F_SETFL, flags | O_NONBLOCK) == -1) {
         perror("make_nonblocking: fcntl");
         abort();
     }


### PR DESCRIPTION
Removes legacy defines:
- No longer branches for AIX, SUN, SYSV, or ULTRIX.
- Doesn't overwrite any flags in make_nonblocking.
- Removes TIOCNOTTY branch in favor of modern setsid().

Adds {flag?} help:
- Missed with the implementation commit.

Implements PREFIX_ inserver defines:
- `PREFIX_GOOD` prepends a bold-green `<*>` in front of the given string.
- `PREFIX_WARN` prepends a bold-yellow `<?>` in front of the given string.
- `PREFIX_BAD` prepends a bold-red `<!>` in front of the given string.
- Closes #692.