### PR TITLE
Attempts a refactored flag subsystem.

### DIFF
--- a/docs/man.txt
+++ b/docs/man.txt
@@ -126,12 +126,12 @@ E's
 
 F's
   fabs               fail               fg_mode            findnext
-  firstdescr         flag?              flags              float
-  float?             floor              fmod               fmtstring
-  fmttime            for                force              force_level
-  forcedby           forcedby_array     foreach            foreground
-  fork               frand              ftostr             ftostrc
-  fulldepth          
+  firstdescr         flag?              flags              flags?
+  float              float?             floor              fmod
+  fmtstring          fmttime            for                force
+  force_level        forcedby           forcedby_array     foreach
+  foreground         fork               frand              ftostr
+  ftostrc            fulldepth          
 
 G's
   gaussian           getlink            getlinks           getlinks_array
@@ -4151,27 +4151,27 @@ dbcmp                     dbref                     dbtop
 desc                      drop                      dump
 entrances_array           exit?                     exits
 exits_array               fail                      findnext
-flag?                     getlink                   getlinks
-getlinks_array            ignore_add                ignore_del
-ignoring?                 location                  match
-mlevel                    movepennies               moveto
-name                      newexit                   newobject
-newpassword               newplayer                 newprogram
-newroom                   next                      nextentrance
-nextowned                 objmem                    odrop
-ofail                     ok?                       osucc
-owner                     part_pmatch               pennies
-player?                   pmatch                    pname_history
-prog                      program?                  recycle
-rmatch                    room?                     set
-setdesc                   setdrop                   setfail
-setlink                   setlinks_array            setname
-setodrop                  setofail                  setosucc
-setown                    setsucc                   setsysparm
-stats                     stats_array               succ
-sysparm                   sysparm_array             thing?
-timestamps                toadplayer                trig
-truename                  unparseobj                
+flag?                     flags?                    getlink
+getlinks                  getlinks_array            ignore_add
+ignore_del                ignoring?                 location
+match                     mlevel                    movepennies
+moveto                    name                      newexit
+newobject                 newpassword               newplayer
+newprogram                newroom                   next
+nextentrance              nextowned                 objmem
+odrop                     ofail                     ok?
+osucc                     owner                     part_pmatch
+pennies                   player?                   pmatch
+pname_history             prog                      program?
+recycle                   rmatch                    room?
+set                       setdesc                   setdrop
+setfail                   setlink                   setlinks_array
+setname                   setodrop                  setofail
+setosucc                  setown                    setsucc
+setsysparm                stats                     stats_array
+succ                      sysparm                   sysparm_array
+thing?                    timestamps                toadplayer
+trig                      truename                  unparseobj
 
 ~----------------------------------------------------------------------------
 ~
@@ -4463,7 +4463,22 @@ a program's READ, or if they are in the MUF editor.
 The "Truewizard" flag will check for a W flag with or without the QUELL set.
 The "Mucker" flag returns the most significant bit of the mucker level and
 the "Nucker" flag returns the least significant bit. (Use MLEVEL instead.)
-Also see: SET and MLEVEL
+Also see: SET, MLEVEL and FLAGS?
+~
+~
+FLAGS?
+FLAGS? (d s -- i )
+
+  Determines if object d has the flag pattern given by string s. A flag
+pattern consists of at least one single-character flag with an optional
+! token in front to negate the specific check. Flag patterns also recognize
+object types.
+
+  Does not recognize full flag names, including the virtual alias
+"truewizard"; "T" checks for an object of type thing.
+
+  Examples of flag patterns include "PB3", "L!A", and "!O".
+Also see: SET, MLEVEL and FLAG?
 ~
 ~
 MLEVEL

--- a/docs/mpihelp.html
+++ b/docs/mpihelp.html
@@ -99,6 +99,7 @@
     <li><a href="#filter">filter</a></li>
     <li><a href="#flag?">flag?</a></li>
     <li><a href="#flags">flags</a></li>
+    <li><a href="#flags?">flags?</a></li>
     <li><a href="#fold">fold</a></li>
     <li><a href="#for">for</a></li>
     <li><a href="#force">force</a></li>
@@ -1542,6 +1543,7 @@ items delimited by that string, otherwise it assumes a carriage return.
     <li><a href="#exits">exits</a></li>
     <li><a href="#flag?">flag?</a></li>
     <li><a href="#flags">flags</a></li>
+    <li><a href="#flags?">flags?</a></li>
     <li><a href="#force">force</a></li>
     <li><a href="#fullname">fullname</a></li>
     <li><a href="#holds">holds</a></li>
@@ -1593,7 +1595,7 @@ by the owner of the trigger object.
 </h3>
   Returns the state of the flag on the given object. 1 = on; 0 = off.
 The ! token may be used before the name of a flag to negate the check and
-check for the absence of the flag. Returns 0 for nrecognized flags.
+check for the absence of the flag. Returns 0 for unrecognized flags.
 
 <p>
   You can check the &quot;interactive&quot; flag to see if a player is currently in
@@ -1602,6 +1604,23 @@ a program's READ, or if they are in the MUF editor.
 The &quot;Truewizard&quot; flag will check for a W flag with or without the QUELL set.
 The &quot;Mucker&quot; flag returns the most significant bit of the mucker level and
 the &quot;Nucker&quot; flag returns the least significant bit.
+<!-- HTML_TOPICEND -->
+
+
+<h3 id="flags?">{flags?:obj,pattern}
+<br>
+</h3>
+  Determines if object d has the flag pattern given by string s. A flag
+pattern consists of at least one single-character flag with an optional
+! token in front to negate the specific check. Flag patterns also recognize 
+object types.
+
+<p>
+  Does not recognize full flag names, including the virtual alias
+&quot;truewizard&quot;; &quot;T&quot; checks for an object of type thing.
+
+<p>
+  Examples of flag patterns include &quot;PB3&quot;, &quot;L!A&quot;, and &quot;!O&quot;.
 <!-- HTML_TOPICEND -->
 
 

--- a/docs/mpihelp.txt
+++ b/docs/mpihelp.txt
@@ -59,8 +59,8 @@ E's
   eq     eval   eval!  exec   exec!  exits  
 
 F's
-  filter     flag?      flags      fold       for        force      foreach
-  ftime      fullname   func       
+  filter     flag?      flags      flags?     fold       for        force
+  foreach    ftime      fullname   func       
 
 G's
   ge  gt  
@@ -1088,9 +1088,9 @@ Database Related Functions|Database|DBFuncs
 Database Related Functions
 
 contains   contents   controls   created    dbeq       exits      flag?
-flags      force      fullname   holds      istype     lastused   links
-loc        locked     modified   money      name       nearby     owner
-ref        testlock   type       usecount   
+flags      flags?     force      fullname   holds      istype     lastused
+links      loc        locked     modified   money      name       nearby
+owner      ref        testlock   type       usecount   
 
 ~----------------------------------------------------------------------------
 ~
@@ -1120,7 +1120,7 @@ FLAG?
 {flag?:obj,flag}
   Returns the state of the flag on the given object. 1 = on; 0 = off.
 The ! token may be used before the name of a flag to negate the check and
-check for the absence of the flag. Returns 0 for nrecognized flags.
+check for the absence of the flag. Returns 0 for unrecognized flags.
 
   You can check the "interactive" flag to see if a player is currently in
 a program's READ, or if they are in the MUF editor.
@@ -1128,6 +1128,19 @@ a program's READ, or if they are in the MUF editor.
 The "Truewizard" flag will check for a W flag with or without the QUELL set.
 The "Mucker" flag returns the most significant bit of the mucker level and
 the "Nucker" flag returns the least significant bit.
+~
+~
+FLAGS?
+{flags?:obj,pattern}
+  Determines if object d has the flag pattern given by string s. A flag
+pattern consists of at least one single-character flag with an optional
+! token in front to negate the specific check. Flag patterns also recognize 
+object types.
+
+  Does not recognize full flag names, including the virtual alias
+"truewizard"; "T" checks for an object of type thing.
+
+  Examples of flag patterns include "PB3", "L!A", and "!O".
 ~
 ~
 OWNER

--- a/docs/mufman.html
+++ b/docs/mufman.html
@@ -319,6 +319,7 @@
     <li><a href="#firstdescr">firstdescr</a></li>
     <li><a href="#flag?">flag?</a></li>
     <li><a href="#flags">flags</a></li>
+    <li><a href="#flags?">flags?</a></li>
     <li><a href="#float">float</a></li>
     <li><a href="#float?">float?</a></li>
     <li><a href="#floor">floor</a></li>
@@ -6660,6 +6661,7 @@ not cause an error for SETPROP or any other property related primitive.
     <li><a href="#fail">fail</a></li>
     <li><a href="#findnext">findnext</a></li>
     <li><a href="#flag?">flag?</a></li>
+    <li><a href="#flags?">flags?</a></li>
     <li><a href="#getlink">getlink</a></li>
     <li><a href="#getlinks">getlinks</a></li>
     <li><a href="#getlinks_array">getlinks_array</a></li>
@@ -7126,8 +7128,33 @@ The &quot;Truewizard&quot; flag will check for a W flag with or without the QUEL
 The &quot;Mucker&quot; flag returns the most significant bit of the mucker level and
 the &quot;Nucker&quot; flag returns the least significant bit. (Use MLEVEL instead.)
 <p>Also see:
-    <a href="#set">SET</a> and
-    <a href="#mlevel">MLEVEL</a>
+    <a href="#set">SET</a>,
+    <a href="#mlevel">MLEVEL</a> and
+    <a href="#flags?">FLAGS?</a>
+</p>
+<!-- HTML_TOPICEND -->
+
+
+<h3 id="flags?">FLAGS? (d s -- i )
+<br>
+
+<br>
+</h3>
+  Determines if object d has the flag pattern given by string s. A flag
+pattern consists of at least one single-character flag with an optional
+! token in front to negate the specific check. Flag patterns also recognize
+object types.
+
+<p>
+  Does not recognize full flag names, including the virtual alias
+&quot;truewizard&quot;; &quot;T&quot; checks for an object of type thing.
+
+<p>
+  Examples of flag patterns include &quot;PB3&quot;, &quot;L!A&quot;, and &quot;!O&quot;.
+<p>Also see:
+    <a href="#set">SET</a>,
+    <a href="#mlevel">MLEVEL</a> and
+    <a href="#flag?">FLAG?</a>
 </p>
 <!-- HTML_TOPICEND -->
 

--- a/include/array.h
+++ b/include/array.h
@@ -1,7 +1,7 @@
 /** @file array.h
  *
  * Header for the different array types used in Fuzzball.  This is primarily
- * used for MUF primitives. 
+ * used for MUF primitives.
  *
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
@@ -77,7 +77,7 @@ typedef struct stk_array_t {
         array_data *packed; /**< pointer to packed array */
         array_tree *dict;   /**< pointer to dictionary AVL tree */
     } data;                 /**< Two different array types */
-    stk_array_list list_node; /**< list array is on, typically of all allocated 
+    stk_array_list list_node; /**< list array is on, typically of all allocated
                                *   to a MUF program
                                */
 } stk_array;

--- a/include/boolexp.h
+++ b/include/boolexp.h
@@ -171,17 +171,17 @@ int test_lock_false_default(int descr, dbref player, dbref thing, const char *lo
  * must be aware that the buffer can mutate under you if another
  * unparse_boolexp happens.  Also, this means the call is not threadsafe.
  *
- * If fullname is true, then DBREFS will be run through unparse_object.
+ * If fullname is true, then DBREFS will be run through flag_unparse_object.
  * Otherwise, #12345 style DBREFs will be displayed.
  *
- * @see unparse_object
+ * @see flag_unparse_object
  *
  * @param player the player who is going to see the output of this command
  * @param b the boolean expression to process
  * @param fullname Show names instead of DBREFs?  True or false.
  *
  * @return pointer to static buffer containing string for display.
- */ 
+ */
 const char *unparse_boolexp(dbref player, struct boolexp *b, int fullname);
 
 #endif /* !BOOLEXP_H */

--- a/include/commands.h
+++ b/include/commands.h
@@ -15,7 +15,7 @@
  * This file is grouped alphabetically just to make it slightly easier to find
  * things.  Please keep that ordering.
  */
- 
+
 /*
  * A
  */
@@ -25,7 +25,7 @@
  *
  * Defined in: create.c
  *
- * The action will not do anything until it is LINKed.  This is the 
+ * The action will not do anything until it is LINKed.  This is the
  * implementation of \@action.
  *
  * Action names must pass ok_object_name.
@@ -119,7 +119,7 @@ void do_bless(int descr, dbref player, const char *target, const char *propname)
  *
  * @param player the player doing the \@boot command
  * @param name the string name that will be matched for the player to boot.
- */ 
+ */
 void do_boot(dbref player, const char *name);
 
 /*
@@ -967,7 +967,7 @@ void do_process_status(dbref player);
  *
  * Defined in create.c
  *
- * First, find a program that matches that name.  If there's one, then we 
+ * First, find a program that matches that name.  If there's one, then we
  * put the player into edit mode and do it.  Otherwise, we create a new object
  * for the player, and call it a program.
  *

--- a/include/config.h
+++ b/include/config.h
@@ -1,6 +1,6 @@
 /** @file config.h
  *
- * Tunable parameters -- Edit to you heart's content 
+ * Tunable parameters -- Edit to you heart's content
  *
  * Parameters that control system behavior, and tell the system
  * what resources are available (most of this is now done by
@@ -31,7 +31,7 @@ typedef int dbref;  /**< Type wrapper for dbref - must support negatives */
  ************************************************************************/
 
 /**
- * Makes God (\#1) immune to \@force, \@newpassword, and being set !Wizard.  
+ * Makes God (\#1) immune to \@force, \@newpassword, and being set !Wizard.
  */
 #define GOD_PRIV
 
@@ -72,7 +72,7 @@ typedef int dbref;  /**< Type wrapper for dbref - must support negatives */
  * This is similar to the X-Forwarded-For request header in HTTP.
  * The purpose is to provide administrators running a FORWARDED
  * aware proxy or webclient accurate hostnames in WHO*.
- * 
+ *
  * A client must indicate their desire to use this option with
  * IAC WILL FORWARDED and receive a IAC DO FORWARDED in response,
  * after which they may at any time send a sequence like:
@@ -131,15 +131,15 @@ typedef int dbref;  /**< Type wrapper for dbref - must support negatives */
 #define BUFFER_LEN ((MAX_COMMAND_LEN)*4)
 
 /**
- * Maximum buffer length for short strings
- *
- * Suitable for command output, error messages, etc.
+ * Maximum buffer length for smaller strings
  */
+#define MINI_BUFFER_LEN 64
 #define SMALL_BUFFER_LEN 128
+#define MEDIUM_BUFFER_LEN 256
 
 /************************************************************************
-   Various Messages 
- 
+   Various Messages
+
    Printed from the server at times, esp. during login.
  ************************************************************************/
 
@@ -176,7 +176,7 @@ typedef int dbref;  /**< Type wrapper for dbref - must support negatives */
 #undef DEBUG_SSL_LOG_ALL
 
 /************************************************************************
-  System Dependency Defines. 
+  System Dependency Defines.
 
   You probably will not have to monkey with this unless the muck fails
  to compile for some reason.
@@ -273,7 +273,7 @@ typedef int dbref;  /**< Type wrapper for dbref - must support negatives */
 
 #ifdef MALLOC_PROFILING
 # include "crt_malloc.h"
-#endif	
+#endif
 
 /*
  * Windows compile environment.

--- a/include/db.h
+++ b/include/db.h
@@ -13,6 +13,7 @@
 #include <time.h>
 
 #include "config.h"
+#include "flags.h"
 #include "mcp.h"
 
 /**
@@ -32,7 +33,7 @@
  */
 extern char match_args[BUFFER_LEN];
 
-/** 
+/**
  * @var match_cmdname
  *      The super not threadsafe way the user typed in command is passed
  *      from the interp loop to other functions.
@@ -359,69 +360,6 @@ extern char match_cmdname[BUFFER_LEN];
 
 #define DB_PARMSINFO     0x0001 /**< legacy database value */
 
-#define TYPE_ROOM           0x0 /**< room bit */
-#define TYPE_THING          0x1 /**< thing bit */
-#define TYPE_EXIT           0x2 /**< exit bit */
-#define TYPE_PLAYER         0x3 /**< player bit */
-#define TYPE_PROGRAM        0x4 /**< program bit */
-
-/* 0x5 available */
-
-#define TYPE_GARBAGE        0x6 /**< garbage bit */
-#define NOTYPE              0x7 /**< no particular type */
-#define TYPE_MASK           0x7 /**< bitmask for all types */
-
-/* 0x8 available */
-
-#define WIZARD             0x10 /**< gets automatic control */
-#define LINK_OK            0x20 /**< anybody can link to this */
-#define DARK               0x40 /**< contents of room are not printed */
-#define INTERNAL           0x80 /**< internal-use-only flag */
-#define STICKY            0x100 /**< this object goes home when dropped */
-#define BUILDER           0x200 /**< this player can use construction commands */
-#define CHOWN_OK          0x400 /**< this object can be \@chowned, or
-                                 *   this player can see color
-                                 */
-#define JUMP_OK           0x800 /**< A room which can be jumped from, or
-                                 *   a player who can be jumped to
-                                 */
-/* 0x1000 available */
-/* 0x2000 available */
-
-#define KILL_OK          0x4000 /**< Kill_OK bit.  Means you can be killed. */
-#define GUEST            0x8000 /**< Guest flag */
-#define HAVEN           0x10000 /**< can't kill here */
-#define ABODE           0x20000 /**< can set home here */
-#define MUCKER          0x40000 /**< programmer */
-#define QUELL           0x80000 /**< When set, wiz-perms are turned off */
-#define SMUCKER        0x100000 /**< second programmer bit.  For levels */
-#define INTERACTIVE    0x200000 /**< internal: player in MUF editor */
-#define OBJECT_CHANGED 0x400000 /**< internal: set when an object is dbdirty()ed */
-
-/* 0x800000 available */
-
-#define VEHICLE       0x1000000 /**< Vehicle flag */
-#define ZOMBIE        0x2000000 /**< Zombie flag */
-#define LISTENER      0x4000000 /**< internal: listener flag */
-#define XFORCIBLE     0x8000000 /**< externally forcible flag */
-#define READMODE     0x10000000 /**< internal: when set, player is in a READ */
-#define SANEBIT      0x20000000 /**< internal: used to check db sanity */
-#define YIELD        0x40000000 /**< Yield flag */
-#define OVERT        0x80000000 /**< Overt flag */
-
-/** what flags to NOT dump to disk. */
-#define DUMP_MASK   (INTERACTIVE | OBJECT_CHANGED | LISTENER | READMODE | SANEBIT)
-
-/**
- * Returns the TYPE_ value of 'x'
- *
- * Does not check to see if 'x' is a valid ref.
- *
- * @param x the db object to get type of
- * @return a type valud - one of the TYPE_* constants
- */
-#define Typeof(x)   (x == HOME ? TYPE_ROOM : (FLAGS(x) & TYPE_MASK))
-
 #define GOD         ((dbref)  1)    /**< head player */
 #define NOTHING     ((dbref) -1)    /**< null dbref */
 #define AMBIGUOUS   ((dbref) -2)    /**< multiple possibilities, for matchers */
@@ -459,7 +397,7 @@ extern char match_cmdname[BUFFER_LEN];
  * @param d the object to check
  * @return true if d is a valid and non-garbage object, false otherwise
  */
-#define OkObj(d)        (ObjExists(d) && Typeof(d) != TYPE_GARBAGE)
+#define OkObj(d)        (ObjExists(d) && OBJECT_TYPE(d) != TYPE_GARBAGE)
 
 #ifdef GOD_PRIV
 /**
@@ -474,44 +412,6 @@ extern char match_cmdname[BUFFER_LEN];
 #endif
 
 /**
- * Calculates the "raw" MUCKER level of an object, not counting WIZARD bit
- *
- * This will be a number between 0 and 3 inclusive.  'x' is not sanity
- * checked to be sure it exists.
- *
- * @param x the object to calculate MUCKER level for.
- * @return an integer between 0 and 3 inclusive
- */
-#define MLevRaw(x)  (((FLAGS(x) & MUCKER)? 2:0) + ((FLAGS(x) & SMUCKER)? 1:0))
-
-/**
- * Calculates the MUCKER level of an object, taking into account WIZARD bit
- *
- * This will be a number between 0 and 4 inclusive.  'x' is not sanity checked
- * to be sure it exists.
- *
- * @param x the object to calculate MUCKER level for.
- * @return an integer between 0 and 4 inclusive
- */
-#define MLevel(x)   (((FLAGS(x) & WIZARD) && \
-                    ((FLAGS(x) & MUCKER) || (FLAGS(x) & SMUCKER)))? 4 : \
-                    (((FLAGS(x) & MUCKER)? 2 : 0) + \
-                    ((FLAGS(x) & SMUCKER)? 1 : 0)))
-
-/**
- * Priority level -- used for exit matching
- *
- * The higher the priority, the more likely it will match.  This does not
- * check to see if 'x' is a valid object.
- *
- * @param x the ref to get priority for
- * @return a numeric priority level
- */
-#define PLevel(x)   ((FLAGS(x) & (MUCKER | SMUCKER))? \
-                    (((FLAGS(x) & MUCKER)? 2:0) + ((FLAGS(x) & SMUCKER)? 1:0) + 1) : \
-                    ((FLAGS(x) & ABODE)? 0 : 1))
-
-/**
  * Check to see if object 'x' is dark
  *
  * Does not check to see if 'x' is valid first.
@@ -519,7 +419,7 @@ extern char match_cmdname[BUFFER_LEN];
  * @param x the dbref to check
  * @return boolean true if x is dark, false otherwise
  */
-#define Dark(x)         ((FLAGS(x) & DARK) != 0)
+#define Dark(x)         FLAG_CHECK(x, 'D')
 
 /**
  * Check to see if object 'x' is an unquelled WIZARD
@@ -529,7 +429,7 @@ extern char match_cmdname[BUFFER_LEN];
  * @param x the dbref to check
  * @return boolean true if x is an unquelled wizard, false otherwise
  */
-#define Wizard(x)       ((FLAGS(x) & WIZARD) != 0 && (FLAGS(x) & QUELL) == 0)
+#define Wizard(x)       (FLAG_CHECK(x, 'W') && !FLAG_CHECK(x, 'Q'))
 
 /**
  * Check to see if object 'x' is a WIZARD
@@ -539,17 +439,7 @@ extern char match_cmdname[BUFFER_LEN];
  * @param x the dbref to check
  * @return boolean true if x is a wizard, false otherwise
  */
-#define TrueWizard(x)   ((FLAGS(x) & WIZARD) != 0)
-
-/**
- * Check to see if object 'x' is a MUCKER
- *
- * Does not check to see if 'x' is valid first.
- *
- * @param x the dbref to check
- * @return boolean true if x is a MUCKER
- */
-#define Mucker(x)       (MLevel(x) != 0)
+#define TrueWizard(x)   FLAG_CHECK(x, 'W')
 
 /**
  * Check to see if object 'x' can build
@@ -560,7 +450,7 @@ extern char match_cmdname[BUFFER_LEN];
  * @param x the dbref to check
  * @return true if x can build
  */
-#define Builder(x)      ((FLAGS(x) & (WIZARD|BUILDER)) != 0)
+#define Builder(x)      (FLAG_CHECK(x, 'B') || FLAG_CHECK(x, 'W'))
 
 /**
  * Check to see if object 'x' can be linked to
@@ -574,8 +464,8 @@ extern char match_cmdname[BUFFER_LEN];
  * @return true if x can be linked to
  */
 #define Linkable(x)     ((x) == HOME || \
-                        (((Typeof(x) == TYPE_ROOM || Typeof(x) == TYPE_THING) ? \
-                        (FLAGS(x) & ABODE) : (FLAGS(x) & LINK_OK)) != 0))
+                        ((OBJECT_TYPE(x) == TYPE_ROOM || OBJECT_TYPE(x) == TYPE_THING) ? \
+                         FLAG_CHECK(x, 'A') : FLAG_CHECK(x, 'L')))
 
 /**
  * Set MUCKER level
@@ -608,9 +498,9 @@ extern char match_cmdname[BUFFER_LEN];
  * @return boolean true if x is a guest
  */
 #ifdef GOD_PRIV
-#define ISGUEST(x)  ((FLAGS(x) & GUEST) && !God(x))
+#define ISGUEST(x)  (FLAG_CHECK(x, 'G') && !God(x))
 #else /* !defined(GOD_PRIV) */
-#define ISGUEST(x)  ((FLAGS(x) & GUEST) && (FLAGS(x) & TYPE_PLAYER) && !TrueWizard(x))
+#define ISGUEST(x)  (FLAG_CHECK(x, 'G') && OBJECT_TYPE(x) == TYPE_PLAYER && !TrueWizard(x))
 #endif /* GOD_PRIV */
 
 /**
@@ -625,7 +515,7 @@ extern char match_cmdname[BUFFER_LEN];
  * @param x the potential guest ref
  */
 #define NOGUEST(_cmd,x) \
-    if(ISGUEST(x)) {   \
+    if (ISGUEST(x)) {   \
         log_status("Guest %s(#%d) failed attempt to %s.\n",NAME(x),x,_cmd); \
         notifyf_nolisten(x, "Guests are not allowed to %s.\r", _cmd); \
         return; \
@@ -644,7 +534,7 @@ extern char match_cmdname[BUFFER_LEN];
  * @param x the ref of the person to be notified on failure.
  */
 #define NOFORCE(_cmd, x) \
-    if(force_level) {   \
+    if (force_level) {   \
         notifyf_nolisten(x, "You can't use %s from a @force or {force}.\r", _cmd); \
         return; \
     }
@@ -666,7 +556,7 @@ extern char match_cmdname[BUFFER_LEN];
  * @param player the player to check
  * @return some integer MUCKER level
  */
-# define TUNE_MLEV(player)      (God(player) ? MLEV_GOD : MLevel(player))
+# define TUNE_MLEV(player)      (God(player) ? MLEV_GOD : OBJECT_EFFECTIVE_MLEVEL(player))
 #else
 # define MLEV_GOD               MLEV_WIZARD
 
@@ -676,7 +566,7 @@ extern char match_cmdname[BUFFER_LEN];
  * @param player the player to check
  * @return some integer MUCKER level
  */
-# define TUNE_MLEV(player)      MLevel(player)
+# define TUNE_MLEV(player)      OBJECT_EFFECTIVE_MLEVEL(player)
 #endif
 
 /**
@@ -689,7 +579,7 @@ extern char match_cmdname[BUFFER_LEN];
  * @param x the player to check a builder bit for
  */
 #define BUILDERONLY(_cmd,x) \
-    if(!Builder(x)) {   \
+    if (!Builder(x)) {   \
         notifyf_nolisten(x, "Only builders are allowed to %s.\r", _cmd); \
         return; \
     }
@@ -704,7 +594,7 @@ extern char match_cmdname[BUFFER_LEN];
  * @param x the player to check a MUCKER bit for
  */
 #define MUCKERONLY(_cmd,x) \
-    if(!Mucker(x)) {   \
+    if (OBJECT_MLEVEL(x) == 0) {   \
         notifyf_nolisten(x, "Only programmers are allowed to %s.\r", _cmd); \
         return; \
     }
@@ -719,7 +609,7 @@ extern char match_cmdname[BUFFER_LEN];
  * @param x the player to check a player bit for
  */
 #define PLAYERONLY(_cmd,x) \
-    if(Typeof(x) != TYPE_PLAYER) {   \
+    if (OBJECT_TYPE(x) != TYPE_PLAYER) {   \
         notifyf_nolisten(x, "Only players are allowed to %s.\r", _cmd); \
         return; \
     }
@@ -734,7 +624,7 @@ extern char match_cmdname[BUFFER_LEN];
  * @param x the player to check a wizard bit for
  */
 #define WIZARDONLY(_cmd,x) \
-    if(!Wizard(OWNER(x))) {   \
+    if (!Wizard(OWNER(x))) {   \
         notifyf_nolisten(x, "You are not allowed to %s.\r", _cmd); \
         return; \
     }
@@ -762,7 +652,7 @@ extern char match_cmdname[BUFFER_LEN];
  * @param x the player to check if is a superuser
  */
 #define GODONLY(_cmd,x) \
-    if(!God(x)) {   \
+    if (!God(x)) {   \
         notifyf_nolisten(x, "You are not allowed to %s.\r", _cmd); \
         return; \
     }
@@ -774,7 +664,7 @@ extern char match_cmdname[BUFFER_LEN];
  * Object lists are "connected" via the ->next property on a dbref-based
  * linked list.  This does a for loop to traverse the entire linked list.
  *
- * Use this in place of 'for(...)'
+ * Use this in place of 'for (...)'
  *
  * @param var the variable to use as an iterator - dbref will be stored here
  * @param first the starting dbref
@@ -793,8 +683,6 @@ extern char match_cmdname[BUFFER_LEN];
  */
 #define PUSH(thing, locative) \
     {DBSTORE((thing), next, (locative)); (locative) = (thing);}
-
-typedef long object_flag_type;  /**< Object flag type - need 32+ bits */
 
 /**
  * Each type of object may have a _specific structure associated with it.
@@ -850,7 +738,7 @@ struct program_specific {
  */
 #define FREE_PROGRAM_SP(x)      { \
     dbref foo = x; \
-    if(PROGRAM_SP(foo)) \
+    if (PROGRAM_SP(foo)) \
         free(PROGRAM_SP(foo)); \
     PROGRAM_SP(foo) = (struct program_specific *)NULL; \
 }
@@ -1028,7 +916,7 @@ struct program_specific {
  *
  * @param x the program to increment
  * @return the resultant value
- */ 
+ */
 #define PROGRAM_INC_INSTANCES(x)    (PROGRAM_SP(x)->instances++)
 
 /**
@@ -1039,7 +927,7 @@ struct program_specific {
  *
  * @param x the program to decrement
  * @return the resultant value
- */ 
+ */
 #define PROGRAM_DEC_INSTANCES(x)    (PROGRAM_SP(x)->instances--)
 
 /**
@@ -1050,7 +938,7 @@ struct program_specific {
  *
  * @param x the program to increment
  * @return the resultant value
- */ 
+ */
 #define PROGRAM_INC_INSTANCES_IN_PRIMITIVE(x)   (PROGRAM_SP(x)->instances_in_primitive++)
 
 /**
@@ -1061,7 +949,7 @@ struct program_specific {
  *
  * @param x the program to decrement
  * @return the resultant value
- */ 
+ */
 #define PROGRAM_DEC_INSTANCES_IN_PRIMITIVE(x)   (PROGRAM_SP(x)->instances_in_primitive--)
 
 /**
@@ -1072,7 +960,7 @@ struct program_specific {
  *
  * @param x the program to increment
  * @return the resultant value
- */ 
+ */
 #define PROGRAM_INC_PROF_USES(x)    (PROGRAM_SP(x)->profuses++)
 
 /**
@@ -1958,7 +1846,7 @@ dbref create_action(dbref player, const char *name, dbref source, char *error);
 /**
  * Allocate an PROGRAM type object
  *
- * With a given name and owner/creator.  Returns the DBREF of the program. 
+ * With a given name and owner/creator.  Returns the DBREF of the program.
  * The 'name' memory is copied.  Initializes the "special" fields.
  *
  * Uses an error parameter to communicate the reason for failure. This
@@ -2207,18 +2095,6 @@ int member(dbref thing, dbref list);
 dbref new_object(bool isplayer);
 
 /**
- * Returns true if the object has the given flag set (or reset).
- *
- * Understands flag alias and multiple not conditions (!!x = x, !!!x = !x).
- *
- * Checking "truewizard" is the same as checking "wizard" and "!quell".
- *
- * @param ref the object to check
- * @param flag the flag (or alias) to check
- */
-bool has_flag(dbref ref, const char *flag);
-
-/**
  * Find a dbref in an objnode list
  *
  * @param head the head of the objnode list
@@ -2409,55 +2285,6 @@ void set_source(dbref action, dbref source);
  * @return the calculated size of the object.
  */
 size_t size_object(dbref i, int load);
-
-/**
- * Returns the flag associated with the given string, if any.
- *
- * Understands flag alias prefixes.
- *  
- * Passing "truewizard" here just returns the WIZARD flag.
- *
- * @param ref the object to check
- * @param flag_string the flag (or alias) to check
- * @return the flag corresponding to the string, or 0 if none match.
- */
-object_flag_type str_to_flag(const char *flag_string);
-
-/**
- * "Unparses" flags, or rather, gives a string representation of object flags
- *
- * This uses a static buffer, so make sure to copy it if you want to keep
- * it.  This is, of course, not threadsafe.
- *
- * @param thing the object to construct a flag string for
- * @return the constructed flag string in a static buffer
- */
-const char *unparse_flags(dbref thing);
-
-/**
- * "Unparse" an object, showing itsnam and list of flags if permissions allow
- *
- * Uses the provided buffer that has the given size.  Practically speaking,
- * names can be as long as BUFFER_LEN, so your buffer should probably
- * be BUFFER_LEN at least in size (This is the most common practice).  If
- * a name was actually its maximum length, then there is not enough room
- * for flags to show up.  Traditionally, Fuzzball has not cared about this
- * problem because, traditionally, names just don't get that long.
- *
- * Flags are only shown if:
- *
- * * player == NOTHING
- * * or player does not have STICKY flag AND:
- *   * 'loc' is linkable - @see can_link_to
- *   * or 'loc' is not a player and 'player' controls 'loc'
- *   * or 'loc' is CHOWN_OK
- *
- * @param player the player doing the call or NOTHING
- * @param object the target to generate unparse text for
- * @param buffer the buffer to use
- * @param size the size of the buffer
- */
-void unparse_object(dbref player, dbref object, char *buffer, size_t size);
 
 /**
  * Remove the action from its current location's exit list

--- a/include/fbstrings.h
+++ b/include/fbstrings.h
@@ -526,7 +526,7 @@ char *string_substitute(const char *str, const char *oldstr, const char *newstr,
  * the result into 'buf'
  *
  * WARNING: This does NOT validate the length of 'buf' and that makes
- *          this a potentially dangerous call.  It should be safe 
+ *          this a potentially dangerous call.  It should be safe
  *          if 'buf' is the same size as 'input' or larger.
  *
  * This call effectively removes color from a string, as well as makes

--- a/include/fbtime.h
+++ b/include/fbtime.h
@@ -61,7 +61,7 @@ char *time_format_1(time_t dt);
  * Creates a time string from a UNIX timestamp delta in "format 2" layout.
  *
  * It computes the delta between the given timestamp and GMT time, then
- * goes through a logic process to figure out what "resolution" of 
+ * goes through a logic process to figure out what "resolution" of
  * the timestamp should be.  If the delta is greater than a day, then
  * days is used.  If greater than an hour, then hours is used.  If greater
  * than a minute, then minutes are used.  Otherwise, seconds.

--- a/include/flags.h
+++ b/include/flags.h
@@ -76,6 +76,16 @@
 #define OBJECT_TYPE(ref)   (ref == HOME ? TYPE_ROOM : (FLAGS(ref) & TYPE_MASK))
 
 /**
+ * Returns a pointer to the object_type struct for the given dbref.
+ * 
+ * Does not check to see if 'ref' is a valid ref.
+ *
+ * @param ref the db object to get type info for
+ * @return the related object_type struct
+ */
+#define OBJECT_TYPE_INFO(ref) (&object_types[OBJECT_TYPE(ref)])
+
+/**
  * The MUCKER level of the object, ignoring the WIZARD bit.
  *
  * Does not check to see if 'ref' is a valid object.
@@ -108,6 +118,20 @@
  */
 #define OBJECT_PRIORITY(ref) \
     ((OBJECT_MLEVEL(ref) > 0) ? (OBJECT_MLEVEL(ref) + 1) : (FLAG_CHECK((ref), 'A') ? 0 : 1))
+
+/**
+ * This structure and array define the fundamental object types within the
+ * database and their associated display strings.
+ */
+struct object_type {
+    char symbol;
+    char *uppercase;
+    char *titlecase;
+    char *singular;
+    char *plural;
+};
+
+extern struct object_type object_types[];
 
 typedef long object_flag_type;  /**< Object flag type - need 32+ bits */
 
@@ -234,22 +258,6 @@ void flag_list_verbose(dbref ref, char *buf, size_t size);
  * @param size the size of the buffer
  */
 void flag_unparse_object(dbref player, dbref ref, char *buf, size_t size);
-
-/**
- * Returns the uppercase name of an object's type.
- *
- * @param ref  The object to check.
- * @return     A string like "ROOM", "PLAYER", or "INVALID".
- */
-const char* object_type_name(dbref ref);
-
-/**
- * Returns the titlecase name of an object's type.
- *
- * @param ref  The object to check.
- * @return     A string like "Room", "Player", or "Bad".
- */
-const char* object_type_name_mpi(dbref ref);
 
 /**
  * Returns the flag associated with the given string, if any.

--- a/include/flags.h
+++ b/include/flags.h
@@ -244,6 +244,14 @@ void flag_unparse_object(dbref player, dbref ref, char *buf, size_t size);
 const char* object_type_name(dbref ref);
 
 /**
+ * Returns the titlecase name of an object's type.
+ *
+ * @param ref  The object to check.
+ * @return     A string like "Room", "Player", or "Bad".
+ */
+const char* object_type_name_mpi(dbref ref);
+
+/**
  * Returns the flag associated with the given string, if any.
  *
  * Understands flag alias prefixes.

--- a/include/flags.h
+++ b/include/flags.h
@@ -1,0 +1,280 @@
+/** @file flags.h
+ *
+ * Header that supports the MUCK's object flag and type system.
+ *
+ * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
+ */
+
+#ifndef FLAGS_H
+#define FLAGS_H
+
+#include <stdbool.h>
+
+#include "config.h"
+
+/**
+ * Definitions of the bit used in object flags.
+ */
+#define TYPE_ROOM           0x0 /**< room bit */
+#define TYPE_THING          0x1 /**< thing bit */
+#define TYPE_EXIT           0x2 /**< exit bit */
+#define TYPE_PLAYER         0x3 /**< player bit */
+#define TYPE_PROGRAM        0x4 /**< program bit */
+
+/* 0x5 available */
+
+#define TYPE_GARBAGE        0x6 /**< garbage bit */
+#define TYPE_ANY            0x7 /**< no particular type */
+#define TYPE_MASK           0x7 /**< bitmask for all types */
+
+/* 0x8 available */
+
+#define WIZARD             0x10 /**< gets automatic control */
+#define LINK_OK            0x20 /**< anybody can link to this */
+#define DARK               0x40 /**< contents of room are not printed */
+#define INTERNAL           0x80 /**< internal-use-only flag */
+#define STICKY            0x100 /**< this object goes home when dropped */
+#define BUILDER           0x200 /**< this player can use construction commands */
+#define CHOWN_OK          0x400 /**< allow ownership transfer or enable color */
+#define JUMP_OK           0x800 /**< player and location config for jump commands */
+
+/* 0x1000 available */
+/* 0x2000 available */
+
+#define KILL_OK          0x4000 /**< Kill_OK bit.  Means you can be killed. */
+#define GUEST            0x8000 /**< Guest flag */
+#define HAVEN           0x10000 /**< can't kill here */
+#define ABODE           0x20000 /**< can set home here */
+#define MUCKER          0x40000 /**< programmer */
+#define QUELL           0x80000 /**< When set, wiz-perms are turned off */
+#define SMUCKER        0x100000 /**< second programmer bit.  For levels */
+#define INTERACTIVE    0x200000 /**< internal: player in MUF editor */
+#define OBJECT_CHANGED 0x400000 /**< internal: set when an object is dbdirty()ed */
+
+/* 0x800000 available */
+
+#define VEHICLE       0x1000000 /**< Vehicle flag */
+#define ZOMBIE        0x2000000 /**< Zombie flag */
+#define LISTENER      0x4000000 /**< internal: listener flag */
+#define XFORCIBLE     0x8000000 /**< externally forcible flag */
+#define READMODE     0x10000000 /**< internal: when set, player is in a READ */
+#define SANEBIT      0x20000000 /**< internal: used to check db sanity */
+#define YIELD        0x40000000 /**< Yield flag */
+#define OVERT        0x80000000 /**< Overt flag */
+
+/** what flags to NOT dump to disk. */
+#define DUMP_MASK   (INTERACTIVE | OBJECT_CHANGED | LISTENER | READMODE | SANEBIT)
+
+/**
+ * Returns the TYPE_ value of 'ref'
+ *
+ * Does not check to see if 'ref' is a valid ref.
+ *
+ * @param ref the db object to get type of
+ * @return a type value - one of the TYPE_* constants
+ */
+#define OBJECT_TYPE(ref)   (ref == HOME ? TYPE_ROOM : (FLAGS(ref) & TYPE_MASK))
+
+/**
+ * The MUCKER level of the object, ignoring the WIZARD bit.
+ *
+ * Does not check to see if 'ref' is a valid object.
+ *
+ * @param ref the object to check
+ * @return the MUCKER level of the object (0-3).
+ */
+#define OBJECT_MLEVEL(ref) \
+    ((FLAG_CHECK((ref), 'M') ? 2 : 0) + (FLAG_CHECK((ref), 'N') ? 1 : 0))
+
+/**
+ * The effective MUCKER level of the object, including the WIZARD bit.
+ *
+ * Does not check to see if 'ref' is a valid object.
+ *
+ * @param ref the object to check
+ * @return the effective MUCKER level of the object (0-4).
+ */
+#define OBJECT_EFFECTIVE_MLEVEL(ref) \
+    ((OBJECT_MLEVEL(ref) > 0 && TrueWizard(ref)) ? 4 : OBJECT_MLEVEL(ref))
+
+/**
+ * Returns the priority level of the object, for exit matching. Objects set 'A'
+ * with no MUCKER level are lowest priority.
+ *
+ * Does not check to see if 'ref' is a valid object.
+ *
+ * @param ref the object to check
+ * @return  the priority level of the object (0-4).
+ */
+#define OBJECT_PRIORITY(ref) \
+    ((OBJECT_MLEVEL(ref) > 0) ? (OBJECT_MLEVEL(ref) + 1) : (FLAG_CHECK((ref), 'A') ? 0 : 1))
+
+typedef long object_flag_type;  /**< Object flag type - need 32+ bits */
+
+/**
+ * Callback to determine flag management permissions. Currently unused.
+ */
+typedef bool (*fn_can_set)(int type, char flag, dbref player);
+
+/**
+ * Interface and permission data for a symbol / object type pair.
+ */
+struct flag_data {
+    char symbol;
+    const char *display_name;
+    fn_can_set can_set;
+    bool hidden;
+};
+
+/**
+ * Processed flag context for lookup tables.
+ */
+struct flag_entry {
+    object_flag_type value;
+    char symbol;
+    struct flag_data data;
+};
+
+#define NUM_SYMBOLS 26
+
+/**
+ * Flag lookup table. Declared here so it can be used by FLAG_VALUE().
+ */
+extern struct flag_entry flag_lists_by_symbol[TYPE_ANY+1][NUM_SYMBOLS];
+
+/**
+ * Resolves a flag symbol to its corresponding bitmask value.
+ *
+ * Uses the default TYPE_ANY value for translation.
+ *
+ * @param c the character symbol to look up (e.g., 'W')
+ * @return  the object_flag_type bitmask value
+ */
+#define FLAG_VALUE(c) flag_lists_by_symbol[TYPE_ANY][(c) - 'A'].value
+
+/**
+ * Evaluates whether a specific flag is set on an object.
+ *
+ * Does not check to see if 'ref' is a valid ref.
+ *
+ * @param ref the object dbref to check
+ * @param c   the character symbol of the flag
+ * @return    a boolean representation (0 or 1) of the flag's state
+ */
+#define FLAG_CHECK(ref, c) (!!(db[(ref)].flags & FLAG_VALUE(c)))
+
+/**
+ * Initializes the flag lookup tables from the raw flag list.
+ */
+void flag_init(void);
+
+/**
+ * Evaluates a single flag string against an object.
+ *
+ * Recognizes flag symbols, names, and virtual flag 'truewizard'.
+ *
+ * @param ref  The object to check.
+ * @param p    The flag string (e.g., "W", "!W", "Wizard").
+ * @return     True if the object satisfies the expression.
+ */
+bool flag_eval(dbref ref, const char *spec);
+
+/**
+ * Evaluates a pattern of flag symbols against an object.
+ *
+ * Recognizes type symbols, flag symbols, and MUCKER levels.
+ *
+ * @param ref  The object to check.
+ * @param p    The pattern string (e.g., "PW3" or "J!A").
+ * @return     True if all conditions in the pattern match.
+ */
+bool flag_eval_pattern(dbref ref, const char *pattern);
+
+/**
+ * Generates a string representation of object flags. Uses the provided
+ * buffer that has the given size.
+ *
+ * @param thing the object to construct a flag string for
+ * @param buffer the buffer to use
+ * @param size the size of the buffer
+ */
+void flag_list(dbref ref, char *buf, size_t size);
+
+/**
+ * Generate a long-form text description of the flags on a given object.
+ * Uses the provided buffer that has the given size.
+ *
+ * @param thing to generate description for
+ * @param buffer the buffer to use
+ * @param size the size of the buffer
+ */
+void flag_list_verbose(dbref ref, char *buf, size_t size);
+
+/**
+ * "Unparse" an object, showing its name and list of flags if permissions allow
+ *
+ * Uses the provided buffer that has the given size.  Practically speaking,
+ * names can be as long as BUFFER_LEN, so your buffer should probably
+ * be BUFFER_LEN at least in size (This is the most common practice).  If
+ * a name was actually its maximum length, then there is not enough room
+ * for flags to show up.  Traditionally, Fuzzball has not cared about this
+ * problem because, traditionally, names just don't get that long.
+ *
+ * Flags are only shown if:
+ *
+ * * player == NOTHING
+ * * or player does not have the STICKY flag AND:
+ *   * 'loc' is linkable - @see can_link_to
+ *   * or 'loc' is not a player and 'player' controls 'loc'
+ *   * or 'loc' is CHOWN_OK
+ *
+ * @param player the player doing the call or NOTHING
+ * @param object the target to generate unparse text for
+ * @param buffer the buffer to use
+ * @param size the size of the buffer
+ */
+void flag_unparse_object(dbref player, dbref ref, char *buf, size_t size);
+
+/**
+ * Returns the uppercase name of an object's type.
+ *
+ * @param ref  The object to check.
+ * @return     A string like "ROOM", "PLAYER", or "INVALID".
+ */
+const char* object_type_name(dbref ref);
+
+/**
+ * Returns the flag associated with the given string, if any.
+ *
+ * Understands flag alias prefixes.
+ * Passing "truewizard" here just returns the WIZARD flag.
+ *
+ * @param ref the object to check
+ * @param flag_string the flag (or alias) to check
+ * @return the flag corresponding to the string, or 0 if none match.
+ */
+object_flag_type str_to_flag(const char *flag_string);
+
+/**
+ * Determines if a given player is unable to (re)set the given flag
+ *
+ * The 'business logic' here is actually fairly dense and not easily
+ * summed up in a comment. The reader is encouraged to review the very
+ * well documented code for details.
+ *
+ * This is all pretty well documented in the MUCK's help files.
+ *
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
+ *
+ * @private
+ * @param player the effective aplayer we are checking permissions for
+ * @param mlev the effective mucker level we are checking permissions for
+ * @param thing the thing we want to interact with
+ * @param flag the flag we wish to interact with
+ * @param value whether the desired state is on or off
+ * @param error[out] error message, if any
+ * @return boolean 1 if restricted from setting flag, 0 if okay to set.
+ */
+int unable_to_set_flag(dbref player, int mlev, dbref thing, object_flag_type flag, bool value, char *error);
+#endif /* !FLAGS_H */

--- a/include/hashtab.h
+++ b/include/hashtab.h
@@ -47,7 +47,7 @@ typedef hash_entry *hash_tab;           /**< A hash table itself */
  * @param name the name of the entry to add
  * @param data the data to store
  * @param table the hash stable to store it in
- * @param size the page size of the hash table 
+ * @param size the page size of the hash table
  */
 hash_entry *add_hash(const char *name, hash_data data, hash_tab * table,
                      unsigned int size);

--- a/include/inst.h
+++ b/include/inst.h
@@ -111,7 +111,7 @@ struct muf_proc_data {
  *
  * @param x the variable to fetch data for
  * @return either x->data or "" if x is NULL
- */ 
+ */
 #define DoNullInd(x) ((x) ? (x) -> data : "")
 
 /**

--- a/include/interface.h
+++ b/include/interface.h
@@ -568,7 +568,7 @@ int notify_listeners(dbref who, dbref xprog, dbref obj, dbref room, const char *
  *
  * @param player the player (or zombie) to deliver the message to
  * @param msg the message to send as a character string
- * @param isprivate zombie message filter -- see the notes above. 
+ * @param isprivate zombie message filter -- see the notes above.
  * @return boolean true if message received, false if nothing was queued.
  */
 int notify_nolisten(dbref player, const char *msg, int isprivate);

--- a/include/interp.h
+++ b/include/interp.h
@@ -592,7 +592,7 @@ do { \
  * on the frame structure.
  */
 #define CHECKOFLOW(x) do { \
-        if((*top + (x - 1)) >= STACK_SIZE) \
+        if ((*top + (x - 1)) >= STACK_SIZE) \
             abort_interp("Stack Overflow!"); \
         fr->expect_push_to = *top + (x); \
     } while (0)
@@ -610,7 +610,7 @@ do { \
  * on the frame structure.
  */
 #define CHECKOFLOW(x) do { \
-        if((*top + (x - 1)) >= STACK_SIZE) \
+        if ((*top + (x - 1)) >= STACK_SIZE) \
             abort_interp("Stack Overflow!"); \
     } while (0)
 #endif

--- a/include/look.h
+++ b/include/look.h
@@ -67,7 +67,7 @@ int checkflags(dbref what, struct flgchkdat check);
  * and loads the struct 'check' with the necessary filter paramters.
  *
  * Flags is parsed as follows; it may have an = in it, in which case
- * the "right" side of the = is 
+ * the "right" side of the = is
  *
  * owners (1), locations (3), links (2), count (4), size (5) or default (0)
  *

--- a/include/mcp.h
+++ b/include/mcp.h
@@ -273,7 +273,7 @@ void mcp_frame_package_remove(McpFrame *mfr, const char *package);
  * This removes the package from all McpFrames and renegotiates the ones
  * that need it.  If the package is removed, it will have max/min version 0.
  *
- * @param package the package to renegotiate 
+ * @param package the package to renegotiate
  */
 void mcp_frame_package_renegotiate(const char *package);
 
@@ -443,7 +443,7 @@ void mcp_package_register(const char *pkgname, McpVer minver, McpVer maxver,
  * The send is not immediate, it is queued to the descriptor with queue_write
  *
  * @see queue_write
- * 
+ *
  * @param mfr the frame we're transmitting to
  * @param text the message to send
  */

--- a/include/mfun.h
+++ b/include/mfun.h
@@ -610,7 +610,7 @@ const char *mfn_div(MFUNARGS);
 /**
  * MPI function that returns the boolean value arg0 == arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * For this call, that particular nuance doesn't matter too much.
@@ -791,7 +791,7 @@ const char *mfn_filter(MFUNARGS);
 /**
  * MPI function that returns if an object if it has the given flag (re)set.
  *
- * @see has_flag
+ * @see flag_eval
  *
  * @param descr the descriptor of the caller
  * @param player the ref of the calling player
@@ -804,6 +804,7 @@ const char *mfn_filter(MFUNARGS);
  * @param mesgtyp the type of the message
  * @return string parsed results
  */
+
 const char *mfn_flagp(MFUNARGS);
 
 /**
@@ -823,6 +824,24 @@ const char *mfn_flagp(MFUNARGS);
  * @return string parsed results
  */
 const char *mfn_flags(MFUNARGS);
+
+/**
+ * MPI function that returns if an object's flags match the given pattern.
+ *
+ * @see flag_eval_pattern
+ *
+ * @param descr the descriptor of the caller
+ * @param player the ref of the calling player
+ * @param what the dbref of the trigger
+ * @param perms the dbref for permission consideration
+ * @param argc the number of arguments
+ * @param argv the array of strings for arguments
+ * @param buf the working buffer
+ * @param buflen the size of the buffer
+ * @param mesgtyp the type of the message
+ * @return string parsed results
+ */
+const char *mfn_flagsp(MFUNARGS);
 
 /**
  * MPI function that takes a list, and evaluates a an expression with variables
@@ -991,7 +1010,7 @@ const char *mfn_func(MFUNARGS);
 /**
  * MPI function that returns the boolean value arg0 >= arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * @param descr the descriptor of the caller
@@ -1010,7 +1029,7 @@ const char *mfn_ge(MFUNARGS);
 /**
  * MPI function that returns the boolean value arg0 > arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * @param descr the descriptor of the caller
@@ -1314,7 +1333,7 @@ const char *mfn_lcommon(MFUNARGS);
 /**
  * MPI function that returns the boolean value arg0 <= arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * @param descr the descriptor of the caller
@@ -1587,7 +1606,7 @@ const char *mfn_lsort(MFUNARGS);
 /**
  * MPI function that returns the boolean value arg0 < arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * @param descr the descriptor of the caller
@@ -1665,7 +1684,7 @@ const char *mfn_lunique(MFUNARGS);
 /**
  * MPI function that returns the larger of arg0 and arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * Returns the larger of the two.
@@ -1708,7 +1727,7 @@ const char *mfn_midstr(MFUNARGS);
 /**
  * MPI function that returns the smaller of arg0 and arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * Returns the smaller of the two.
@@ -1877,7 +1896,7 @@ const char *mfn_name(MFUNARGS);
 /**
  * MPI function that returns the boolean value arg0 != arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * For this call, that particular nuance doesn't matter too much.
@@ -2268,7 +2287,7 @@ const char *mfn_revoke(MFUNARGS);
  *
  * arg2 is the padding string which defaults to " " but can be any
  * string.
- * 
+ *
  *
  * @param descr the descriptor of the caller
  * @param player the ref of the calling player
@@ -3005,6 +3024,7 @@ static struct mfun_dat mfun_list[] = {
     {"FILTER", mfn_filter, 0, 0, 0, 3, 5},
     {"FLAG?", mfn_flagp, 1, 0, 1, 2, 2},
     {"FLAGS", mfn_flags, 1, 0, 1, 1, 1},
+    {"FLAGS?", mfn_flagsp, 1, 0, 1, 2, 2},
     {"FOLD", mfn_fold, 0, 0, 0, 4, 5},
     {"FOR", mfn_for, 0, 0, 0, 5, 5},
     {"FORCE", mfn_force, 1, 0, 1, 2, 2},

--- a/include/move.h
+++ b/include/move.h
@@ -40,7 +40,7 @@
  *
  *   Finally, the "X has arrived" notification is sent to the target room.
  *   To make propqueues run after autolook, this message is disconnected from
- *   the arrive propqueue processing which is done further down. 
+ *   the arrive propqueue processing which is done further down.
  *   This notification follows the same rules as the "has left"  message
  *
  * - If 'player' is not a thing, or if 'player' is a ZOMBIE or VEHICLE, then

--- a/include/mpi.h
+++ b/include/mpi.h
@@ -126,7 +126,7 @@ int free_top_mvar(void);
  * How the string is concatinated is controlled by 'mode'.  If mode is
  * 0, then the list is delimited by \\r characters such as with the {list}
  * macro.
- * 
+ *
  * For mode 1, most lines are separated by a single space.  If a line ends in '.', '?',
  * or '!' then a second space is added as well to the delimiter.
  *
@@ -253,7 +253,7 @@ dbref mesg_dbref(int descr, dbref player, dbref what, dbref perms, char *buf, in
  * @param buf the string to match dbref
  * @param mesgtyp the mesgtyp from the MPI call containg blessed perms
  * @return matched ref, UNKNOWN, or PERMDENIED as appropriate
- */ 
+ */
 dbref mesg_dbref_local(int descr, dbref player, dbref what, dbref perms, char *buf,
                        int mesgtyp);
 
@@ -288,7 +288,7 @@ dbref mesg_dbref_raw(int descr, dbref player, dbref what, const char *buf);
  * @param buf the string to match dbref
  * @param mesgtyp the mesgtyp from the MPI call containg blessed perms
  * @return matched ref, UNKNOWN, or PERMDENIED as appropriate
- */ 
+ */
 dbref mesg_dbref_strict(int descr, dbref player, dbref what, dbref perms,
                         char *buf, int mesgtyp);
 
@@ -324,13 +324,13 @@ char *mesg_parse(int descr, dbref player, dbref what, dbref perms,
  *
  * The importance of this function is that it allocates certain standard
  * MPI variables: how (if MPI_NOHOW is not in mesgtyp), cmd, and arg
- * 
+ *
  * Then it runs MesgParse to process the message after those variables
  * are set up.  And finally, it does cleanup.
  *
  * Statistics are kept as part of this call, to keep track of how much
  * time MPI is taking up to run.  This updates all the profile numbers.
- * 
+ *
  * @param descr the descriptor of the calling player
  * @param player the player doing the MPI parsing call
  * @param what the object that triggered the MPI parse call

--- a/include/mufevent.h
+++ b/include/mufevent.h
@@ -59,7 +59,7 @@ stk_array *get_mufevent_pids(stk_array * nw, dbref ref);
  * STARTED which is an integer value UNIX timestamp of the start time
  * SUBTYPE which is hard coded to empty string (events never have a subtype)
  * TYPE which is hard coded to MUFEVENT (this is always a MUF event)
- * 
+ *
  * @param nw the dictionary to put informatin into
  * @param pid the PID to get information for
  * @param pinned pinned value for the "FILTERS" array in the dictionary

--- a/include/p_connects.h
+++ b/include/p_connects.h
@@ -311,9 +311,9 @@ void prim_descr_user(PRIM_PROTOTYPE);
  * Implementation of MUF DESCRIDLE
  *
  * Consumes a descriptor number and returns how many seconds it has been idle.
- * 
+ *
  * @see pdescridle
- * 
+ *
  * @param player the player running the MUF program
  * @param program the program being run
  * @param mlev the effective MUCKER level
@@ -331,7 +331,7 @@ void prim_descr_idle(PRIM_PROTOTYPE);
  * that cannot be determined.
  *
  * @see least_idle_player_descr
- * 
+ *
  * @param player the player running the MUF program
  * @param program the program being run
  * @param mlev the effective MUCKER level
@@ -347,9 +347,9 @@ void prim_descr_notify(PRIM_PROTOTYPE);
  *
  * Consumes a dbref and returns the most idle descriptor number, or -1 if
  * that cannot be determined.
- * 
+ *
  * @see pdescrdbref
- * 
+ *
  * @param player the player running the MUF program
  * @param program the program being run
  * @param mlev the effective MUCKER level
@@ -412,7 +412,7 @@ void prim_descr_most_idle(PRIM_PROTOTYPE);
 void prim_descr_securep(PRIM_PROTOTYPE);
 
 /**
- * Implementation of MUF DESCRBUFSIZE 
+ * Implementation of MUF DESCRBUFSIZE
  *
  * Consumes a descriptor number and returns the number of bytes available.
  *

--- a/include/p_db.h
+++ b/include/p_db.h
@@ -362,6 +362,23 @@ void prim_mlevel(PRIM_PROTOTYPE);
 void prim_flagp(PRIM_PROTOTYPE);
 
 /**
+ * Implementation of MUF FLAGS?
+ *
+ * Consumes a dbref and a flag pattern string ("C!A"), and returns a boolean
+ * that represents if the object's flags are set accordingly.  Requires
+ * remote-read priviliges when applicable.
+ *
+ * @param player the player running the MUF program
+ * @param program the program being run
+ * @param mlev the effective MUCKER level
+ * @param pc the program counter pointer
+ * @param arg the argument stack
+ * @param top the top-most item of the stack
+ * @param fr the program frame
+ */
+void prim_flagsp(PRIM_PROTOTYPE);
+
+/**
  * Implementation of MUF PLAYER?
  *
  * Consumes a dbref, and returns a boolean that represents if the object
@@ -1271,7 +1288,7 @@ void prim_toadplayer(PRIM_PROTOTYPE);
     prim_compile, prim_uncompile, prim_newpassword, prim_getpids,       \
     prim_program_getlines, prim_getpidinfo, prim_program_setlines,	\
     prim_setlinks_array, prim_toadplayer, prim_supplicant,		\
-    prim_pname_history, prim_dump
+    prim_pname_history, prim_dump, prim_flagsp
 
 /**
  * Primitive callback function names - must be in same order as callbacks.
@@ -1292,6 +1309,6 @@ void prim_toadplayer(PRIM_PROTOTYPE);
     "COMPILE", "UNCOMPILE", "NEWPASSWORD", "GETPIDS",      \
     "PROGRAM_GETLINES", "GETPIDINFO", "PROGRAM_SETLINES",  \
     "SETLINKS_ARRAY", "TOADPLAYER", "SUPPLICANT",	   \
-    "PNAME_HISTORY", "DUMP"
+    "PNAME_HISTORY", "DUMP", "FLAGS?"
 
 #endif /* !P_DB_H */

--- a/include/p_math.h
+++ b/include/p_math.h
@@ -111,7 +111,7 @@ void prim_divide(PRIM_PROTOTYPE);
  * @see prim_fmod
  * @see prim_modf
  *
- * Returns the modulo of the lower number by the top number.  
+ * Returns the modulo of the lower number by the top number.
  *
  * Dbrefs and variable numbers can also be manipulated with this.
  *

--- a/include/p_misc.h
+++ b/include/p_misc.h
@@ -585,7 +585,7 @@ void prim_event_send(PRIM_PROTOTYPE);
  *
  * Consumes a string and an object specification, and returns a boolean that
  * represents if an object can be created with the given name.
- * 
+ *
  * The specification can be an object that is of the same type of the object,
  * or a string representing the type.  If the second is used, the values can
  * be one of these case-sensitive strings:

--- a/include/player.h
+++ b/include/player.h
@@ -123,7 +123,7 @@ dbref lookup_player(const char *name);
  *
  * * Passwords cannot be blank
  * * They cannot contain non-printable characters
- * * And also no space characters 
+ * * And also no space characters
  *
  * @param password the password to check
  * @return boolean true if it is valid, false otherwise

--- a/include/predicates.h
+++ b/include/predicates.h
@@ -46,7 +46,7 @@ int can_link(dbref who, dbref what);
  * Checks if 'who' can link an object of type 'what_type' to 'where'
  *
  * Because this may be called prior to the object existing, it is
- * checked by type; however, 'Typeof(dbref)' is often used to see
+ * checked by type; however, OBJECT_TYPE(dbref) is often used to see
  * if some existing objet's ref can link to where.
  *
  * @param who the person we are checking link permissions for

--- a/include/props.h
+++ b/include/props.h
@@ -31,7 +31,7 @@ union pdata_u {
     int val;                /**< Integer data */
     double fval;            /**< Float data */
     dbref ref;              /**< DBREF data */
-    long pos;               /**< Probably unused ? */ 
+    long pos;               /**< Probably unused ? */
 };
 
 /**
@@ -452,7 +452,7 @@ void delete_proplist(PropPtr p);
  * Any errors (no such property) will be written to the buffer.
  *
  * @param player is the player doing the call, and is used to determine
- *        permissions for unparse_object ('ref' type props)
+ *        permissions for flag_unparse_object ('ref' type props)
  * @param obj is the object who's property is being examined.
  * @param name is the property name
  * @param buf is a buffer that you provide for property information to
@@ -538,7 +538,7 @@ void exec_or_notify(int descr, dbref player, dbref thing, const char *message,
  *                     MPI &how or the MUF command.  Such as "(\@Desc)"
  */
 void exec_or_notify_prop(int descr, dbref player, dbref thing,
-                         const char *propname, const char *whatcalled);         
+                         const char *propname, const char *whatcalled);
 
 /**
  * Finds the first node ("leftmost") on the property AVL list 'p' or
@@ -934,7 +934,7 @@ PropPtr propdir_first_elem(PropPtr root, char *path);
 
 /**
  * Fetches a given property from the property path structure 'root'.
- * As this is something of a low level call you may prefer to use 
+ * As this is something of a low level call you may prefer to use
  * get_property
  *
  * @see get_property
@@ -1197,8 +1197,8 @@ void set_standard_property(int descr, dbref player, const char *objname,
  * This method (unlike some others) does full property name validation.
  * Leading / are trimmed off, and if there is a ':' the prop name will
  * be terminated at that point (the : becomes a \0).  The : is defined
- * as PROP_DELIMITER.  
- * 
+ * as PROP_DELIMITER.
+ *
  * If there is no property name after cleanup, this just returns with nothing
  * done.
  *
@@ -1249,8 +1249,8 @@ void set_property_flags(dbref player, const char *pname, int flags);
  * This method (unlike some others) does full property name validation.
  * Leading / are trimmed off, and if there is a ':' the prop name will
  * be terminated at that point (the : becomes a \0).  The : is defined
- * as PROP_DELIMITER.  
- * 
+ * as PROP_DELIMITER.
+ *
  * If there is no property name after cleanup, this just returns with nothing
  * done.
  *

--- a/include/timequeue.h
+++ b/include/timequeue.h
@@ -352,9 +352,9 @@ void listenqueue(int descr, dbref player, dbref where, dbref trigger,
  */
 int in_timequeue(int pid);
 
-/** 
+/**
  * Return the seconds until the the next event will run
- * 
+ *
  * This may be -1 if either the next event is is set to when = -1, or
  * if there is nothing on the queue.  It could be 0 if there is something
  * available to run immediately.  Otherwise, it will be the seconds until

--- a/include/tune.h
+++ b/include/tune.h
@@ -67,7 +67,7 @@ struct tune_entry {
     const char *group;            /**< Configuration group      */
     const char *module;           /**< Associated module        */
     int type;                     /**< Parameter type           */
-    union tuneval defaultval;     /**< Default value            */	
+    union tuneval defaultval;     /**< Default value            */
     union tuneval_ptr currentval; /**< Current value            */
     int readmlev;                 /**< MUCKER level to read     */
     int writemlev;                /**< MUCKER level to write    */

--- a/include/tunelist.h
+++ b/include/tunelist.h
@@ -672,7 +672,7 @@ struct tune_entry tune_list[] = {
         .currentval.n=&tp_exit_cost,
         0,
         MLEV_WIZARD,
-        true 
+        true
     },
     {
         "exit_darking",
@@ -2253,7 +2253,7 @@ struct tune_entry tune_list[] = {
         MLEV_GOD,
         true,
         false,
-        NOTYPE 
+        TYPE_ANY
     },
     {
         "welcome_mpi_who",

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -73,9 +73,9 @@ MALLSRC= crt_malloc.c
 MALLOBJ= crt_malloc.o
 
 SRC= array.c boolexp.c compile.c create.c db.c debugger.c diskprop.c edit.c \
-	events.c fbmath.c fbsignal.c fbstrings.c fbtime.c game.c hashtab.c help.c \
-	interface.c interface_ssl.c interp.c log.c look.c match.c mcp.c mcpgui.c \
-	mcppkgs.c mfuns.c mfuns2.c move.c msgparse.c mufevent.c p_array.c \
+	events.c fbmath.c fbsignal.c fbstrings.c fbtime.c flags.c game.c hashtab.c \
+	help.c interface.c interface_ssl.c interp.c log.c look.c match.c mcp.c \
+	mcpgui.c mcppkgs.c mfuns.c mfuns2.c move.c msgparse.c mufevent.c p_array.c \
 	p_connects.c p_db.c p_error.c p_float.c p_math.c p_mcp.c p_misc.c \
 	p_props.c p_regex.c p_stack.c p_strings.c pennies.c player.c predicates.c \
 	propdirs.c property.c props.c sanity.c set.c smtp.c speech.c \

--- a/src/array.c
+++ b/src/array.c
@@ -1,7 +1,7 @@
 /** @file array.c
  *
  * Source for the different array types used in Fuzzball.  This is primarily
- * used for MUF primitives. 
+ * used for MUF primitives.
  *
  * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
  */
@@ -291,7 +291,7 @@ array_tree_compare_arrays(const array_iter * a, const array_iter * b, int case_s
     }
 
     /* I believe this is to avoid accidental recursion; this way, we make
-     * sure we only check each array once because the visited_set is 
+     * sure we only check each array once because the visited_set is
      * a hash of memory addresses.
      */
     if (!visited_set_add_and_return_if_added(visited_a, a->data.array) ||
@@ -3072,7 +3072,7 @@ array_join(stk_array *arr, const char* delim, char* outbuf, int buflen,
 
     keepgoing = array_first(arr, &temp1);
 
-    while(keepgoing) {
+    while (keepgoing) {
         in = array_getitem(arr, &temp1);
 
         switch (in->type) {

--- a/src/boolexp.c
+++ b/src/boolexp.c
@@ -12,6 +12,7 @@
 #include <string.h>
 
 #include "config.h"
+#include "flags.h"
 
 #include "boolexp.h"
 #include "db.h"
@@ -174,13 +175,13 @@ eval_boolexp_rec(int descr, dbref player, struct boolexp *b, dbref thing)
                     return 0;
 
                 /* Programs are evaluated */
-                if (Typeof(b->data.thing) == TYPE_PROGRAM) {
+                if (OBJECT_TYPE(b->data.thing) == TYPE_PROGRAM) {
                     struct inst *rv;
                     struct frame *tmpfr;
                     dbref real_player;
 
-                    if (Typeof(player) == TYPE_PLAYER ||
-                        Typeof(player) == TYPE_THING)
+                    if (OBJECT_TYPE(player) == TYPE_PLAYER ||
+                        OBJECT_TYPE(player) == TYPE_THING)
                         real_player = player;
                     else
                         real_player = OWNER(player);
@@ -230,8 +231,8 @@ eval_boolexp_rec(int descr, dbref player, struct boolexp *b, dbref thing)
             case BOOLEXP_MPI:
                 if (b->data.mpi) {
                     char buf[BUFFER_LEN];
-                    dbref real_player = (Typeof(player) == TYPE_PLAYER ||
-                            Typeof(player) == TYPE_THING) ? player :
+                    dbref real_player = (OBJECT_TYPE(player) == TYPE_PLAYER ||
+                            OBJECT_TYPE(player) == TYPE_THING) ? player :
                             OWNER(player);
                     const char *result = do_parse_mesg(descr, real_player,
                             thing, b->data.mpi, "(Lock)", buf, sizeof(buf),
@@ -830,7 +831,7 @@ static char *buftop;
  * must be aware that the buffer can mutate under you if another
  * unparse_boolexp happens.  Also, this means the call is not threadsafe.
  *
- * If fullname is true, then DBREFS will be run through unparse_object.
+ * If fullname is true, then DBREFS will be run through flag_unparse_object.
  * Otherwise, #12345 style DBREFs will be displayed.
  *
  * 'outer_type' is used to pass in the node-type of the parent to the
@@ -838,14 +839,14 @@ static char *buftop;
  * parens or not.  The top level node is given outer_type == BOOLEXP_CONST
  * as basically a non-typee.
  *
- * @see unparse_object
+ * @see flag_unparse_object
  *
  * @private
  * @param player the player who is going to see the output of this command
  * @param b the boolean expression to process
  * @param outer_type the type of the parent node
  * @param fullname Show names instead of DBREFs?  True or false.
- */ 
+ */
 static void
 unparse_boolexp1(dbref player, struct boolexp *b, short outer_type, int fullname)
 {
@@ -892,7 +893,7 @@ unparse_boolexp1(dbref player, struct boolexp *b, short outer_type, int fullname
             case BOOLEXP_CONST:
                 if (fullname) {
                     char unparse_buf[BUFFER_LEN];
-                    unparse_object(player, b->data.thing, unparse_buf, sizeof(unparse_buf));
+                    flag_unparse_object(player, b->data.thing, unparse_buf, sizeof(unparse_buf));
                     strcpyn(buftop, sizeof(boolexp_buf) - (size_t)(buftop - boolexp_buf),
                             unparse_buf);
                 } else {
@@ -932,17 +933,17 @@ unparse_boolexp1(dbref player, struct boolexp *b, short outer_type, int fullname
  * must be aware that the buffer can mutate under you if another
  * unparse_boolexp happens.  Also, this means the call is not threadsafe.
  *
- * If fullname is true, then DBREFS will be run through unparse_object.
+ * If fullname is true, then DBREFS will be run through flag_unparse_object.
  * Otherwise, #12345 style DBREFs will be displayed.
  *
- * @see unparse_object
+ * @see flag_unparse_object
  *
  * @param player the player who is going to see the output of this command
  * @param b the boolean expression to process
  * @param fullname Show names instead of DBREFs?  True or false.
  *
  * @return pointer to static buffer containing string for display.
- */ 
+ */
 const char *
 unparse_boolexp(dbref player, struct boolexp *b, int fullname)
 {

--- a/src/compile.c
+++ b/src/compile.c
@@ -22,6 +22,7 @@
 #include "edit.h"
 #include "fbmath.h"
 #include "fbstrings.h"
+#include "flags.h"
 #include "game.h"
 #include "hashtab.h"
 #include "inst.h"
@@ -395,7 +396,7 @@ do_abort_compile(COMPSTATE * cstat, const char *c)
      *
      * If no errors are to be displayed, log them instead.
      */
-    if (((FLAGS(cstat->player) & INTERACTIVE) 
+    if (((FLAGS(cstat->player) & INTERACTIVE)
           && !(FLAGS(cstat->player) & READMODE)) || cstat->force_err_display) {
         notify_nolisten(cstat->player, _buf, 1);
     } else {
@@ -910,7 +911,7 @@ void
 do_uncompile(dbref player)
 {
     for (dbref i = 0; i < db_top; i++) {
-        if (Typeof(i) == TYPE_PROGRAM) {
+        if (OBJECT_TYPE(i) == TYPE_PROGRAM) {
             uncompile_program(i);
         }
     }
@@ -941,9 +942,9 @@ free_unused_programs()
      *       Yah, this is a lil easier said than done :)
      */
     for (dbref i = 0; i < db_top; i++) {
-        if ((Typeof(i) == TYPE_PROGRAM) && !(FLAGS(i) & (ABODE | INTERNAL)) &&
+        if ((OBJECT_TYPE(i) == TYPE_PROGRAM) && !FLAG_CHECK(i, 'A') && !(FLAGS(i) & INTERNAL) &&
             (now - DBFETCH(i)->ts_lastused > tp_clean_interval)
-            && (PROGRAM_INSTANCES(i) == 0)) {
+            && PROGRAM_INSTANCES(i) == 0) {
             uncompile_program(i);
         }
     }
@@ -1030,7 +1031,7 @@ MaybeOptimizeVarsAt(COMPSTATE * cstat, struct INTERMEDIATE *first, int AtNo,
             case PROG_LVAR_AT_CLEAR:
                 if (lvarflag) {
                     if (curr->in.data.number == first->in.data.number) {
-                        /* Can't optimize if references to the variable 
+                        /* Can't optimize if references to the variable
                          * found before a var!
                          */
                         return;
@@ -2880,7 +2881,7 @@ do_compile(int descr, dbref player_in, dbref program_in, int force_err_display)
         notify_nolisten(cstat.player, "Program compiled successfully.", 1);
 
     /* restart AUTOSTART program. */
-    if ((FLAGS(cstat.program) & ABODE) && TrueWizard(OWNER(cstat.program))) {
+    if (FLAG_CHECK(cstat.program, 'A') && TrueWizard(OWNER(cstat.program))) {
         add_muf_queue_event(-1, OWNER(cstat.program), NOTHING, NOTHING,
                             cstat.program, "Startup", "Queued Event.", 0);
         notify_nolisten(cstat.player, "Program autostarted.", 1);
@@ -2992,32 +2993,32 @@ do_string(COMPSTATE * cstat)
  */
 static int
 do_old_comment(COMPSTATE * cstat)
-{		
-    if (!cstat->next_char)		
-        return 1;		
+{
+    if (!cstat->next_char)
+        return 1;
 
-     while (*cstat->next_char && *cstat->next_char != ENDCOMMENT)		
-        cstat->next_char++;		
+     while (*cstat->next_char && *cstat->next_char != ENDCOMMENT)
+        cstat->next_char++;
 
-     if (!(*cstat->next_char)) {		
-        advance_line(cstat);		
+     if (!(*cstat->next_char)) {
+        advance_line(cstat);
 
-         if (!cstat->curr_line) {		
-            return 1;		
-        }		
+         if (!cstat->curr_line) {
+            return 1;
+         }
 
-         return do_old_comment(cstat);		
-    } else {		
-        cstat->next_char++;		
+         return do_old_comment(cstat);
+    } else {
+        cstat->next_char++;
 
-         if (!(*cstat->next_char))		
-            advance_line(cstat);		
-    }		
+         if (!(*cstat->next_char))
+            advance_line(cstat);
+    }
 
-     return 0;		
-}		
+    return 0;
+}
 
-/**		
+/**
  * The "new" comment parser, supporting recursive comments.
  *
  * I believe this means that you can have comments inside comments,
@@ -3113,7 +3114,7 @@ do_new_comment(COMPSTATE * cstat, int depth)
     return 0;
 }
 
-/**		
+/**
   * This implements the skipping of comments in the code by the compiler.
   *
   * 'Depth' is a funny thing here.  It isn't really used the same as depth
@@ -3122,23 +3123,23 @@ do_new_comment(COMPSTATE * cstat, int depth)
   * code or not.  It is, in fact, really kind of superfluous because
   * it is set according to the binary value of cstat->force_comment which
   * is also used in this call.
-  *		
+  *
   * @TODO Remove 'depth' from the calling signature and use
   *       !cstat->force_comment in the two relevant if statements instead.
-  *		
+  *
   * Basically, force_comment and depth should either both be true or both
   * be false, otherwise this code doesn't work "properly".
-  *		
+  *
   * The "do_new_comment" code is used for parsing recursive comments, otherwise
   * the "do_old_comment" code is used.
-  *		
+  *
   * @see do_new_comment
   * @see do_old_comment
-  *		
+  *
   * @private
   * @param cstat compile state structure
   * @param depth boolean that should be the same as cstat->force_comment
-  */		
+  */
 static void
 do_comment(COMPSTATE * cstat, int depth)
 {
@@ -3169,18 +3170,18 @@ do_comment(COMPSTATE * cstat, int depth)
              *       I don't understand why this falls back to the old
              *       parser if force_comment = 0, it would seem to make
              *       more sense to error here.
-             *		
+             *
              *       But frankly this whole function is written strange
              *       so I don't really understand the logic behind any
              *       of this structure.
-             *		
+             *
              *       Its clear to me that "depth" was supposed to mean
              *       something else but it wound up de-facto being a
              *       boolean clone of cstat->force_comment.  Because
              *       there is no original documentation, the original
              *       thought process is lost or at least limited to the
              *       original programmer.
-             */		
+             */
             if (cstat->force_comment) {
                 switch (retval) {
                     case 1:
@@ -3197,7 +3198,7 @@ do_comment(COMPSTATE * cstat, int depth)
                 if (cstat->line_copy) {
                     free((void *) cstat->line_copy);
                     cstat->line_copy = NULL;
-                }		
+                }
 
                 cstat->curr_line = curr_line;
                 cstat->macrosubs = macrosubs;
@@ -3498,7 +3499,7 @@ do_directive(COMPSTATE * cstat, char *direct)
         skip_whitespace(&cstat->next_char);
         advance_line(cstat);
 
-        if (!tmpname || !*tmpname || MLevel(OWNER(cstat->program)) < 4) {
+        if (!tmpname || !*tmpname || OBJECT_EFFECTIVE_MLEVEL(OWNER(cstat->program)) < 4) {
             include_defs(cstat, OWNER(cstat->program));
             include_defs(cstat, (dbref) 0);
         }
@@ -3645,7 +3646,7 @@ do_directive(COMPSTATE * cstat, char *direct)
 
             strcpyn(tempa, sizeof(tempa), match_args);
             strcpyn(tempb, sizeof(tempb), match_cmdname);
-            init_match(cstat->descr, cstat->player, tmpname, NOTYPE, &md);
+            init_match(cstat->descr, cstat->player, tmpname, TYPE_ANY, &md);
             match_registered(&md);
             match_absolute(&md);
             match_me(&md);
@@ -3807,7 +3808,7 @@ do_directive(COMPSTATE * cstat, char *direct)
 
         strcpyn(tempa, sizeof(tempa), match_args);
         strcpyn(tempb, sizeof(tempb), match_cmdname);
-        init_match(cstat->descr, cstat->player, tmpname, NOTYPE, &md);
+        init_match(cstat->descr, cstat->player, tmpname, TYPE_ANY, &md);
         match_registered(&md);
         match_absolute(&md);
         i = (int) match_result(&md);
@@ -3834,7 +3835,7 @@ do_directive(COMPSTATE * cstat, char *direct)
 
         j = 0;
 
-        if (Typeof(i) == TYPE_PROGRAM) {
+        if (OBJECT_TYPE(i) == TYPE_PROGRAM) {
             if (!PROGRAM_CODE(i)) {
                 struct line *tmpline;
 
@@ -3845,8 +3846,8 @@ do_directive(COMPSTATE * cstat, char *direct)
                 PROGRAM_SET_FIRST(i, tmpline);
             }
 
-            if (MLevel(OWNER(i)) > 0 &&
-                (MLevel(OWNER(cstat->program)) >= 4 || OWNER(i) == OWNER(cstat->program)
+            if (OBJECT_EFFECTIVE_MLEVEL(OWNER(i)) > 0 &&
+                (OBJECT_EFFECTIVE_MLEVEL(OWNER(cstat->program)) >= 4 || OWNER(i) == OWNER(cstat->program)
                 || Linkable(i))
             ) {
                 struct publics *pbs;
@@ -3860,7 +3861,7 @@ do_directive(COMPSTATE * cstat, char *direct)
                     pbs = pbs->next;
                 }
 
-                if (pbs && MLevel(OWNER(cstat->program)) >= pbs->mlev)
+                if (pbs && OBJECT_EFFECTIVE_MLEVEL(OWNER(cstat->program)) >= pbs->mlev)
                     j = 1;
             }
         }
@@ -3908,7 +3909,7 @@ do_directive(COMPSTATE * cstat, char *direct)
 
             strcpyn(tempa, sizeof(tempa), match_args);
             strcpyn(tempb, sizeof(tempb), match_cmdname);
-            init_match(cstat->descr, cstat->player, tmpname, NOTYPE, &md);
+            init_match(cstat->descr, cstat->player, tmpname, TYPE_ANY, &md);
             match_registered(&md);
             match_absolute(&md);
             match_me(&md);
@@ -4004,7 +4005,7 @@ do_directive(COMPSTATE * cstat, char *direct)
 
         strcpyn(tempa, sizeof(tempa), match_args);
         strcpyn(tempb, sizeof(tempb), match_cmdname);
-        init_match(cstat->descr, cstat->player, tmpname, NOTYPE, &md);
+        init_match(cstat->descr, cstat->player, tmpname, TYPE_ANY, &md);
         match_registered(&md);
         match_absolute(&md);
         i = (int) match_result(&md);
@@ -4013,7 +4014,7 @@ do_directive(COMPSTATE * cstat, char *direct)
 
         free(tmpname);
 
-        if (OkObj(i) && Typeof(i) == TYPE_PROGRAM) {
+        if (OkObj(i) && OBJECT_TYPE(i) == TYPE_PROGRAM) {
             j = 1;
         } else {
             j = 0;
@@ -5454,7 +5455,7 @@ free_prog_real(dbref prog, const char *file, const int line)
 
     if (c) {
         char unparse_buf[BUFFER_LEN];
-        unparse_object(GOD, prog, unparse_buf, sizeof(unparse_buf));
+        flag_unparse_object(NOTHING, prog, unparse_buf, sizeof(unparse_buf));
 
         /*
          * These sanity checks are to prevent faulty C programming and to

--- a/src/create.c
+++ b/src/create.c
@@ -20,6 +20,7 @@
 #include "edit.h"
 #include "fbmath.h"
 #include "fbstrings.h"
+#include "flags.h"
 #include "game.h"
 #include "log.h"
 #include "move.h"
@@ -91,7 +92,7 @@ do_open(int descr, dbref player, const char *direction, const char *linkto)
         return;
     }
 
-    unparse_object(player, exit, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(player, exit, unparse_buf, sizeof(unparse_buf));
     notifyf(player, "Exit %s opened.", unparse_buf);
 
     /* check second arg to see if we should do a link */
@@ -150,12 +151,12 @@ do_link(int descr, dbref player, const char *thing_name, const char *dest_name)
     if ((thing = noisy_match_result(&md)) == NOTHING)
         return;
 
-    if (Typeof(thing) != TYPE_EXIT && strchr(dest_name, EXIT_DELIMITER)) {
+    if (OBJECT_TYPE(thing) != TYPE_EXIT && strchr(dest_name, EXIT_DELIMITER)) {
         notify(player, "Only actions and exits can be linked to multiple destinations.");
         return;
     }
 
-    switch (Typeof(thing)) {
+    switch (OBJECT_TYPE(thing)) {
         case TYPE_EXIT:
             /* we're ok, check the usual stuff */
             if (DBFETCH(thing)->sp.exit.ndest != 0) {
@@ -203,7 +204,7 @@ do_link(int descr, dbref player, const char *thing_name, const char *dest_name)
 
             if (ndest == 0) {
                 notify(player, "No destinations linked.");
-                if(!Wizard(OWNER(thing)))
+                if (!Wizard(OWNER(thing)))
                     SETVALUE(player, GETVALUE(player) + tp_link_cost);
                 DBDIRTY(player);
                 break;
@@ -228,14 +229,14 @@ do_link(int descr, dbref player, const char *thing_name, const char *dest_name)
             match_me(&md);
             match_here(&md);
 
-            if (Typeof(thing) == TYPE_THING)
+            if (OBJECT_TYPE(thing) == TYPE_THING)
                 match_possession(&md);
 
             if ((dest = noisy_match_result(&md)) == NOTHING)
                 return;
 
             if (!controls(player, thing)
-                || !can_link_to(player, Typeof(thing), dest)) {
+                || !can_link_to(player, OBJECT_TYPE(thing), dest)) {
                 notify(player,
                     "Permission denied. (you don't control the thing, or you can't link to dest)");
                 return;
@@ -247,7 +248,7 @@ do_link(int descr, dbref player, const char *thing_name, const char *dest_name)
             }
 
             /* do the link */
-            if (Typeof(thing) == TYPE_THING) {
+            if (OBJECT_TYPE(thing) == TYPE_THING) {
                 THING_SET_HOME(thing, dest);
             } else {
                 PLAYER_SET_HOME(thing, dest);
@@ -266,7 +267,7 @@ do_link(int descr, dbref player, const char *thing_name, const char *dest_name)
             if ((dest = noisy_match_result(&md)) == NOTHING)
                 break;
 
-            if (!controls(player, thing) || !can_link_to(player, Typeof(thing), dest)
+            if (!controls(player, thing) || !can_link_to(player, OBJECT_TYPE(thing), dest)
                 || (thing == dest)) {
                 notify(player,
                     "Permission denied. (you don't control the room, or can't link to the dropto)");
@@ -281,7 +282,7 @@ do_link(int descr, dbref player, const char *thing_name, const char *dest_name)
             break;
         default:
             notify(player, "Internal error: weird object type.");
-            log_status("PANIC: weird object: Typeof(%d) = %d", thing, Typeof(thing));
+            log_status("PANIC: weird object: OBJECT_TYPE(%d) = %d", thing, OBJECT_TYPE(thing));
             break;
     }
 
@@ -328,7 +329,7 @@ do_dig(int descr, dbref player, const char *name, const char *pname)
 
     newparent = LOCATION(LOCATION(player));
 
-    while ((newparent != NOTHING) && !(FLAGS(newparent) & ABODE))
+    while ((newparent != NOTHING) && !FLAG_CHECK(newparent, 'A'))
         newparent = LOCATION(newparent);
 
     if (newparent == NOTHING)
@@ -340,7 +341,7 @@ do_dig(int descr, dbref player, const char *name, const char *pname)
         return;
     }
 
-    unparse_object(player, room, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(player, room, unparse_buf, sizeof(unparse_buf));
     notifyf(player, "Room %s created.", unparse_buf);
 
     strcpyn(buf, sizeof(buf), pname);
@@ -371,11 +372,11 @@ do_dig(int descr, dbref player, const char *name, const char *pname)
 
         if ((parent = noisy_match_result(&md)) == NOTHING) {
             notify(player, "Parent set to default.");
-        } else if (!can_link_to(player, Typeof(room), parent) || room == parent) {
+        } else if (!can_link_to(player, OBJECT_TYPE(room), parent) || room == parent) {
             notify(player, "Permission denied.  Parent set to default.");
         } else {
             moveto(room, parent);
-            unparse_object(player, parent, unparse_buf, sizeof(unparse_buf));
+            flag_unparse_object(player, parent, unparse_buf, sizeof(unparse_buf));
             notifyf(player, "Parent set to %s.", unparse_buf);
         }
     }
@@ -388,7 +389,7 @@ do_dig(int descr, dbref player, const char *name, const char *pname)
 /**
  * Implementation of \@program
  *
- * First, find a program that matches that name.  If there's one, then we 
+ * First, find a program that matches that name.  If there's one, then we
  * put the player into edit mode and do it.  Otherwise, we create a new object
  * for the player, and call it a program.
  *
@@ -426,7 +427,7 @@ do_program(int descr, dbref player, const char *name, const char *rname)
             return;
         }
 
-        unparse_object(player, program, unparse_buf, sizeof(unparse_buf));
+        flag_unparse_object(player, program, unparse_buf, sizeof(unparse_buf));
         notifyf(player, "Program %s created.", unparse_buf);
 
         if (*rname) {
@@ -526,7 +527,7 @@ do_clone(int descr, dbref player, const char *name, const char *rname)
     /* Further sanity checks */
 
     /* things only. */
-    if (Typeof(thing) != TYPE_THING) {
+    if (OBJECT_TYPE(thing) != TYPE_THING) {
         notify(player, "That is not a cloneable object.");
         return;
     }
@@ -554,8 +555,8 @@ do_clone(int descr, dbref player, const char *name, const char *rname)
         return;
     }
 
-    unparse_object(player, thing, unparse_buf, sizeof(unparse_buf));
-    unparse_object(player, clonedthing, unparse_buf2, sizeof(unparse_buf2));
+    flag_unparse_object(player, thing, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(player, clonedthing, unparse_buf2, sizeof(unparse_buf2));
     notifyf(player, "Object %s cloned as %s.", unparse_buf, unparse_buf2);
 
     if (*rname) {
@@ -621,10 +622,10 @@ do_create(dbref player, char *name, char *acost)
         notify_nolisten(player, error, 1);
         return;
     }
- 
+
     SETVALUE(thing, MAX(0,MIN(OBJECT_ENDOWMENT(cost), tp_max_object_endowment)));
 
-    unparse_object(player, thing, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(player, thing, unparse_buf, sizeof(unparse_buf));
     notifyf(player, "Object %s created.", unparse_buf);
 
     if (*rname) {
@@ -655,7 +656,7 @@ parse_source(int descr, dbref player, const char *source_name)
     dbref source;
     struct match_data md;
 
-    init_match(descr, player, source_name, NOTYPE, &md);
+    init_match(descr, player, source_name, TYPE_ANY, &md);
 
     /* source type can be any */
     match_neighbor(&md);
@@ -675,12 +676,12 @@ parse_source(int descr, dbref player, const char *source_name)
         return NOTHING;
     }
 
-    if (Typeof(source) == TYPE_EXIT) {
+    if (OBJECT_TYPE(source) == TYPE_EXIT) {
         notify(player, "You can't attach an action to an action.");
         return NOTHING;
     }
 
-    if (Typeof(source) == TYPE_PROGRAM) {
+    if (OBJECT_TYPE(source) == TYPE_PROGRAM) {
         notify(player, "You can't attach an action to a program.");
         return NOTHING;
     }
@@ -691,7 +692,7 @@ parse_source(int descr, dbref player, const char *source_name)
 /**
  * This routine attaches a new existing action to a source object, if possible.
  *
- * The action will not do anything until it is LINKed.  This is the 
+ * The action will not do anything until it is LINKed.  This is the
  * implementation of \@action.
  *
  * Action names must pass ok_object_name.
@@ -751,7 +752,7 @@ do_action(int descr, dbref player, const char *action_name,
         return;
     }
 
-    unparse_object(player, action, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(player, action, unparse_buf, sizeof(unparse_buf));
     notifyf(player, "Action %s created and attached.", unparse_buf);
 
     if (tp_autolink_actions) {
@@ -797,7 +798,7 @@ do_attach(int descr, dbref player, const char *action_name, const char *source_n
     if ((action = noisy_match_result(&md)) == NOTHING)
         return;
 
-    if (Typeof(action) != TYPE_EXIT) {
+    if (OBJECT_TYPE(action) != TYPE_EXIT) {
         notify(player, "That's not an action!");
         return;
     } else if (!controls(player, action)) {
@@ -807,7 +808,7 @@ do_attach(int descr, dbref player, const char *action_name, const char *source_n
     }
 
     if (((source = parse_source(descr, player, source_name)) == NOTHING)
-        || Typeof(source) == TYPE_PROGRAM)
+        || OBJECT_TYPE(source) == TYPE_PROGRAM)
         return;
 
     unset_source(action);
@@ -815,7 +816,7 @@ do_attach(int descr, dbref player, const char *action_name, const char *source_n
 
     notify(player, "Action re-attached.");
 
-    if (MLevRaw(action)) {
+    if (OBJECT_MLEVEL(action)) {
         SetMLevel(action, 0);
         notify(player, "Action priority Level reset to zero.");
     }
@@ -858,7 +859,7 @@ do_recycle(int descr, dbref player, const char *name)
     }
 #endif
     if (!controls(player, thing)) {
-        if (Wizard(OWNER(player)) && (Typeof(thing) == TYPE_GARBAGE))
+        if (Wizard(OWNER(player)) && (OBJECT_TYPE(thing) == TYPE_GARBAGE))
             notify(player, "That's already garbage!");
         else
             notify(player,
@@ -871,7 +872,7 @@ do_recycle(int descr, dbref player, const char *name)
             }
         }
 
-        switch (Typeof(thing)) {
+        switch (OBJECT_TYPE(thing)) {
             case TYPE_ROOM:
                 if (OWNER(thing) != OWNER(player)) {
                     notify(player,

--- a/src/crt_malloc.c
+++ b/src/crt_malloc.c
@@ -63,7 +63,7 @@
  Cumulative totals: 102221 10728956                            151500 11586028
 
  * First two columns are source file and line number of a [cm]alloc() call;
- * 
+ *
  * 'CurBlks' is number of ram blocks currently in existence
  *      created by that call;
  *       File Line CurBlks CurBytes MaxBlks MaxBytes MxByTime TotBlks TotBytes
@@ -73,7 +73,7 @@
  * 'TotBytes' is total number of ram bytes ever allocated by that call.
  * 'MaxBytes' is max value 'CurBytes' has ever had for that call.
  * 'MxByTime' is time 'MaxBytes' value was recorded, as day:hour:minute.
- * 
+ *
  * The code adds 8 bytes overhead per ram block allocated.
  *
  * In addition, by defining MALLOC_PROFILING_EXTRA to be TRUE, this file

--- a/src/db.c
+++ b/src/db.c
@@ -22,6 +22,7 @@
 #include "fbstrings.h"
 #include "fbmath.h"
 #include "fbtime.h"
+#include "flags.h"
 #include "game.h"
 #include "interface.h"
 #include "match.h"
@@ -237,7 +238,7 @@ create_action(dbref player, const char *name, dbref source, char *error)
 /**
  * Allocate an PROGRAM type object
  *
- * With a given name and owner/creator.  Returns the DBREF of the program. 
+ * With a given name and owner/creator.  Returns the DBREF of the program.
  * The 'name' memory is copied.  Initializes the "special" fields.
  *
  * Uses an error parameter to communicate the reason for failure. This
@@ -252,7 +253,6 @@ dbref
 create_program(dbref player, const char *name, char *error)
 {
     char buf[BUFFER_LEN];
-    int jj;
 
     if (!ok_object_name(name, TYPE_PROGRAM)) {
         snprintf(error, SMALL_BUFFER_LEN, "You cannot use that name for a program.");
@@ -283,9 +283,12 @@ create_program(dbref player, const char *name, char *error)
      * Set the right MUCKER level - must be at most the MUCKER level of the
      * creating player.
      */
-    jj = MLevel(newprog);
-    if (jj == 0 || jj > MLevel(player))
-        SetMLevel(newprog, MLevel(player));
+    int newprog_mlevel = OBJECT_EFFECTIVE_MLEVEL(newprog);
+    int player_mlevel = OBJECT_EFFECTIVE_MLEVEL(player);
+
+    if (newprog_mlevel == 0 || newprog_mlevel > player_mlevel) {
+        SetMLevel(newprog, player_mlevel);
+    }
 
     return newprog;
 }
@@ -301,7 +304,7 @@ create_program(dbref player, const char *name, char *error)
  *
  * Uses an error parameter to communicate the reason for failure. This
  * should be at least SMALL_BUFFER_LEN in size.
- * 
+ *
  * @param player the owner dbref
  * @param name the name of the new room
  * @param parent the parent room's dbref
@@ -316,8 +319,13 @@ create_room(dbref player, const char *name, dbref parent, char *error)
         return NOTHING;
     }
 
-    dbref newroom = create_object(name, player,
-                    TYPE_ROOM | (FLAGS(player) & JUMP_OK));
+    object_flag_type new_flags = TYPE_ROOM;
+
+    if (FLAG_CHECK(player, 'J')) {
+        new_flags |= FLAG_VALUE('J');
+    }
+
+    dbref newroom = create_object(name, player, new_flags);
 
     LOCATION(newroom) = parent;
     PUSH(newroom, CONTENTS(parent));
@@ -342,7 +350,7 @@ create_room(dbref player, const char *name, dbref parent, char *error)
  *
  * Uses an error parameter to communicate the reason for failure. This
  * should be at least SMALL_BUFFER_LEN in size.
- * 
+ *
  * @param player the owner dbref
  * @param name the name of the new thing
  * @param location the location to place the object
@@ -385,7 +393,7 @@ create_thing(dbref player, const char *name, dbref location, char *error)
  *
  * Uses an error parameter to communicate the reason for failure. This
  * should be at least SMALL_BUFFER_LEN in size.
- * 
+ *
  * @param thing the thing to clone
  * @param player the player for determining the cloned thing's home
  * @param copy_hidden_props if true, this copies hidden properties
@@ -554,7 +562,7 @@ db_write_object(FILE * f, dbref i)
     putproperties(f, i);
 #endif /* DISKBASE */
 
-    switch (Typeof(i)) {
+    switch (OBJECT_TYPE(i)) {
         case TYPE_THING:
             putref(f, THING_HOME(i));
             putref(f, o->exits);
@@ -919,7 +927,7 @@ db_free_object(dbref i)
      * Do this before freeing the name because uncompile_program()
      * may try to print some error messages.
      */
-    if (Typeof(i) == TYPE_PROGRAM) {
+    if (OBJECT_TYPE(i) == TYPE_PROGRAM) {
         uncompile_program(i);
 
         if (PROGRAM_FIRST(i)) {
@@ -942,9 +950,9 @@ db_free_object(dbref i)
     }
 #endif
 
-    if (Typeof(i) == TYPE_EXIT) {
+    if (OBJECT_TYPE(i) == TYPE_EXIT) {
         free(o->sp.exit.dest);
-    } else if (Typeof(i) == TYPE_PLAYER) {
+    } else if (OBJECT_TYPE(i) == TYPE_PLAYER) {
         free((void *) PLAYER_PASSWORD(i));
         free(PLAYER_DESCRS(i));
         PLAYER_SET_DESCRS(i, NULL);
@@ -953,11 +961,11 @@ db_free_object(dbref i)
         ignore_flush_cache(i);
     }
 
-    if (Typeof(i) == TYPE_THING) {
+    if (OBJECT_TYPE(i) == TYPE_THING) {
         FREE_THING_SP(i);
     }
 
-    if (Typeof(i) == TYPE_PLAYER) {
+    if (OBJECT_TYPE(i) == TYPE_PLAYER) {
         FREE_PLAYER_SP(i);
     }
 }
@@ -1034,7 +1042,7 @@ db_read_object(FILE * f, dbref objno)
     o->ts_modified = getref(f);
 
     c = getc(f);
- 
+
     if (c == '*') {
 #ifdef DISKBASE
         o->propsfpos = ftell(f);
@@ -1154,8 +1162,8 @@ autostart_progs(void)
     }
 
     for (dbref i = 0; i < db_top; i++) {
-        if (Typeof(i) == TYPE_PROGRAM) {
-            if ((FLAGS(i) & ABODE) && TrueWizard(OWNER(i))) {
+        if (OBJECT_TYPE(i) == TYPE_PROGRAM) {
+            if (FLAG_CHECK(i, 'A') && TrueWizard(OWNER(i))) {
                 /*
                  * Pre-compile AUTOSTART programs.  They queue up when they
                  * finish compiling.
@@ -1221,7 +1229,7 @@ db_read(FILE * f)
     tune_load_parms_from_file(f, NOTHING, getref(f));
 
     for (dbref j = 0; j < db_top; j++) {
-        if (Typeof(j) == TYPE_GARBAGE) {
+        if (OBJECT_TYPE(j) == TYPE_GARBAGE) {
             NEXTOBJ(j) = recyclable;
             recyclable = j;
         }
@@ -1294,179 +1302,7 @@ objnode_pop(objnode **head)
     dbref ref = tmp->data;
     *head = tmp->next;
     free(tmp);
-    return ref; 
-}
-
-/**
- * "Unparses" flags, or rather, gives a string representation of object flags
- *
- * This uses a static buffer, so make sure to copy it if you want to keep
- * it.  This is, of course, not threadsafe.
- *
- * @param thing the object to construct a flag string for
- * @return the constructed flag string in a static buffer
- */
-const char *
-unparse_flags(dbref thing)
-{
-    static char buf[BUFFER_LEN];
-    char *p;
-    const char *type_codes = "R-EPFG";
-
-    p = buf;
-    if (Typeof(thing) != TYPE_THING)
-        *p++ = type_codes[Typeof(thing)];
-
-    /*
-     * @TODO In a perfect world, this would be more configuration based
-     *       and not a long line of if statements.  But, it must be
-     *       high performance because it is used a lot.
-     *
-     *       I don't really have an idea here, to be honest, but its
-     *       something to think about (tanabi)
-     */
-    if (FLAGS(thing) & ~TYPE_MASK) {
-        /* print flags */
-        if (FLAGS(thing) & WIZARD)
-            *p++ = 'W';
-
-        if (FLAGS(thing) & LINK_OK)
-            *p++ = 'L';
-
-        if (FLAGS(thing) & KILL_OK)
-            *p++ = 'K';
-
-        if (FLAGS(thing) & DARK)
-            *p++ = 'D';
-
-        if (FLAGS(thing) & STICKY)
-            *p++ = 'S';
-
-        if (FLAGS(thing) & QUELL)
-            *p++ = 'Q';
-
-        if (FLAGS(thing) & BUILDER)
-            *p++ = 'B';
-
-        if (FLAGS(thing) & CHOWN_OK)
-            *p++ = 'C';
-
-        if (FLAGS(thing) & JUMP_OK)
-            *p++ = 'J';
-
-        if (FLAGS(thing) & GUEST)
-            *p++ = 'G';
-
-        if (FLAGS(thing) & HAVEN)
-            *p++ = 'H';
-
-        if (FLAGS(thing) & ABODE)
-            *p++ = 'A';
-
-        if (FLAGS(thing) & VEHICLE)
-            *p++ = 'V';
-
-        if (FLAGS(thing) & XFORCIBLE)
-            *p++ = 'X';
-
-        if (FLAGS(thing) & ZOMBIE)
-            *p++ = 'Z';
-
-        if (FLAGS(thing) & YIELD)
-            *p++ = 'Y';
-
-        if (FLAGS(thing) & OVERT)
-            *p++ = 'O';
-
-        if (MLevRaw(thing)) {
-            *p++ = 'M';
-
-            switch (MLevRaw(thing)) {
-                case 1:
-                    *p++ = '1';
-                    break;
-
-                case 2:
-                    *p++ = '2';
-                    break;
-
-                case 3:
-                    *p++ = '3';
-                    break;
-            }
-        }
-    }
-
-    *p = '\0';
-    return buf;
-}
-
-/**
- * "Unparse" an object, showing itsnam and list of flags if permissions allow
- *
- * Uses the provided buffer that has the given size.  Practically speaking,
- * names can be as long as BUFFER_LEN, so your buffer should probably
- * be BUFFER_LEN at least in size (This is the most common practice).  If
- * a name was actually its maximum length, then there is not enough room
- * for flags to show up.  Traditionally, Fuzzball has not cared about this
- * problem because, traditionally, names just don't get that long.
- *
- * Flags are only shown if:
- *
- * * player == NOTHING
- * * or player does not have STICKY flag AND:
- *   * 'loc' has flags that can be seen - @see can_see_flags
- *   * or 'loc' is not a player and 'player' controls 'loc'
- *   * or 'loc' is CHOWN_OK
- *
- * @param player the player doing the call or NOTHING
- * @param loc the target to generate unparse text for
- * @param buffer the buffer to use
- * @param size the size of the buffer
- */
-void
-unparse_object(dbref player, dbref loc, char *buffer, size_t size)
-{
-    /* Handle ZOMBIE case */
-    if (player != NOTHING)
-        player = OWNER(player);
-
-    switch (loc) {
-        case NOTHING:
-            strcpyn(buffer, size, "*NOTHING*");
-            return;
-
-        case AMBIGUOUS:
-            strcpyn(buffer, size, "*AMBIGUOUS*");
-            return;
-
-        case HOME:
-            strcpyn(buffer, size, "*HOME*");
-            return;
-
-        case NIL:
-            strcpyn(buffer, size, "*NIL*");
-            return;
-
-        default:
-            if (!ObjExists(loc)) {
-                strcpyn(buffer, size, "*INVALID*");
-                return;
-            }
-
-            if ((player == NOTHING) || (!(FLAGS(player) & STICKY) &&
-                (can_see_flags(player, loc) ||
-                ((Typeof(loc) != TYPE_PLAYER) &&
-                (controls_link(player, loc)
-                || (FLAGS(loc) & CHOWN_OK)))))) {
-                /* show everything */
-                snprintf(buffer, size, "%.*s(#%d%s)", (BUFFER_LEN / 2), NAME(loc), loc,
-                         unparse_flags(loc));
-            } else {
-                /* show only the name */
-                strcpyn(buffer, size, NAME(loc));
-            }
-    }
+    return ref;
 }
 
 /**
@@ -1598,11 +1434,11 @@ size_object(dbref i, int load)
      *       here and in db.h
      */
 
-    if (Typeof(i) == TYPE_EXIT && DBFETCH(i)->sp.exit.dest) {
+    if (OBJECT_TYPE(i) == TYPE_EXIT && DBFETCH(i)->sp.exit.dest) {
         byts += sizeof(dbref) * (size_t)(DBFETCH(i)->sp.exit.ndest);
-    } else if (Typeof(i) == TYPE_PLAYER && PLAYER_PASSWORD(i)) {
+    } else if (OBJECT_TYPE(i) == TYPE_PLAYER && PLAYER_PASSWORD(i)) {
         byts += strlen(PLAYER_PASSWORD(i)) + 1;
-    } else if (Typeof(i) == TYPE_PROGRAM) {
+    } else if (OBJECT_TYPE(i) == TYPE_PROGRAM) {
         byts += size_prog(i);
     }
 
@@ -1746,10 +1582,10 @@ getparent_logic(dbref obj)
     if (obj == NOTHING)
         return NOTHING;
 
-    if (Typeof(obj) == TYPE_THING && (FLAGS(obj) & VEHICLE)) {
+    if (OBJECT_TYPE(obj) == TYPE_THING && FLAG_CHECK(obj, 'V')) {
         obj = THING_HOME(obj);
 
-        if (obj != NOTHING && Typeof(obj) == TYPE_PLAYER) {
+        if (obj != NOTHING && OBJECT_TYPE(obj) == TYPE_PLAYER) {
             obj = PLAYER_HOME(obj);
         }
     } else {
@@ -1791,7 +1627,7 @@ getparent(dbref obj)
             obj = getparent_logic(obj);
         } while (obj != (oldptr = ptr = getparent_logic(ptr)) &&
                  obj != (ptr = getparent_logic(ptr)) &&
-                 obj != NOTHING && Typeof(obj) == TYPE_THING);
+                 obj != NOTHING && OBJECT_TYPE(obj) == TYPE_THING);
 
         if (obj != NOTHING && (obj == oldptr || obj == ptr)) {
             obj = GLOBAL_ENVIRONMENT;
@@ -1847,10 +1683,10 @@ controls(dbref who, dbref what)
          * -winged
          */
         for (dbref index = what; index != NOTHING; index = LOCATION(index)) {
-            if ((OWNER(index) == who) && (Typeof(index) == TYPE_ROOM)
+            if ((OWNER(index) == who) && (OBJECT_TYPE(index) == TYPE_ROOM)
                 && Wizard(index)) {
                 /* Realm Owner doesn't control other Player objects */
-                if (Typeof(what) == TYPE_PLAYER) {
+                if (OBJECT_TYPE(what) == TYPE_PLAYER) {
                     return 0;
                 } else {
                     return 1;
@@ -1882,8 +1718,8 @@ controls(dbref who, dbref what)
 int
 controls_link(dbref who, dbref what)
 {
-    switch (Typeof(what)) {
-    case TYPE_EXIT: 
+    switch (OBJECT_TYPE(what)) {
+    case TYPE_EXIT:
         for (int i = 0, n = DBFETCH(what)->sp.exit.ndest; i < n; i++) {
             if (controls(who, DBFETCH(what)->sp.exit.dest[i]))
                 return 1;
@@ -1973,7 +1809,7 @@ parse_linkable_dest(int descr, dbref player, dbref exit, const char *dest_name)
     dbref dobj;                 /* destination room/player/thing/link */
     struct match_data md;
 
-    init_match(descr, player, dest_name, NOTYPE, &md);
+    init_match(descr, player, dest_name, TYPE_ANY, &md);
     match_everything(&md);
     match_home(&md);
     match_nil(&md);
@@ -1982,9 +1818,9 @@ parse_linkable_dest(int descr, dbref player, dbref exit, const char *dest_name)
         return NOTHING;
     }
 
-    if (dobj != NIL && !tp_teleport_to_player && Typeof(dobj) == TYPE_PLAYER) {
+    if (dobj != NIL && !tp_teleport_to_player && OBJECT_TYPE(dobj) == TYPE_PLAYER) {
         char unparse_buf[BUFFER_LEN];
-        unparse_object(player, dobj, unparse_buf, sizeof(unparse_buf));
+        flag_unparse_object(player, dobj, unparse_buf, sizeof(unparse_buf));
         notifyf(player, "You can't link to players.  Destination %s ignored.",
                 unparse_buf);
         return NOTHING;
@@ -1995,9 +1831,9 @@ parse_linkable_dest(int descr, dbref player, dbref exit, const char *dest_name)
         return NOTHING;
     }
 
-    if (!can_link_to(player, Typeof(exit), dobj)) {
+    if (!can_link_to(player, OBJECT_TYPE(exit), dobj)) {
         char unparse_buf[BUFFER_LEN];
-        unparse_object(player, dobj, unparse_buf, sizeof(unparse_buf));
+        flag_unparse_object(player, dobj, unparse_buf, sizeof(unparse_buf));
         notifyf(player, "You can't link to %s.", unparse_buf);
         return NOTHING;
     } else {
@@ -2089,9 +1925,9 @@ _link_exit(int descr, dbref player, dbref exit, char *dest_name,
             continue;
         }
 
-        unparse_object(player, dest, unparse_buf, sizeof(unparse_buf));
+        flag_unparse_object(player, dest, unparse_buf, sizeof(unparse_buf));
 
-        switch (Typeof(dest)) {
+        switch (OBJECT_TYPE(dest)) {
             case TYPE_PLAYER:
             case TYPE_ROOM:
             case TYPE_PROGRAM:
@@ -2130,7 +1966,7 @@ _link_exit(int descr, dbref player, dbref exit, char *dest_name,
 
             default:
                 notify(player, "Internal error: weird object type.");
-                log_status("PANIC: weird object: Typeof(%d) = %d", dest, Typeof(dest));
+                log_status("PANIC: weird object: OBJECT_TYPE(%d) = %d", dest, OBJECT_TYPE(dest));
 
                 if (dryrun)
                     error = 1;
@@ -2284,7 +2120,7 @@ register_object(dbref player, dbref location, const char *propdir, char *name,
         }
 
         if (prevobj != -50) {
-            unparse_object(player, prevobj, unparse_buf, sizeof(unparse_buf));
+            flag_unparse_object(player, prevobj, unparse_buf, sizeof(unparse_buf));
             notifyf_nolisten(player, "Used to be registered as %s: %s", buf, unparse_buf);
         }
     } else if (object == NOTHING) {
@@ -2292,8 +2128,8 @@ register_object(dbref player, dbref location, const char *propdir, char *name,
         return;
     }
 
-    unparse_object(player, object, unparse_buf, sizeof(unparse_buf));
-    unparse_object(player, location, unparse_buf2, sizeof(unparse_buf2));
+    flag_unparse_object(player, object, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(player, location, unparse_buf2, sizeof(unparse_buf2));
 
     if (object == NOTHING) {
         remove_property(location, buf);
@@ -2341,129 +2177,6 @@ env_distance(dbref from, dbref to)
 }
 
 /**
- * Returns the flag associated with the given string, if any.
- *
- * Understands flag alias prefixes.
- *
- * Passing "truewizard" here just returns the WIZARD flag.
- *
- * @param ref the object to check
- * @param flag_string the flag (or alias) to check
- * @return the flag corresponding to the string, or 0 if none match.
- */
-object_flag_type
-str_to_flag(const char *flag_string)
-{
-    if (!*flag_string) {
-        return 0;
-    }
-
-    if (string_prefix("abode", flag_string)
-            || string_prefix("autostart", flag_string)
-            || string_prefix("abate", flag_string)) {
-        return ABODE;
-    } else if (string_prefix("builder", flag_string)
-            || string_prefix("bound", flag_string)) {
-        return BUILDER;
-    } else if (string_prefix("chown_ok", flag_string)
-            || string_prefix("color", flag_string)) {
-        return CHOWN_OK;
-    } else if (string_prefix("dark", flag_string)
-            || string_prefix("debug", flag_string)) {
-        return DARK;
-    } else if (string_prefix("guest", flag_string)) {
-        return GUEST;
-    } else if (string_prefix("haven", flag_string)
-            || string_prefix("hide", flag_string)
-            || string_prefix("harduid", flag_string)) {
-        return HAVEN;
-    } else if (string_prefix("interactive", flag_string)) {
-        return INTERACTIVE;
-    } else if (string_prefix("jump_ok", flag_string)) {
-        return JUMP_OK;
-    } else if (string_prefix("kill_ok", flag_string)) {
-        return KILL_OK;
-    } else if (string_prefix("link_ok", flag_string)) {
-        return LINK_OK;
-    } else if (string_prefix("mucker", flag_string)) {
-        return MUCKER;
-    } else if (string_prefix("nucker", flag_string)) {
-        return SMUCKER;
-    } else if (string_prefix("overt", flag_string)) {
-        return OVERT;
-    } else if (string_prefix("quell", flag_string)) {
-        return QUELL;
-    } else if (string_prefix("sticky", flag_string)
-            || string_prefix("silent", flag_string)
-            || string_prefix("setuid", flag_string)) {
-        return STICKY;
-    } else if (string_prefix("vehicle", flag_string)
-            || string_prefix("viewable", flag_string)) {
-        return VEHICLE;
-    } else if (string_prefix("wizard", flag_string)) {
-        return WIZARD;
-    } else if (string_prefix("truewizard", flag_string)) {
-        return WIZARD;
-    } else if (string_prefix("xforcible", flag_string)
-            || string_prefix("xpress", flag_string)) {
-        return XFORCIBLE;
-    } else if (string_prefix("yield", flag_string)) {
-        return YIELD;
-    } else if (string_prefix("zombie", flag_string)) {
-        return ZOMBIE;
-    }
-
-    return 0;
-}
-
-
-/**
- * Returns true if the object has the given flag set (or reset).
- *
- * Understands flag alias prefixes and multiple not conditions (!!x = x).
- *
- * Checking "truewizard" is the same as checking "wizard" and "!quell".
- *
- * @param ref the object to check
- * @param flag the flag (or alias) to check
- * @return if the object has the specific flag state
- */
-bool
-has_flag(dbref ref, const char *flag)
-{
-    object_flag_type tmp = 0;
-    int truwiz = 0;
-    bool result, negated = false;
-
-    while (*flag == NOT_TOKEN) {
-        flag++;
-        negated = (!negated);
-    }
-
-    if (string_prefix("truewizard", flag)) {
-        truwiz = 1;
-    }
-
-    tmp = str_to_flag(flag);
-
-    if (negated) {
-        if ((!truwiz) && (tmp == WIZARD)) {
-            result = (!Wizard(ref));
-        } else {
-            result = (tmp && ((FLAGS(ref) & tmp) == 0));
-        }
-    } else {
-        if ((!truwiz) && (tmp == WIZARD)) {
-            result = Wizard(ref);
-        } else {
-            result = (tmp && ((FLAGS(ref) & tmp) != 0));
-        }
-    }
-
-    return result;
-}
-
-/**
  * Helper function to collect object statistics.
  *
  * Populates the stats array with counts of owned objects: total, rooms, exits,
@@ -2487,7 +2200,7 @@ collect_dbstats(dbref player, dbref ref, int stats[7])
     for (dbref i = 0; i < db_top; i++) {
         if (ref == NOTHING || OWNER(i) == ref) {
             for (int t = 0, n = ARRAYSIZE(types); t < n; t++) {
-                if (Typeof(i) == types[t]) {
+                if (OBJECT_TYPE(i) == types[t]) {
                     stats[t+1]++;
                     stats[0]++;
                     break;

--- a/src/debugger.c
+++ b/src/debugger.c
@@ -195,7 +195,7 @@ show_line_prims(dbref program, struct inst *pc, int maxprims, int markpc)
     /*
      * We're in the right position; loop from linestart til lineend,
      * putting together text versions of the instructions.
-     */ 
+     */
     while (linestart <= lineend) {
         if (strlen(buf) < BUFFER_LEN / 2) {
             if (*buf)

--- a/src/diskprop.c
+++ b/src/diskprop.c
@@ -188,7 +188,7 @@ putprops_copy(FILE * f, dbref obj)
         return;
     }
 
-    /* 
+    /*
      * If we got this far, then we're copying properties from 'input_file'
      * to the output.
      */

--- a/src/edit.c
+++ b/src/edit.c
@@ -19,6 +19,7 @@
 #include "db.h"
 #include "edit.h"
 #include "fbstrings.h"
+#include "flags.h"
 #include "inst.h"
 #include "interface.h"
 #include "interp.h"
@@ -705,7 +706,7 @@ static void
 do_quit(dbref player, dbref program)
 {
     char unparse_buf[BUFFER_LEN];
-    unparse_object(player, program, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(player, program, unparse_buf, sizeof(unparse_buf));
     log_status("PROGRAM SAVED: %s by %s(%d)", unparse_buf,
                NAME(player), player);
     write_program(PROGRAM_FIRST(program), program);
@@ -879,12 +880,12 @@ val_and_head(dbref player, int arg[], int argc)
 
     program = arg[0];
 
-    if (!ObjExists(program) || Typeof(program) != TYPE_PROGRAM) {
+    if (!ObjExists(program) || OBJECT_TYPE(program) != TYPE_PROGRAM) {
         notify(player, "That isn't a program.");
         return;
     }
 
-    if (!(controls(player, program) || (FLAGS(program) & VEHICLE))) {
+    if (!(controls(player, program) || FLAG_CHECK(program, 'V'))) {
         notify(player, "That's not a public program.");
         return;
     }
@@ -921,12 +922,12 @@ list_publics(int descr, dbref player, int arg[], int argc)
 
     program = (argc == 0) ? PLAYER_CURR_PROG(player) : arg[0];
 
-    if (!OkObj(program) || Typeof(program) != TYPE_PROGRAM) {
+    if (!OkObj(program) || OBJECT_TYPE(program) != TYPE_PROGRAM) {
         notify(player, "That isn't a program.");
         return;
     }
 
-    if (!(controls(player, program) || (FLAGS(program) & VEHICLE))) {
+    if (!(controls(player, program) || FLAG_CHECK(program, 'V'))) {
         notify(player, "That's not a public program.");
         return;
     }
@@ -946,7 +947,7 @@ list_publics(int descr, dbref player, int arg[], int argc)
 
         if (!PROGRAM_CODE(program)) {
             char unparse_buf[BUFFER_LEN];
-            unparse_object(player, program, unparse_buf, sizeof(unparse_buf));
+            flag_unparse_object(player, program, unparse_buf, sizeof(unparse_buf));
             notifyf(player, "Unable to compile %s.", unparse_buf);
             return;
         }
@@ -1418,12 +1419,12 @@ do_list(int descr, dbref player, const char *name, char *linespec)
     if ((thing = noisy_match_result(&md)) == NOTHING)
         return;
 
-    if (Typeof(thing) != TYPE_PROGRAM) {
+    if (OBJECT_TYPE(thing) != TYPE_PROGRAM) {
         notify(player, "You can't list anything but a program.");
         return;
     }
 
-    if (!(controls(player, thing) || (FLAGS(thing) & VEHICLE))) {
+    if (!(controls(player, thing) || FLAG_CHECK(thing, 'V'))) {
         notify(player,
                "Permission denied. (You don't control the program, and it's not set Viewable)");
         return;
@@ -1645,7 +1646,7 @@ edit_program(dbref player, dbref program)
 {
     char unparse_buf[BUFFER_LEN];
 
-    if ((Typeof(program) != TYPE_PROGRAM) || !controls(player, program)) {
+    if ((OBJECT_TYPE(program) != TYPE_PROGRAM) || !controls(player, program)) {
         notify(player, "Permission denied!");
         return;
     }
@@ -1664,7 +1665,7 @@ edit_program(dbref player, dbref program)
     FLAGS(player) |= INTERACTIVE;
     DBDIRTY(player);
 
-    unparse_object(player, program, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(player, program, unparse_buf, sizeof(unparse_buf));
     notifyf(player, "Entering editor for %s.", unparse_buf);
 
     list_program(player, program, NULL, 0, 0);

--- a/src/events.c
+++ b/src/events.c
@@ -125,7 +125,7 @@ dump_db_now()
 
 /**
  * @private
- * @var last cleanup time for cleaning up the for pool and 
+ * @var last cleanup time for cleaning up the for pool and
  */
 static time_t last_clean_time = 0L;
 

--- a/src/fbmath.c
+++ b/src/fbmath.c
@@ -90,7 +90,7 @@ arith_type(short op1_type, short op2_type)
 int
 comp_t(short op_type)
 {
-    return (op_type == PROG_INTEGER || op_type == PROG_FLOAT 
+    return (op_type == PROG_INTEGER || op_type == PROG_FLOAT
             || op_type == PROG_OBJECT);
 }
 
@@ -328,7 +328,7 @@ xMD5Update(struct xMD5Context *ctx, const uint8_t * buf, size_t len)
 /**
  * Finalize an MD5 digest
  *
- * Final wrapup - pad to 64-byte boundary with the bit pattern 
+ * Final wrapup - pad to 64-byte boundary with the bit pattern
  * 1 0* (64-bit count of bits processed, MSB-first)
  *
  * @private

--- a/src/fbsignal.c
+++ b/src/fbsignal.c
@@ -357,7 +357,7 @@ sig_reap(int i)
      * knowing about it, and dealing with it as necessary.
      *
      * The fix for SSL connections getting closed when databases were
-     * saved with DISKBASE disabled required closing all sockets 
+     * saved with DISKBASE disabled required closing all sockets
      * when the server fork()ed.  This made it impossible for that
      * process to spit out the "save done" message.  However, because
      * that process dies as soon as it finishes dumping the database,

--- a/src/fbstrings.c
+++ b/src/fbstrings.c
@@ -311,7 +311,7 @@ pronoun_substitute(int descr, dbref player, const char *str)
         sexstr = do_parse_mesg(descr, player, player, sexstr, "(Lock)", sexbuf,
                                sizeof(sexbuf),
                                (MPI_ISPRIVATE | MPI_ISLOCK |
-                                (Prop_Blessed(player, tp_gender_prop) ? 
+                                (Prop_Blessed(player, tp_gender_prop) ?
                                  MPI_ISBLESSED : 0)));
     }
 
@@ -740,7 +740,7 @@ strencrypt(const char *data, const char *key)
         if (!*(++cp))
             cp = key;
 
-        result = (enarr[(unsigned char) *upt] - (32 - (CHARCOUNT - 96))) + 
+        result = (enarr[(unsigned char) *upt] - (32 - (CHARCOUNT - 96))) +
                  count + seed;
         *ups = (char)enarr[(result % CHARCOUNT) + (32 - (CHARCOUNT - 96))];
         count = (((*upt) ^ count) + seed) & 0xff;
@@ -871,7 +871,7 @@ strdecrypt(const char *data, const char *key)
  * the result into 'buf'
  *
  * WARNING: This does NOT validate the length of 'buf' and that makes
- *          this a potentially dangerous call.  It should be safe 
+ *          this a potentially dangerous call.  It should be safe
  *          if 'buf' is the same size as 'input' or larger.
  *
  * This call effectively removes color from a string, as well as makes
@@ -1907,7 +1907,7 @@ ref2str(dbref obj, char *buf, size_t buflen)
         return buf;
     }
 
-    if (obj >= 0 && Typeof(obj) == TYPE_PLAYER) {
+    if (obj >= 0 && OBJECT_TYPE(obj) == TYPE_PLAYER) {
         snprintf(buf, buflen, "*%s", NAME(obj));
     } else {
         snprintf(buf, buflen, "#%d", obj);

--- a/src/fbtime.c
+++ b/src/fbtime.c
@@ -53,7 +53,7 @@ ts_useobject(dbref thing)
     DBFETCH(thing)->ts_usecount++;
     DBDIRTY(thing);
 
-    if (Typeof(thing) == TYPE_ROOM)
+    if (OBJECT_TYPE(thing) == TYPE_ROOM)
         ts_useobject(LOCATION(thing));
 }
 
@@ -74,7 +74,7 @@ ts_lastuseobject(dbref thing)
 
     DBSTORE(thing, ts_lastused, time(NULL));
 
-    if (Typeof(thing) == TYPE_ROOM)
+    if (OBJECT_TYPE(thing) == TYPE_ROOM)
         ts_lastuseobject(LOCATION(thing));
 }
 
@@ -168,7 +168,7 @@ time_format_1(time_t dt)
  * Creates a time string from a UNIX timestamp delta in "format 2" layout.
  *
  * It computes the delta between the given timestamp and GMT time, then
- * goes through a logic process to figure out what "resolution" of 
+ * goes through a logic process to figure out what "resolution" of
  * the timestamp should be.  If the delta is greater than a day, then
  * days is used.  If greater than an hour, then hours is used.  If greater
  * than a minute, then minutes are used.  Otherwise, seconds.
@@ -390,7 +390,7 @@ time_string_to_seconds(char *string, const char *format, const char **error)
 
         for ( ; *finder != '\0' && isdigit(*finder); finder++, year_digits++);
 
-        if(year_digits == 4) {
+        if (year_digits == 4) {
             /* do 4 digit year */
             format = "%T%t%m/%d/%Y";
         }

--- a/src/flags.c
+++ b/src/flags.c
@@ -21,17 +21,18 @@
  */
 struct object_type {
     char symbol;
-    char *all_caps;
+    char *uppercase;
+    char *titlecase;
     char *singular;
     char *plural;
 };
 
 struct object_type object_types[] = {
-    { 'R', "ROOM", "room", "rooms" },
-    { 'T', "THING", "thing", "things" },
-    { 'E', "EXIT/ACTION", "exit", "exits" },
-    { 'P', "PLAYER", "player", "players" },
-    { 'F', "PROGRAM", "program", "programs" }
+    { 'R', "ROOM", "Room", "room", "rooms" },
+    { 'T', "THING", "Thing", "thing", "things" },
+    { 'E', "EXIT/ACTION", "Exit", "exit", "exits" },
+    { 'P', "PLAYER", "Player", "player", "players" },
+    { 'F', "PROGRAM", "Program", "program", "programs" }
 };
 
 /**
@@ -52,7 +53,28 @@ object_type_name(dbref ref) {
         return "UNKNOWN";
     }
 
-    return object_types[type].all_caps;
+    return object_types[type].uppercase;
+}
+
+/**
+ * Returns the titlecase name of an object's type.
+ *
+ * @param ref  The object to check.
+ * @return     A string like "Room", "Player", or "Bad".
+ */
+const char*
+object_type_name_mpi(dbref ref) {
+    if (!ObjExists(ref)) {
+        return "Bad";
+    }
+
+    int type = OBJECT_TYPE(ref);
+
+    if (type < 0 || type >= ARRAYSIZE(object_types)) {
+        return "UNKNOWN";
+    }
+
+    return object_types[type].titlecase;
 }
 
 /**

--- a/src/flags.c
+++ b/src/flags.c
@@ -295,8 +295,7 @@ flag_list(dbref ref, char *buf, size_t size)
     }
 
     int mlevel = OBJECT_MLEVEL(ref);
-    if (mlevel > 0 && (p + 2 < end)) {
-        *p++ = 'M';
+    if (mlevel > 0 && (p + 1 < end)) {
         *p++ = mlevel + '0';
     }
 

--- a/src/flags.c
+++ b/src/flags.c
@@ -1,0 +1,675 @@
+/** @file flags.c
+ *
+ * Implementation of the MUCK's object flag and type system.
+ *
+ * This file is part of Fuzzball MUCK.  Please see LICENSE.md for details.
+ */
+
+#include <stdbool.h>
+#include <strings.h>
+
+#include "config.h"
+
+#include "db.h"
+#include "fbstrings.h"
+#include "flags.h"
+#include "game.h"
+
+/**
+ * This structure and array define the fundamental object types within the
+ * database and their associated display strings.
+ */
+struct object_type {
+    char symbol;
+    char *all_caps;
+    char *singular;
+    char *plural;
+};
+
+struct object_type object_types[] = {
+    { 'R', "ROOM", "room", "rooms" },
+    { 'T', "THING", "thing", "things" },
+    { 'E', "EXIT/ACTION", "exit", "exits" },
+    { 'P', "PLAYER", "player", "players" },
+    { 'F', "PROGRAM", "program", "programs" }
+};
+
+/**
+ * Returns the uppercase name of an object's type.
+ *
+ * @param ref  The object to check.
+ * @return     A string like "ROOM", "PLAYER", or "INVALID".
+ */
+const char*
+object_type_name(dbref ref) {
+    if (!ObjExists(ref)) {
+        return "INVALID";
+    }
+
+    int type = OBJECT_TYPE(ref);
+
+    if (type < 0 || type >= ARRAYSIZE(object_types)) {
+        return "UNKNOWN";
+    }
+
+    return object_types[type].all_caps;
+}
+
+/**
+ * This structure and array support the listing of system flags and provides
+ * context-specific aliasing based on the object type.
+ *
+ * Entries are stored in the order of presentation.
+ * Each flag must have a default TYPE_ANY name.
+ */
+struct flag_raw {
+    short bit;             /**< bitmask index for this flag */
+    short object_type;     /**< associated object type (or TYPE_ANY) */
+    struct flag_data data; /**< flag configuration */
+};
+
+static const struct flag_raw flag_list_raw[] = {
+    {  4, TYPE_ANY, { 'W', "WIZARD" } },
+    {  5, TYPE_ANY, { 'L', "LINK_OK" } },
+    { 14, TYPE_ANY, { 'K', "KILL_OK" } },
+    {  6, TYPE_ANY, { 'D', "DARK" } },
+    {  6, TYPE_PROGRAM, { 'D', "DEBUG" } },
+    {  8, TYPE_ANY, { 'S', "STICKY" } },
+    {  8, TYPE_PLAYER, { 'S', "SILENT" } },
+    {  8, TYPE_PROGRAM, { 'S', "SETUID" } },
+    { 19, TYPE_ANY, { 'Q', "QUELL" } },
+    {  9, TYPE_ANY, { 'B', "BOUND" } },
+    {  9, TYPE_PLAYER, { 'B', "BUILDER" } },
+    { 10, TYPE_ANY, { 'C', "CHOWN_OK" } },
+    { 10, TYPE_PLAYER, { 'C', "COLOR" } },
+    { 11, TYPE_ANY, { 'J', "JUMP_OK" } },
+    { 15, TYPE_ANY, { 'G', "GUEST" } },
+    { 15, TYPE_ROOM, { 'G', "GUEST_RESTRICT" } },
+    { 15, TYPE_EXIT, { 'G', "GUEST_RESTRICT" } },
+    { 16, TYPE_ANY, { 'H', "HAVEN" } },
+    { 16, TYPE_THING, { 'H', "HIDE" } },
+    { 16, TYPE_PROGRAM, { 'H', "HARDUID" } },
+    { 17, TYPE_ANY, { 'A', "ABODE" } },
+    { 17, TYPE_EXIT, { 'A', "ABATE" } },
+    { 17, TYPE_PROGRAM, { 'A', "AUTOSTART" } },
+    { 24, TYPE_ANY, { 'V', "VEHICLE" } },
+    { 24, TYPE_ROOM, { 'V', "VEHICLE_RESTRICT" } },
+    { 24, TYPE_EXIT, { 'V', "VEHICLE_RESTRICT" } },
+    { 24, TYPE_PROGRAM, { 'V', "VIEWABLE" } },
+    { 27, TYPE_ANY, { 'X', "XFORCIBLE" } },
+    { 27, TYPE_EXIT, { 'X', "XPRESS" } },
+    { 25, TYPE_ANY, { 'Z', "ZOMBIE" } },
+    { 25, TYPE_ROOM, { 'Z', "ZOMBIE_RESTRICT" } },
+    { 25, TYPE_EXIT, { 'Z', "ZOMBIE_RESTRICT" } },
+    { 25, TYPE_PROGRAM, { 'Z', "ZMUF_DEBUGGER" } },
+    { 30, TYPE_ANY, { 'Y', "YIELD" } },
+    { 31, TYPE_ANY, { 'O', "OVERT" } },
+
+    /* hidden from flag displays */
+    { 18, TYPE_ANY, { 'M', "MUCKER", NULL, true } },
+    { 20, TYPE_ANY, { 'N', "NUCKER", NULL, true } },
+    { 21, TYPE_ANY, { 'I', "INTERACTIVE", NULL, true } },
+
+    { -1, TYPE_ANY, { 0, NULL, NULL } }
+};
+
+#define NUM_BITS 32
+
+/**
+ * Lookup tables for flags indexed by type, then bit position or symbol.
+ */
+static struct flag_entry flag_lists_by_bit[TYPE_ANY+1][NUM_BITS] = {};
+struct flag_entry flag_lists_by_symbol[TYPE_ANY+1][NUM_SYMBOLS] = {};
+
+/**
+ * Initializes the flag lookup tables from the raw flag list.
+ */
+void
+flag_init()
+{
+    for (const struct flag_raw *flag = flag_list_raw; flag->bit != -1; flag++) {
+        int index = flag->data.symbol - 'A';
+        if (index < 0 || index >= NUM_SYMBOLS) continue;
+        if (flag->bit >= NUM_BITS) continue;
+
+        for (int i = 0; i <= TYPE_ANY; i++) {
+            if (flag->object_type == i || flag->object_type == TYPE_ANY) {
+                flag_lists_by_symbol[i][index].value = (1 << flag->bit);
+                flag_lists_by_symbol[i][index].symbol = flag->data.symbol;
+                flag_lists_by_symbol[i][index].data = flag->data;
+
+                flag_lists_by_bit[i][flag->bit].value = (1 << flag->bit);
+                flag_lists_by_bit[i][flag->bit].symbol = flag->data.symbol;
+                flag_lists_by_bit[i][flag->bit].data = flag->data;
+            }
+        }
+    }
+}
+
+/**
+ * Helper to check if a flag entry matches a given name or symbol.
+ *
+ * @param entry  The flag entry to check.
+ * @param flag   The flag name or symbol string to match against.
+ * @return       True if the flag matches.
+ */
+static bool
+flag_matches(struct flag_entry *entry, const char *flag)
+{
+    if (flag[1] == '\0') {
+        return (flag[0] == entry->symbol);
+    }
+
+    if (entry->data.display_name) {
+        return string_prefix(entry->data.display_name, flag);
+    }
+
+    return false;
+}
+
+
+/**
+ * Evaluates a single flag string against an object.
+ *
+ * Recognizes flag symbols, names, and virtual flag 'truewizard'.
+ *
+ * @param ref  The object to check.
+ * @param p    The flag string (e.g., "W", "!W", "Wizard").
+ * @return     True if the object satisfies the expression.
+ */
+bool
+flag_eval(dbref ref, const char *p)
+{
+    bool negate = false;
+    while (*p == NOT_TOKEN) {
+        negate = !negate;
+        p++;
+    }
+
+    if (*p == '\0') return false;
+
+    bool result = false;
+
+    if (string_prefix("truewizard", p)) {
+        result = TrueWizard(ref);
+    } else if (string_prefix("wizard", p) || (p[0] == 'W' && p[1] == '\0')) {
+        result = Wizard(ref);
+    } else if (p[1] == '\0' && *p >= 'A' && *p <= 'Z') {
+        result = FLAG_CHECK(ref, *p);
+    } else {
+        int type = OBJECT_TYPE(ref);
+
+        for (int i = 0; i < NUM_BITS; i++) {
+            struct flag_entry *entry = &flag_lists_by_bit[type][i];
+
+            if (flag_matches(entry, p)) {
+                result = FLAG_CHECK(ref, entry->symbol);
+                break;
+            }
+        }
+    }
+
+    return negate ? !result : result;
+}
+
+/**
+ * Evaluates a pattern of flag symbols against an object.
+ *
+ * Recognizes type symbols, flag symbols, and MUCKER levels.
+ *
+ * @param ref  The object to check.
+ * @param p    The pattern string (e.g., "PW3" or "J!A").
+ * @return     True if all conditions in the pattern match.
+ */
+bool
+flag_eval_pattern(dbref ref, const char *p)
+{
+    int type = OBJECT_TYPE(ref);
+
+    while (*p) {
+        bool negate = false;
+        while (*p == NOT_TOKEN) {
+            negate = !negate;
+            p++;
+        }
+        if (*p == '\0') break;
+
+        bool has_flag;
+        if (*p == 'W') {
+            has_flag = Wizard(ref);
+        } else if (*p == object_types[type].symbol) {
+            has_flag = true;
+        } else if (*p >= '0' && *p <= '3') {
+            has_flag = (OBJECT_MLEVEL(ref) == (*p - 48));
+        } else if (*p >= 'A' && *p <= 'Z') {
+            has_flag = FLAG_CHECK(ref, *p);
+        } else {
+            return false;
+        }
+
+        if (negate == has_flag) return false;
+
+        p++;
+    }
+    return true;
+}
+
+/**
+ * Generate a long-form text description of the flags on a given object.
+ * Uses the provided buffer that has the given size.
+ *
+ * @param thing to generate description for
+ * @param buffer the buffer to use
+ * @param size the size of the buffer
+ */
+void
+flag_list_verbose(dbref ref, char *buf, size_t size)
+{
+    int type = OBJECT_TYPE(ref);
+    char *p = buf;
+    char *end = buf + size;
+    object_flag_type flags = db[ref].flags;
+
+    while (flags) {
+        int i = ffsl(flags) - 1;
+        struct flag_entry *entry = &flag_lists_by_bit[type][i];
+
+        if (entry->symbol && !entry->data.hidden) {
+            p += snprintf(p, end - p, "%s ", entry->data.display_name);
+        }
+        flags &= ~(1U << i);
+    }
+
+    int mlevel = OBJECT_MLEVEL(ref);
+    if (mlevel > 0) {
+        p += snprintf(p, end - p, "MUCKER%d ", mlevel);
+    }
+
+    if (p > buf) p--;
+
+    *p = '\0';
+}
+
+/**
+ * Generates a string representation of object flags. Uses the provided
+ * buffer that has the given size.
+ *
+ * @param thing the object to construct a flag string for
+ * @param buffer the buffer to use
+ * @param size the size of the buffer
+ */
+void
+flag_list(dbref ref, char *buf, size_t size)
+{
+    int type = OBJECT_TYPE(ref);
+    char *p = buf;
+    char *end = buf + size;
+    object_flag_type flags = db[ref].flags;
+
+    if (size == 0) return;
+
+    *p = '\0';
+
+    while (flags) {
+        int i = ffsl(flags) - 1;
+        struct flag_entry *entry = &flag_lists_by_bit[type][i];
+
+        if (entry->symbol && !entry->data.hidden) {
+            if (p < end - 1) {
+              *p++ = entry->symbol;
+            }
+        }
+
+        flags &= ~(1U << i);
+    }
+
+    int mlevel = OBJECT_MLEVEL(ref);
+    if (mlevel > 0 && (p + 2 < end)) {
+        *p++ = 'M';
+        *p++ = mlevel + '0';
+    }
+
+    *p = '\0';
+}
+
+/**
+ * "Unparse" an object, showing its name and list of flags if permissions allow
+ *
+ * Uses the provided buffer that has the given size.  Practically speaking,
+ * names can be as long as BUFFER_LEN, so your buffer should probably
+ * be BUFFER_LEN at least in size (This is the most common practice).  If
+ * a name was actually its maximum length, then there is not enough room
+ * for flags to show up.  Traditionally, Fuzzball has not cared about this
+ * problem because, traditionally, names just don't get that long.
+ *
+ * Flags are only shown if:
+ *
+ * * player == NOTHING
+ * * or player does not have the STICKY flag AND:
+ *   * 'loc' is linkable - @see can_link_to
+ *   * or 'loc' is not a player and 'player' controls 'loc'
+ *   * or 'loc' is CHOWN_OK
+ *
+ * @param player the player doing the call or NOTHING
+ * @param object the target to generate unparse text for
+ * @param buffer the buffer to use
+ * @param size the size of the buffer
+ */
+void
+flag_unparse_object(dbref player, dbref ref, char *buf, size_t size)
+{
+    char flags_buf[MINI_BUFFER_LEN];
+
+    if (player != NOTHING) {
+        player = OWNER(player);
+    }
+
+    switch (ref) {
+        case NOTHING:   strcpyn(buf, size, "*NOTHING*"); return;
+        case AMBIGUOUS: strcpyn(buf, size, "*AMBIGUOUS*"); return;
+        case HOME:      strcpyn(buf, size, "*HOME*"); return;
+        case NIL:       strcpyn(buf, size, "*NIL*"); return;
+
+        default:
+            if (!ObjExists(ref)) {
+                strcpyn(buf, size, "*INVALID*");
+                return;
+            }
+
+            if (player == NOTHING ||
+                (!FLAG_CHECK(player, 'S') && (
+                    can_see_flags(player, ref) || (
+                        OBJECT_TYPE(ref) != TYPE_PLAYER && (
+                            controls_link(player, ref) ||
+                            FLAG_CHECK(ref, 'C')
+                        )
+                    )
+                ))) {
+
+                flag_list(ref, flags_buf, sizeof(flags_buf));
+                snprintf(buf, size, "%.*s(#%d%c%s)", BUFFER_LEN / 2, NAME(ref), ref, object_types[OBJECT_TYPE(ref)].symbol, flags_buf);
+            } else {
+                strcpyn(buf, size, NAME(ref));
+            }
+    }
+}
+
+/**
+ * Returns the flag associated with the given string, if any.
+ *
+ * Understands flag alias prefixes.
+ * Passing "truewizard" here just returns the WIZARD flag.
+ *
+ * @param ref the object to check
+ * @param flag_string the flag (or alias) to check
+ * @return the flag corresponding to the string, or 0 if none match.
+ */
+object_flag_type
+str_to_flag(const char *flag_string)
+{
+    if (!*flag_string) {
+        return 0;
+    }
+
+    if (string_prefix("abode", flag_string)
+            || string_prefix("autostart", flag_string)
+            || string_prefix("abate", flag_string)) {
+        return ABODE;
+    } else if (string_prefix("builder", flag_string)
+            || string_prefix("bound", flag_string)) {
+        return BUILDER;
+    } else if (string_prefix("chown_ok", flag_string)
+            || string_prefix("color", flag_string)) {
+        return CHOWN_OK;
+    } else if (string_prefix("dark", flag_string)
+            || string_prefix("debug", flag_string)) {
+        return DARK;
+    } else if (string_prefix("guest", flag_string)) {
+        return GUEST;
+    } else if (string_prefix("haven", flag_string)
+            || string_prefix("hide", flag_string)
+            || string_prefix("harduid", flag_string)) {
+        return HAVEN;
+    } else if (string_prefix("interactive", flag_string)) {
+        return INTERACTIVE;
+    } else if (string_prefix("jump_ok", flag_string)) {
+        return JUMP_OK;
+    } else if (string_prefix("kill_ok", flag_string)) {
+        return KILL_OK;
+    } else if (string_prefix("link_ok", flag_string)) {
+        return LINK_OK;
+    } else if (string_prefix("mucker", flag_string)) {
+        return MUCKER;
+    } else if (string_prefix("nucker", flag_string)) {
+        return SMUCKER;
+    } else if (string_prefix("overt", flag_string)) {
+        return OVERT;
+    } else if (string_prefix("quell", flag_string)) {
+        return QUELL;
+    } else if (string_prefix("sticky", flag_string)
+            || string_prefix("silent", flag_string)
+            || string_prefix("setuid", flag_string)) {
+        return STICKY;
+    } else if (string_prefix("vehicle", flag_string)
+            || string_prefix("viewable", flag_string)) {
+        return VEHICLE;
+    } else if (string_prefix("wizard", flag_string)) {
+        return WIZARD;
+    } else if (string_prefix("truewizard", flag_string)) {
+        return WIZARD;
+    } else if (string_prefix("xforcible", flag_string)
+            || string_prefix("xpress", flag_string)) {
+        return XFORCIBLE;
+    } else if (string_prefix("yield", flag_string)) {
+        return YIELD;
+    } else if (string_prefix("zombie", flag_string)) {
+        return ZOMBIE;
+    }
+
+    return 0;
+}
+
+/**
+ * Determines if a given player is unable to (re)set the given flag
+ *
+ * The 'business logic' here is actually fairly dense and not easily
+ * summed up in a comment. The reader is encouraged to review the very
+ * well documented code for details.
+ *
+ * This is all pretty well documented in the MUCK's help files.
+ *
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
+ *
+ * @private
+ * @param player the effective aplayer we are checking permissions for
+ * @param mlev the effective mucker level we are checking permissions for
+ * @param thing the thing we want to interact with
+ * @param flag the flag we wish to interact with
+ * @param value whether the desired state is on or off
+ * @param error[out] error message, if any
+ * @return boolean 1 if restricted from setting flag, 0 if okay to set.
+ */
+int
+unable_to_set_flag(dbref player, int mlev, dbref thing, object_flag_type flag, bool value, char *error)
+{
+    if (force_level && (
+            flag == WIZARD
+            || (flag == XFORCIBLE && OBJECT_TYPE(thing) != TYPE_EXIT)
+            || (flag & MUCKER)
+            || (flag & SMUCKER)
+    )) {
+        snprintf(error, SMALL_BUFFER_LEN, "That flag cannot be forced.");
+        return 1;
+    }
+
+    /* Non-wizards can only set their own programs M0. */
+    if (!value && (flag & (MUCKER | SMUCKER))) {
+        if (!Wizard(OWNER(player))) {
+            if ((OWNER(player) != OWNER(thing)) || (OBJECT_TYPE(thing) != TYPE_PROGRAM)) {
+                snprintf(error, SMALL_BUFFER_LEN, "Permission denied. (You can't set that M0)");
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    /* Non-wizards can only set their programs up to their own mucker level. */
+    if (flag & (MUCKER | SMUCKER)) {
+        unsigned short requested_mlevel = (((flag & MUCKER ? 2 : 0) + (flag & SMUCKER ? 1 : 0)));
+        if (!Wizard(OWNER(player))) {
+            if ((OWNER(player) != OWNER(thing)) || (OBJECT_TYPE(thing) != TYPE_PROGRAM)
+                || (OBJECT_MLEVEL(player) < requested_mlevel)) {
+                snprintf(error, SMALL_BUFFER_LEN, "Permission denied. (You can't set that M%d)", requested_mlevel);
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    switch (flag) {
+        case ABODE:
+            /* Trying to set a program AUTOSTART requires TrueWizard */
+            return (!TrueWizard(OWNER(player)) && (OBJECT_TYPE(thing) == TYPE_PROGRAM));
+
+        case GUEST:
+            /* Guest operations require a wizard */
+            return (!(Wizard(OWNER(player))));
+
+        case YIELD:
+        case OVERT:
+            /* Mucking with the env-chain matching requires TrueWizard */
+            if (!(Wizard(OWNER(player)))) {
+                return 1;
+            }
+
+            /* ...and only for makes sense for things or rooms. */
+            if (OBJECT_TYPE(thing) != TYPE_THING && OBJECT_TYPE(thing) != TYPE_ROOM) {
+                return 1;
+            }
+
+            return 0;
+
+        case ZOMBIE:
+            /* Restricting a player from using zombies requires a wizard. */
+            if (OBJECT_TYPE(thing) == TYPE_PLAYER) {
+                return (!(Wizard(OWNER(player))));
+            }
+
+            /* If a player's set Zombie, he's restricted from using them...
+             * unless he's a wizard, in which case he can do whatever.
+             */
+            if ((OBJECT_TYPE(thing) == TYPE_THING) && FLAG_CHECK(player, 'Z')) {
+                return (!(Wizard(OWNER(player))));
+            }
+
+            return 0;
+
+        case VEHICLE:
+            /* Restricting a player from using vehicles requires a wizard. */
+            if (OBJECT_TYPE(thing) == TYPE_PLAYER){
+                return (!(Wizard(OWNER(player))));
+            }
+
+            /* Can only set things !V if they have no players in them. */
+            if (!value && OBJECT_TYPE(thing) == TYPE_THING) {
+                dbref obj = CONTENTS(thing);
+
+                for (; obj != NOTHING; obj = NEXTOBJ(obj)) {
+                    if (OBJECT_TYPE(obj) == TYPE_PLAYER) {
+                        snprintf(error, SMALL_BUFFER_LEN, "That vehicle still has players in it!");
+                        return 1;
+                    }
+                }
+            }
+
+            /* If only wizards can create vehicles... */
+            if (tp_wiz_vehicles) {
+                /* then only a wizard can create a vehicle. :) */
+                if (OBJECT_TYPE(thing) == TYPE_THING) {
+                    return (!(Wizard(OWNER(player))));
+                }
+            } else {
+                /* But, if vehicles aren't restricted to wizards, then
+                 * players who have not been restricted can do so
+                 */
+                if ((OBJECT_TYPE(thing) == TYPE_THING) && FLAG_CHECK(player, 'V')) {
+                    return (!(Wizard(OWNER(player))));
+                }
+            }
+
+            return (0);
+
+        case DARK:
+            /* Dark can be set on a Program or Room by anyone. */
+            if (!Wizard(OWNER(player))) {
+                /* Setting a player dark requires a wizard. */
+                if (OBJECT_TYPE(thing) == TYPE_PLAYER) {
+                    return 1;
+                }
+
+                /* If exit darking is restricted, it requires a wizard. */
+                if (!tp_exit_darking && OBJECT_TYPE(thing) == TYPE_EXIT) {
+                    return 1;
+                }
+
+                /* If thing darking is restricted, it requires a wizard. */
+                if (!tp_thing_darking && OBJECT_TYPE(thing) == TYPE_THING) {
+                    return 1;
+                }
+            }
+
+            return 0;
+
+        case QUELL:
+#ifdef GOD_PRIV
+            /* Only God (or God's stuff) can quell or unquell another wizard. */
+            return (TrueWizard(thing) && (thing != player) && !God(OWNER(player)) &&
+                    (OBJECT_TYPE(thing) == TYPE_PLAYER));
+#else
+            /* You cannot quell or unquell another wizard. */
+            return (TrueWizard(thing) && (thing != player) && (OBJECT_TYPE(thing) == TYPE_PLAYER));
+#endif
+
+        case BUILDER:
+            /* Setting a program BOUND reguires M2. */
+            if (OBJECT_TYPE(thing) == TYPE_PROGRAM) {
+                return (mlev < 2);
+            }
+
+            /* Setting a player Builder or a room Bound is limited to a Wizard. */
+            return (!Wizard(OWNER(player)));
+
+        case WIZARD:
+            /* To do anything with a Wizard flag requires a Wizard. */
+            if (Wizard(OWNER(player))) {
+                /* check for stupid wizard */
+                if (!value && thing == player) {
+                    snprintf(error, SMALL_BUFFER_LEN, "You cannot make yourself mortal.");
+                    return 1;
+                }
+
+#ifdef GOD_PRIV
+                /* Only God can make a player a Wizard, or re-mort one. */
+                return ((OBJECT_TYPE(thing) == TYPE_PLAYER) && !God(player));
+#else
+                /* We don't want someone setting themselves !W, to prevent
+                 * a case where there are no wizards at all
+                 */
+                return ((OBJECT_TYPE(thing) == TYPE_PLAYER && thing == OWNER(player)));
+#endif
+            } else {
+                return 1;
+            }
+
+        case XFORCIBLE:
+            return (!Wizard(OWNER(player)) && OBJECT_TYPE(thing) == TYPE_EXIT);
+
+        default:
+            /* No other flags are restricted. */
+            return 0;
+    }
+}
+

--- a/src/flags.c
+++ b/src/flags.c
@@ -16,17 +16,9 @@
 #include "game.h"
 
 /**
- * This structure and array define the fundamental object types within the
- * database and their associated display strings.
+ * This array defines the fundamental object types within the database and
+ * their associated display strings.
  */
-struct object_type {
-    char symbol;
-    char *uppercase;
-    char *titlecase;
-    char *singular;
-    char *plural;
-};
-
 struct object_type object_types[] = {
     { 'R', "ROOM", "Room", "room", "rooms" },
     { 'T', "THING", "Thing", "thing", "things" },
@@ -34,49 +26,6 @@ struct object_type object_types[] = {
     { 'P', "PLAYER", "Player", "player", "players" },
     { 'F', "PROGRAM", "Program", "program", "programs" }
 };
-
-/**
- * Returns the uppercase name of an object's type.
- *
- * @param ref  The object to check.
- * @return     A string like "ROOM", "PLAYER", or "INVALID".
- */
-const char*
-object_type_name(dbref ref) {
-    if (!ObjExists(ref)) {
-        return "INVALID";
-    }
-
-    int type = OBJECT_TYPE(ref);
-
-    if (type < 0 || type >= ARRAYSIZE(object_types)) {
-        return "UNKNOWN";
-    }
-
-    return object_types[type].uppercase;
-}
-
-/**
- * Returns the titlecase name of an object's type.
- *
- * @param ref  The object to check.
- * @return     A string like "Room", "Player", or "Bad".
- */
-const char*
-object_type_name_mpi(dbref ref) {
-    if (!ObjExists(ref)) {
-        return "Bad";
-    }
-
-    int type = OBJECT_TYPE(ref);
-
-    if (type < 0 || type >= ARRAYSIZE(object_types)) {
-        return "UNKNOWN";
-    }
-
-    return object_types[type].titlecase;
-}
-
 /**
  * This structure and array support the listing of system flags and provides
  * context-specific aliasing based on the object type.

--- a/src/game.c
+++ b/src/game.c
@@ -29,6 +29,7 @@
 #include "fbsignal.h"
 #include "fbstrings.h"
 #include "fbtime.h"
+#include "flags.h"
 #include "game.h"
 #include "interface.h"
 #include "log.h"
@@ -47,7 +48,7 @@
  * @private
  * @param string the string to match against 'command'
  */
-#define Matched(string) { if(!string_prefix((string), command)) goto bad; }
+#define Matched(string) { if (!string_prefix((string), command)) goto bad; }
 
 /**
  * @var a variable to keep track of the force level.  This is incremented
@@ -179,9 +180,9 @@ void
 do_shutdown(dbref player)
 {
     char unparse_buf[BUFFER_LEN];
-    unparse_object(player, player, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(player, player, unparse_buf, sizeof(unparse_buf));
 
-    if (Wizard(player) && Typeof(player) == TYPE_PLAYER) {
+    if (Wizard(player) && OBJECT_TYPE(player) == TYPE_PLAYER) {
         log_status("SHUTDOWN: by %s", unparse_buf);
         shutdown_flag = 1;
         restart_flag = 0;
@@ -226,9 +227,9 @@ void
 do_restart(dbref player)
 {
     char unparse_buf[BUFFER_LEN];
-    unparse_object(player, player, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(player, player, unparse_buf, sizeof(unparse_buf));
 
-    if (Wizard(player) && Typeof(player) == TYPE_PLAYER) {
+    if (Wizard(player) && OBJECT_TYPE(player) == TYPE_PLAYER) {
         log_status("SHUTDOWN & RESTART: by %s", unparse_buf);
         shutdown_flag = 1;
         restart_flag = 1;
@@ -465,6 +466,7 @@ init_game(const char *infile, const char *outfile)
         return -1;
 
     db_free();
+    flag_init(); /* init object flag and type system */
     init_primitives(); /* init muf compiler */
     mesg_init(); /* init mpi interpreter */
     SRANDOM((unsigned int)getpid()); /* init random number generator */
@@ -562,7 +564,7 @@ process_command(int descr, dbref player, const char *command)
 
     /* robustify player */
     if (!ObjExists(player) ||
-        (Typeof(player) != TYPE_PLAYER && Typeof(player) != TYPE_THING)) {
+        (OBJECT_TYPE(player) != TYPE_PLAYER && OBJECT_TYPE(player) != TYPE_THING)) {
         log_status("process_command: bad player %d", player);
         return;
     }

--- a/src/hashtab.c
+++ b/src/hashtab.c
@@ -76,7 +76,7 @@ find_hash(const char *s, hash_tab * table, unsigned int size)
  * @param name the name of the entry to add
  * @param data the data to store
  * @param table the hash stable to store it in
- * @param size the page size of the hash table 
+ * @param size the page size of the hash table
  */
 hash_entry *
 add_hash(const char *name, hash_data data, hash_tab * table,

--- a/src/interface.c
+++ b/src/interface.c
@@ -30,6 +30,7 @@
 #include "fbsignal.h"
 #include "fbstrings.h"
 #include "fbtime.h"
+#include "flags.h"
 #include "game.h"
 #include "interface.h"
 #include "interp.h"
@@ -675,7 +676,7 @@ queue_ansi(struct descriptor_data *d, const char *msg)
     char buf[BUFFER_LEN + 8];
 
     if (d->connected) {
-        if (FLAGS(d->player) & CHOWN_OK) {
+        if (FLAG_CHECK(d->player, 'C')) {
             strip_bad_ansi(buf, msg);
         } else {
             strip_ansi(buf, msg);
@@ -715,7 +716,7 @@ is_local_connection(struct descriptor_data *d)
      *       and generally removes the purpose of this function as you can
      *       just lookup d->is_local (or whatever) instead.
      */
-    /* Treat anything coming from 127.0.0.1 or localhost as local */    
+    /* Treat anything coming from 127.0.0.1 or localhost as local */
     if (!strcmp(d->hostname, "127.0.0.1") ||
         !strcmp(d->hostname, "localhost"))
         return 1;
@@ -796,7 +797,7 @@ dump_users(struct descriptor_data *e, char *user)
     while (d) {
         if (d->connected &&
             (!tp_who_hides_dark ||
-             (wizard || !(FLAGS(d->player) & DARK))) &&
+             (wizard || !Dark(d->player))) &&
              ++players && (!user || string_prefix(NAME(d->player), user))
         ) {
 
@@ -1028,7 +1029,7 @@ announce_puppets(dbref player, const char *msg, const char *prop)
      *       in other ways.
      */
     for (dbref what = 0; what < db_top; what++) {
-        if (Typeof(what) == TYPE_THING && (FLAGS(what) & ZOMBIE)) {
+        if (OBJECT_TYPE(what) == TYPE_THING && FLAG_CHECK(what, 'Z')) {
             if (OWNER(what) == player) {
                 where = LOCATION(what);
 
@@ -1108,7 +1109,7 @@ announce_connect(int descr, dbref player)
         announce_puppets(player, "wakes up.", MESGPROP_PCON);
     }
 
-    /* 
+    /*
      * Queue up all _connect programs referred to by properties
      *
      * @TODO Something odd -- propqueue's are run on every connect but
@@ -1301,7 +1302,7 @@ remember_player_descr(dbref player, int descr)
     size_t count = 0;
     int *arr = NULL;
 
-    if (Typeof(player) != TYPE_PLAYER)
+    if (OBJECT_TYPE(player) != TYPE_PLAYER)
         return;
 
     count = (size_t)PLAYER_DESCRCOUNT(player);
@@ -1334,7 +1335,7 @@ forget_player_descr(dbref player, int descr)
     size_t count = 0;
     int *arr = NULL;
 
-    if (Typeof(player) != TYPE_PLAYER)
+    if (OBJECT_TYPE(player) != TYPE_PLAYER)
         return;
 
     count = (size_t)PLAYER_DESCRCOUNT(player);
@@ -1608,7 +1609,7 @@ connect_player(const char *name, const char *password)
 
     if (*name == NUMBER_TOKEN && number(name + 1) && atoi(name + 1)) {
         player = (dbref) atoi(name + 1);
-        if (!ObjExists(player) || Typeof(player) != TYPE_PLAYER)
+        if (!ObjExists(player) || OBJECT_TYPE(player) != TYPE_PLAYER)
             player = NOTHING;
     } else {
         player = lookup_player(name);
@@ -1980,7 +1981,7 @@ process_commands(void)
                      * WORK: send player's foreground/preempt programs an
                      *       exclusive READ mufevent
                      */
-                    
+
                     /*
                      * @TODO If this returns true, then you've got a problem,
                      *       because nothing will advance the queue other
@@ -2200,7 +2201,7 @@ queue_immediate_and_flush(struct descriptor_data *d, const char *msg)
     char buf[BUFFER_LEN + 8];
 
     if (d->connected) {
-        if (FLAGS(d->player) & CHOWN_OK) {
+        if (FLAG_CHECK(d->player, 'C')) {
             strip_bad_ansi(buf, msg);
         } else {
             strip_ansi(buf, msg);
@@ -2445,7 +2446,7 @@ shutdownsock(struct descriptor_data *d)
 
     if (!descriptor_list)
         descriptor_list_tail = NULL;
-    else if(descriptor_list_tail == d)
+    else if (descriptor_list_tail == d)
         descriptor_list_tail = d->prev;
 
     free((void *) d->hostname);
@@ -2567,7 +2568,7 @@ initializesock(int s, int output_s, const char *hostname, int is_ssl, int is_con
     d->priority_output.tail = &d->priority_output.head;
     d->output.tail = &d->output.head;
     d->input.tail = &d->input.head;
-    
+
 #ifdef IP_FORWARDING
     if (!(d->forwarded_buffer = malloc(SMALL_BUFFER_LEN * sizeof(char))))
         panic("initializesock: Out of memory");
@@ -2993,7 +2994,7 @@ static void listen_bound_sockets()
  * @private
  * @param d the descriptor_data to send a keepalive to.
  */
-static void 
+static void
 send_keepalive(struct descriptor_data *d)
 {
     unsigned char telnet_nop[] = {
@@ -3410,7 +3411,7 @@ process_input(struct descriptor_data *d)
                  */
 
                 /*
-                 * If we get a request to do IP forwarding agree to it, 
+                 * If we get a request to do IP forwarding agree to it,
                  * but only for localhost.
                  */
                 if (*q == TELOPT_FORWARDED) {
@@ -3625,7 +3626,7 @@ load_server_certificates(SSL_CTX *new_ssl_ctx)
     if (!new_ssl_ctx || !tp_ssl_cert_file || !tp_ssl_key_file) {
         return false;
     }
- 
+
     if (!SSL_CTX_use_certificate_chain_file(new_ssl_ctx, tp_ssl_cert_file)) {
         log_status("Could not load certificate file %s", tp_ssl_cert_file);
         fprintf(stderr, "Could not load certificate file %s\n", tp_ssl_cert_file);
@@ -4562,9 +4563,9 @@ notify_nolisten(dbref player, const char *msg, int isprivate)
          *       Recommendation: move get_player_descrs out of the loop.
          *       Do a single check to see if the player is a zombie:
          *
-         *       isZombie = Typeof(player) == TYPE_THING, FLAGS & ZOMBIE,
+         *       isZombie = OBJECT_TYPE(player) == TYPE_THING, FLAGS & ZOMBIE,
          *       and all that other good stuff that's in the second if
-         *       statement after if(tp_allow_zombies)
+         *       statement after if (tp_allow_zombies)
          *
          *       Then, if darr == 0 && !isZombie || isZombie && !tp_allow_zombies,
          *       then return -- these cases we will do nothing.
@@ -4585,14 +4586,14 @@ notify_nolisten(dbref player, const char *msg, int isprivate)
         }
 
         if (tp_allow_zombies) {
-            if ((Typeof(player) == TYPE_THING) && (FLAGS(player) & ZOMBIE) &&
-                !(FLAGS(OWNER(player)) & ZOMBIE) &&
-                (!(FLAGS(player) & DARK) || Wizard(OWNER(player)))) {
+            if ((OBJECT_TYPE(player) == TYPE_THING) && FLAG_CHECK(player, 'Z') &&
+                !FLAG_CHECK(OWNER(player), 'Z') &&
+                (!Dark(player) || Wizard(OWNER(player)))) {
                 ref = LOCATION(player);
 
                 /* Make sure the location is allowed */
                 if (Wizard(OWNER(player)) || ref == NOTHING ||
-                    Typeof(ref) != TYPE_ROOM || !(FLAGS(ref) & ZOMBIE)) {
+                    OBJECT_TYPE(ref) != TYPE_ROOM || !FLAG_CHECK(ref, 'Z')) {
 
                     /*
                      * Make sure the message is either private or the
@@ -4780,7 +4781,7 @@ notify_listeners(dbref who, dbref xprog, dbref obj, dbref room,
     if (obj == NOTHING)
         return 0;
 
-    if (tp_allow_listeners && (tp_allow_listeners_obj || Typeof(obj) == TYPE_ROOM)) {
+    if (tp_allow_listeners && (tp_allow_listeners_obj || OBJECT_TYPE(obj) == TYPE_ROOM)) {
         listenqueue(-1, who, room, obj, obj, xprog, LISTEN_PROPQUEUE, msg,
                     tp_listen_mlev, 1, 0);
         listenqueue(-1, who, room, obj, obj, xprog, WLISTEN_PROPQUEUE, msg,
@@ -4795,10 +4796,10 @@ notify_listeners(dbref who, dbref xprog, dbref obj, dbref room,
      */
     ref = LOCATION(obj);
 
-    if ((Typeof(obj) == TYPE_THING) &&  /* obj is a thing */
-        (FLAGS(obj) & VEHICLE) &&       /* And a vehilcle */
+    if ((OBJECT_TYPE(obj) == TYPE_THING) &&  /* obj is a thing */
+        FLAG_CHECK(obj, 'V') &&       /* And a vehilcle */
         /* And not DARK, unless WIZARD owned */
-        (!(FLAGS(obj) & DARK) || Wizard(OWNER(obj))) &&
+        (!Dark(obj) || Wizard(OWNER(obj))) &&
         /* isprivate toggles if we're going to show the prefix or not */
         (!isprivate) &&
         /* The person who did it is in the same ocation as the thing */
@@ -4807,8 +4808,8 @@ notify_listeners(dbref who, dbref xprog, dbref obj, dbref room,
          * or the location of thing is not a room, or the location of the
          * thing is not a vehicle.
          */
-        (Wizard(OWNER(obj)) || ref == NOTHING || Typeof(ref) != TYPE_ROOM ||
-         (!(FLAGS(ref) & VEHICLE)))) {
+        (Wizard(OWNER(obj)) || ref == NOTHING || OBJECT_TYPE(ref) != TYPE_ROOM ||
+         (!FLAG_CHECK(ref, 'V')))) {
         char pbuf[BUFFER_LEN];
         const char *prefix;
 
@@ -4831,7 +4832,7 @@ notify_listeners(dbref who, dbref xprog, dbref obj, dbref room,
         }
     }
 
-    if (Typeof(obj) == TYPE_PLAYER || Typeof(obj) == TYPE_THING)
+    if (OBJECT_TYPE(obj) == TYPE_PLAYER || OBJECT_TYPE(obj) == TYPE_THING)
         return notify_filtered(who, obj, msg, isprivate);
 
     return 0;
@@ -4871,7 +4872,7 @@ notify_except(dbref first, dbref exception, const char *msg, dbref who)
     }
 
     DOLIST(first, first) {
-        if ((Typeof(first) != TYPE_ROOM) && (first != exception)) {
+        if ((OBJECT_TYPE(first) != TYPE_ROOM) && (first != exception)) {
             /* don't want excepted player or child rooms to hear */
             notify_listeners(who, NOTHING, first, LOCATION(who), msg, 0);
         }
@@ -4958,7 +4959,7 @@ max_open_files(void)
  * \r\n will be added to the end of the message.
  *
  * @param msg the message to send to all the descriptors
- */ 
+ */
 void
 wall_and_flush(const char *msg)
 {
@@ -5012,7 +5013,7 @@ wall_wizards(const char *msg)
  *
  * This also adds the block to d->pending_ssl_write if needed.
  *
- * Returns 1 if something incomplete written, 0 if write was successful, 
+ * Returns 1 if something incomplete written, 0 if write was successful,
  * and -1 if I/O error
  *
  * @private
@@ -5149,7 +5150,7 @@ process_all_output(unsigned int iterations, unsigned int useconds,
 {
     int final_result = 0;
 
-    for (unsigned int i = 0; (!(final_result = process_output(d))) && 
+    for (unsigned int i = 0; (!(final_result = process_output(d))) &&
                              (i < iterations); i++) {
         fb_usleep(useconds);
     }
@@ -5288,7 +5289,7 @@ close_sockets(const char *msg)
 
         socket_write(d, msg, strlen(msg));
         socket_write(d, shutdown_message, strlen(shutdown_message));
-    
+
         if (!d->is_console) {
             if (shutdown(d->descriptor, 2) < 0)
                 perror("shutdown");
@@ -5365,9 +5366,9 @@ do_armageddon(dbref player, const char *msg)
 {
     char buf[BUFFER_LEN];
 
-    if (!Wizard(player) || Typeof(player) != TYPE_PLAYER) {
+    if (!Wizard(player) || OBJECT_TYPE(player) != TYPE_PLAYER) {
         char unparse_buf[BUFFER_LEN];
-        unparse_object(player, player, unparse_buf, sizeof(unparse_buf));
+        flag_unparse_object(player, player, unparse_buf, sizeof(unparse_buf));
 
         notify(player, "Sorry, but you don't look like the god of War to me.");
         log_status("ILLEGAL ARMAGEDDON: tried by %s", unparse_buf);
@@ -5544,7 +5545,7 @@ get_player_descrs(dbref player, int *count)
 {
     int *darr;
 
-    if (Typeof(player) == TYPE_PLAYER) {
+    if (OBJECT_TYPE(player) == TYPE_PLAYER) {
         *count = PLAYER_DESCRCOUNT(player);
         darr = PLAYER_DESCRS(player);
 
@@ -6161,7 +6162,7 @@ ignore_prime_cache(dbref Player)
     if (!tp_ignore_support)
         return 0;
 
-    if (!ObjExists(Player) || Typeof(Player) != TYPE_PLAYER)
+    if (!ObjExists(Player) || OBJECT_TYPE(Player) != TYPE_PLAYER)
         return 0;
 
     if ((Txt = get_property_class(Player, IGNORE_PROP)) == NULL) {
@@ -6345,7 +6346,7 @@ ignore_is_ignoring(dbref Player, dbref Who)
 void
 ignore_flush_cache(dbref Player)
 {
-    if (!ObjExists(Player) || Typeof(Player) != TYPE_PLAYER)
+    if (!ObjExists(Player) || OBJECT_TYPE(Player) != TYPE_PLAYER)
         return;
 
     free(PLAYER_IGNORE_CACHE(Player));
@@ -6426,7 +6427,7 @@ ignore_remove_from_all_players(dbref Player)
         return;
 
     for (dbref i = 0; i < db_top; i++)
-        if (Typeof(i) == TYPE_PLAYER)
+        if (OBJECT_TYPE(i) == TYPE_PLAYER)
             reflist_del(i, IGNORE_PROP, Player);
 
     /* Don't touch the database if it's not been loaded yet... */
@@ -6444,7 +6445,7 @@ ignore_remove_from_all_players(dbref Player)
          *       think the cleanliness is worth a very slight performance
          *       impact.
          */
-        if (Typeof(i) == TYPE_PLAYER) {
+        if (OBJECT_TYPE(i) == TYPE_PLAYER) {
             free(PLAYER_IGNORE_CACHE(i));
             PLAYER_SET_IGNORE_CACHE(i, NULL);
             PLAYER_SET_IGNORE_COUNT(i, 0);

--- a/src/interp.c
+++ b/src/interp.c
@@ -22,6 +22,7 @@
 #include "fbmath.h"
 #include "fbstrings.h"
 #include "fbtime.h"
+#include "flags.h"
 #include "game.h"
 #include "inst.h"
 #include "interface.h"
@@ -662,7 +663,7 @@ interp(int descr, dbref player, dbref location, dbref program,
     struct frame *fr;
 
     /* Check basic permissions to make sure we're allowed to do the call. */
-    if (!MLevel(program) || !MLevel(OWNER(program)) ||
+    if (!OBJECT_MLEVEL(program) || !OBJECT_MLEVEL(OWNER(program)) ||
         ((source != NOTHING) && !TrueWizard(OWNER(source)) &&
          !can_link_to(OWNER(source), TYPE_EXIT, program))) {
         notify_nolisten(player, "Program call: Permission denied.", 1);
@@ -695,8 +696,8 @@ interp(int descr, dbref player, dbref location, dbref program,
 
     fr->errorprog = NOTHING;
     fr->pc = PROGRAM_START(program);
-    fr->writeonly = ((source == -1) || (Typeof(source) == TYPE_ROOM) ||
-		     ((Typeof(source) == TYPE_PLAYER) && (!PLAYER_DESCRCOUNT(source))) ||
+    fr->writeonly = ((source == -1) || (OBJECT_TYPE(source) == TYPE_ROOM) ||
+		     ((OBJECT_TYPE(source) == TYPE_PLAYER) && (!PLAYER_DESCRCOUNT(source))) ||
                      (FLAGS(player) & READMODE));
 
     fr->brkpt.breaknum = -1;
@@ -1396,7 +1397,7 @@ static int nested_interp_loop_count = 0;
  * are different of course).
  *
  * Origprog would be the program the player ran, and program may be different
- * if it is a CALL'd library for instance.  
+ * if it is a CALL'd library for instance.
  *
  * @private
  * @param player the player that is running the program
@@ -1423,7 +1424,7 @@ interp_err(dbref player, dbref program, struct inst *pc,
     err++;
 
     if (OWNER(origprog) == OWNER(player)) {
-        notify_nolisten(player, 
+        notify_nolisten(player,
                         "\033[1;31;40mProgram Error.  Your program just got "
                         "the following error.\033[0m", 1);
     } else {
@@ -1687,9 +1688,9 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
         pc = fr->pc = PROGRAM_START(program);
 
         if (!pc) {
-            char error_buf[BUFFER_LEN];
+            char error_buf[BUFFER_LEN+20];
             char unparse_buf[BUFFER_LEN];
-            unparse_object(player, program, unparse_buf, sizeof(unparse_buf));
+            flag_unparse_object(player, program, unparse_buf, sizeof(unparse_buf));
             snprintf(error_buf, sizeof(error_buf), "Unable to compile %s.", unparse_buf);
             abort_loop_hard(error_buf, NULL, NULL);
         }
@@ -1725,7 +1726,7 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
          * If it is pre-empt, check instruction count, nested loop count,
          * and all.
          */
-        if ((fr->multitask == PREEMPT) || (FLAGS(program) & BUILDER)) {
+        if ((fr->multitask == PREEMPT) || FLAG_CHECK(program, 'B')) {
             if (mlev == 4) {
                 if (tp_max_ml4_preempt_count) {
                     if (instr_count >= tp_max_ml4_preempt_count)
@@ -1750,7 +1751,7 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
             }
         } else {
             /* if in FOREGROUND or BACKGROUND mode, '0 sleep' every so often. */
-            if (((fr->instcnt > tp_instr_slice * 4) && 
+            if (((fr->instcnt > tp_instr_slice * 4) &&
                  (instr_count >= tp_instr_slice)) ||
                  (nested_interp_loop_count > tp_max_nested_interp_loop_count)) {
                 fr->pc = pc;
@@ -1766,7 +1767,7 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
         }
 
         /* Handle enter debug mode or not */
-        if (((FLAGS(program) & ZOMBIE) || fr->brkpt.force_debugging) &&
+        if ((FLAG_CHECK(program, 'Z') || fr->brkpt.force_debugging) &&
             !fr->been_background && controls(player, program)) {
             fr->brkpt.debugging = 1;
         } else {
@@ -1774,9 +1775,9 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
         }
 
         /* Handle debug (dump) mode */
-        if (FLAGS(program) & DARK ||
+        if (Dark(program) ||
             (fr->brkpt.debugging && fr->brkpt.showstack && !fr->brkpt.bypass)) {
-            if ((pc->type != PROG_PRIMITIVE) || 
+            if ((pc->type != PROG_PRIMITIVE) ||
                 (pc->data.number != instno_debug_line)) {
                 char *m =
                     debug_inst(fr, 0, pc, fr->pid, arg, dbuf, sizeof(dbuf),
@@ -2132,7 +2133,7 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
                                        NULL);
 
                         if (!ObjExists(temp1->data.addr->progref) ||
-                            Typeof(temp1->data.addr->progref) != TYPE_PROGRAM)
+                            OBJECT_TYPE(temp1->data.addr->progref) != TYPE_PROGRAM)
                             abort_loop_hard("Internal error.  Invalid address.",
                                             temp1, NULL);
 
@@ -2164,7 +2165,7 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
                                        NULL);
 
                         if (!ObjExists(temp1->data.addr->progref) ||
-                            Typeof(temp1->data.addr->progref) != TYPE_PROGRAM)
+                            OBJECT_TYPE(temp1->data.addr->progref) != TYPE_PROGRAM)
                             abort_loop_hard("Internal error.  Invalid address.",
                                             temp1, NULL);
 
@@ -2222,7 +2223,7 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
                             abort_loop("Dbref required. (1)", temp1, temp2);
 
                         if (!valid_object(temp1)
-                            || Typeof(temp1->data.objref) != TYPE_PROGRAM)
+                            || OBJECT_TYPE(temp1->data.objref) != TYPE_PROGRAM)
                             abort_loop("Invalid object.", temp1, temp2);
 
                         if (!(PROGRAM_CODE(temp1->data.objref))) {
@@ -2237,9 +2238,9 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
                             PROGRAM_SET_FIRST(temp1->data.objref, tmpline);
 
                             if (!(PROGRAM_CODE(temp1->data.objref))) {
-                                char error_buf[BUFFER_LEN];
+                                char error_buf[BUFFER_LEN+20];
                                 char unparse_buf[BUFFER_LEN];
-                                unparse_object(player, temp1->data.objref, unparse_buf, sizeof(unparse_buf));
+                                flag_unparse_object(player, temp1->data.objref, unparse_buf, sizeof(unparse_buf));
                                 snprintf(error_buf, sizeof(error_buf), "Unable to compile %s.", unparse_buf);
                                 abort_loop(error_buf, temp1, temp2);
                             }
@@ -2267,7 +2268,7 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
                             pbs = PROGRAM_PUBS(temp1->data.objref);
 
                             while (pbs) {
-                                tmpint = 
+                                tmpint =
                                         strcasecmp(temp2->data.string->data,
                                                    pbs->subname);
 
@@ -2312,7 +2313,7 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
                     case IN_RET: /* Internal return prim */
                         if (stop > 1 && program != sys[stop - 1].progref) {
                             if (!ObjExists(sys[stop - 1].progref) ||
-                                Typeof(sys[stop - 1].progref) != 
+                                OBJECT_TYPE(sys[stop - 1].progref) !=
                                 TYPE_PROGRAM)
                                 abort_loop_hard("Internal error.  Invalid "
                                                 "address.", NULL, NULL);
@@ -2360,7 +2361,7 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
                                 /* IN_CATCH */
                                 if (fr->errorstr) {
                                     arg[atop].type = PROG_STRING;
-                                    arg[atop++].data.string = 
+                                    arg[atop++].data.string =
                                         alloc_prog_string(fr->errorstr);
                                     free(fr->errorstr);
                                     fr->errorstr = NULL;
@@ -2564,7 +2565,7 @@ interp_loop(dbref player, dbref program, struct frame *fr, int rettyp)
                 while (fr->trys.st->call_level < stop) {
                     if (stop > 1 && program != sys[stop - 1].progref) {
                         if (!ObjExists(sys[stop - 1].progref) ||
-                            Typeof(sys[stop - 1].progref) != TYPE_PROGRAM)
+                            OBJECT_TYPE(sys[stop - 1].progref) != TYPE_PROGRAM)
                             abort_loop_hard("Internal error.  Invalid address.",
                                             NULL, NULL);
 
@@ -2659,7 +2660,7 @@ int
 valid_player(struct inst *oper)
 {
     return (!(oper->type != PROG_OBJECT || !ObjExists(oper->data.objref)
-            || (Typeof(oper->data.objref) != TYPE_PLAYER)));
+            || (OBJECT_TYPE(oper->data.objref) != TYPE_PLAYER)));
 }
 
 /**
@@ -2672,7 +2673,7 @@ int
 valid_object(struct inst *oper)
 {
     return (!(oper->type != PROG_OBJECT || !ObjExists(oper->data.objref)
-            || Typeof(oper->data.objref) == TYPE_GARBAGE));
+            || OBJECT_TYPE(oper->data.objref) == TYPE_GARBAGE));
 }
 
 /**
@@ -2709,7 +2710,7 @@ permissions(dbref player, dbref thing)
     if (thing == player || thing == HOME)
         return 1;
 
-    switch (Typeof(thing)) {
+    switch (OBJECT_TYPE(thing)) {
         case TYPE_PLAYER:
             return 0;
 
@@ -2743,15 +2744,15 @@ permissions(dbref player, dbref thing)
 dbref
 find_mlev(dbref prog, struct frame * fr, int st)
 {
-    if ((FLAGS(prog) & STICKY) && (FLAGS(prog) & HAVEN)) {
+    if (FLAG_CHECK(prog, 'S') && FLAG_CHECK(prog, 'H')) {
         if ((st > 1) && (TrueWizard(OWNER(prog))))
             return (find_mlev(fr->caller.st[st - 1], fr, st - 1));
     }
 
-    if (MLevel(prog) < MLevel(OWNER(prog))) {
-        return (MLevel(prog));
+    if (OBJECT_EFFECTIVE_MLEVEL(prog) < OBJECT_EFFECTIVE_MLEVEL(OWNER(prog))) {
+        return (OBJECT_EFFECTIVE_MLEVEL(prog));
     } else {
-        return (MLevel(OWNER(prog)));
+        return (OBJECT_EFFECTIVE_MLEVEL(OWNER(prog)));
     }
 }
 
@@ -2784,8 +2785,8 @@ find_mlev(dbref prog, struct frame * fr, int st)
 dbref
 find_uid(dbref player, struct frame * fr, int st, dbref program)
 {
-    if ((FLAGS(program) & STICKY) || (fr->perms == STD_SETUID)) {
-        if (FLAGS(program) & HAVEN) {
+    if (FLAG_CHECK(program, 'S') || (fr->perms == STD_SETUID)) {
+        if (FLAG_CHECK(program, 'H')) {
             if ((st > 1) && (TrueWizard(OWNER(program))))
                 return (find_uid(player, fr, st - 1, fr->caller.st[st - 1]));
 
@@ -2798,7 +2799,7 @@ find_uid(dbref player, struct frame * fr, int st, dbref program)
     if (ProgMLevel(program) < 2)
         return (OWNER(program));
 
-    if ((FLAGS(program) & HAVEN) || (fr->perms == STD_HARDUID)) {
+    if (FLAG_CHECK(program, 'H') || (fr->perms == STD_HARDUID)) {
         if (fr->trig == NOTHING)
             return (OWNER(program));
 

--- a/src/log.c
+++ b/src/log.c
@@ -16,6 +16,7 @@
 #include "db.h"
 #include "fbtime.h"
 #include "fbstrings.h"
+#include "flags.h"
 #include "inst.h"
 #include "log.h"
 #include "tune.h"
@@ -295,7 +296,7 @@ log_program_text(struct line *first, dbref player, dbref i)
     strftime(tbuf, sizeof(tbuf), "%Y-%m-%dT%H:%M:%S", localtime(&lt));
     fputs("#######################################", f);
     fputs("#######################################\n", f);
-    unparse_object(player, i, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(player, i, unparse_buf, sizeof(unparse_buf));
     fprintf(f, "%s: %s SAVED BY %s(#%d)\n",
             tbuf, unparse_buf, NAME(player), player);
     fputs("#######################################", f);
@@ -346,8 +347,8 @@ whowhere(dbref who)
 
     snprintf(buf, sizeof(buf), "%s%s%s%s(#%d) in %s(#%d)",
              Wizard(OWNER(who)) ? "WIZ: " : "",
-             (Typeof(who) != TYPE_PLAYER) ? NAME(who) : "",
-             (Typeof(who) != TYPE_PLAYER) ? " owned by " : "",
+             (OBJECT_TYPE(who) != TYPE_PLAYER) ? NAME(who) : "",
+             (OBJECT_TYPE(who) != TYPE_PLAYER) ? " owned by " : "",
              NAME(OWNER(who)), who, NAME(LOCATION(who)), LOCATION(who));
 
     return strdup(buf);

--- a/src/look.c
+++ b/src/look.c
@@ -604,7 +604,7 @@ do_examine(int descr, dbref player, const char *name, const char *dir)
     notify(player, buf);
 
     flag_list_verbose(thing, flags_buf, sizeof(flags_buf));
-    notifyf(player, "Type: %s  Flags: %s", object_type_name(thing), flags_buf);
+    notifyf(player, "Type: %s  Flags: %s", OBJECT_TYPE_INFO(thing)->uppercase, flags_buf);
 
     if (GETDESC(thing))
         notify(player, GETDESC(thing));

--- a/src/look.c
+++ b/src/look.c
@@ -1257,10 +1257,10 @@ checkflags(dbref what, struct flgchkdat check)
     if (check.isnotthree && (OBJECT_MLEVEL(what) == 3))
         return (0);
 
-    if (FLAG_CHECK(what, check.clearflags))
+    if (FLAGS(what) & check.clearflags)
         return (0);
 
-    if (!FLAG_CHECK(what, check.setflags))
+    if ((~FLAGS(what)) & check.setflags)
         return (0);
 
     if (check.forlink) {

--- a/src/look.c
+++ b/src/look.c
@@ -22,6 +22,7 @@
 #endif
 #include "fbstrings.h"
 #include "fbtime.h"
+#include "flags.h"
 #include "game.h"
 #include "interface.h"
 #include "look.h"
@@ -46,7 +47,7 @@ print_owner(dbref player, dbref thing)
 {
     char buf[BUFFER_LEN];
 
-    switch (Typeof(thing)) {
+    switch (OBJECT_TYPE(thing)) {
         case TYPE_PLAYER:
             snprintf(buf, sizeof(buf), "%s is a player.", NAME(thing));
             break;
@@ -81,24 +82,24 @@ print_owner(dbref player, dbref thing)
 static int
 can_see(dbref player, dbref thing, int can_see_loc)
 {
-    if (player == thing || Typeof(thing) == TYPE_EXIT || Typeof(thing) == TYPE_ROOM)
+    if (player == thing || OBJECT_TYPE(thing) == TYPE_EXIT || OBJECT_TYPE(thing) == TYPE_ROOM)
         return 0;
 
     if (can_see_loc) {
-        switch (Typeof(thing)) {
+        switch (OBJECT_TYPE(thing)) {
             case TYPE_PROGRAM:
-                return ((FLAGS(thing) & VEHICLE) || controls(player, thing));
+                return (FLAG_CHECK(thing, 'V') || controls(player, thing));
             case TYPE_PLAYER:
                 if (tp_dark_sleepers) {
                     return (!Dark(thing) && PLAYER_DESCRCOUNT(thing));
                 }
                 /* fall through */
             default:
-                return (!Dark(thing) || (controls(player, thing) && !(FLAGS(player) & STICKY)));
+                return (!Dark(thing) || (controls(player, thing) && !FLAG_CHECK(player, 'S')));
         }
     } else {
         /* can't see loc */
-        return (controls(player, thing) && !(FLAGS(player) & STICKY));
+        return (controls(player, thing) && !FLAG_CHECK(player, 'S'));
     }
 }
 
@@ -137,7 +138,7 @@ look_contents(dbref player, dbref loc, const char *contents_name)
 
             DOLIST(thing, CONTENTS(loc)) {
                 if (can_see(player, thing, can_see_loc)) {
-                    unparse_object(player, thing, unparse_buf, sizeof(unparse_buf));
+                    flag_unparse_object(player, thing, unparse_buf, sizeof(unparse_buf));
                     notify(player, unparse_buf);
                 }
             }
@@ -194,7 +195,7 @@ look_room(int descr, dbref player, dbref loc)
     if (loc == NOTHING) return;
 
     /* tell him the name, and the number if he can link to it */
-    unparse_object(player, loc, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(player, loc, unparse_buf, sizeof(unparse_buf));
     notify(player, unparse_buf);
 
     /* tell him the description
@@ -210,7 +211,7 @@ look_room(int descr, dbref player, dbref loc)
      *        We can even have simple_look process idesc's ... or maybe
      *        even take this whole if statement into simple_look
      */
-    if (Typeof(loc) == TYPE_ROOM) {
+    if (OBJECT_TYPE(loc) == TYPE_ROOM) {
         if (GETDESC(loc)) {
             exec_or_notify(descr, player, loc, GETDESC(loc), "(@Desc)",
                            Prop_Blessed(loc, MESGPROP_DESC) ? MPI_ISBLESSED : 0);
@@ -275,7 +276,7 @@ do_look_at(int descr, dbref player, const char *name, const char *detail)
         look_room(descr, player, LOCATION(player));
     } else {
         /* look at a thing here */
-        init_match(descr, player, name, NOTYPE, &md);
+        init_match(descr, player, name, TYPE_ANY, &md);
         match_all_exits(&md);
         match_neighbor(&md);
         match_possession(&md);
@@ -294,7 +295,7 @@ do_look_at(int descr, dbref player, const char *name, const char *detail)
             /* The syntax used was "look <something>" and we found the
              * <something> with match.
              */
-            switch (Typeof(thing)) {
+            switch (OBJECT_TYPE(thing)) {
                 /* The rules for rooms, players, and things are all
                  * slightly different.
                  *
@@ -343,7 +344,7 @@ do_look_at(int descr, dbref player, const char *name, const char *detail)
                     } else {
                         look_simple(descr, player, thing);
 
-                        if (!(FLAGS(thing) & HAVEN)) {
+                        if (!FLAG_CHECK(thing, 'H')) {
                             look_contents(player, thing, "Contains:");
                             ts_useobject(thing);
                         }
@@ -357,7 +358,7 @@ do_look_at(int descr, dbref player, const char *name, const char *detail)
                 default:
                     look_simple(descr, player, thing);
 
-                    if (Typeof(thing) != TYPE_PROGRAM)
+                    if (OBJECT_TYPE(thing) != TYPE_PROGRAM)
                         ts_useobject(thing);
 
                     snprintf(obj_num, sizeof(obj_num), "#%d", thing);
@@ -441,163 +442,6 @@ do_look_at(int descr, dbref player, const char *name, const char *detail)
 }
 
 /**
- * Generate a long-form text description of the flags on a given object.
- *
- * Note: This uses a static buffer so it is not threadsafe and the contents
- * of the buffer may well mutate if you don't copy the string elsewhere.
- *
- * @private
- * @param thing to generate description for
- * @return string containing descriptive flag text
- */
-static const char *
-flag_description(dbref thing)
-{
-    static char buf[BUFFER_LEN];
-    int jj;
-
-    strcpyn(buf, sizeof(buf), "Type: ");
-
-    switch (Typeof(thing)) {
-        case TYPE_ROOM:
-            strcatn(buf, sizeof(buf), "ROOM");
-            break;
-        case TYPE_EXIT:
-            strcatn(buf, sizeof(buf), "EXIT/ACTION");
-            break;
-        case TYPE_THING:
-            strcatn(buf, sizeof(buf), "THING");
-            break;
-        case TYPE_PLAYER:
-            strcatn(buf, sizeof(buf), "PLAYER");
-            break;
-        case TYPE_PROGRAM:
-            strcatn(buf, sizeof(buf), "PROGRAM");
-            break;
-        case TYPE_GARBAGE:
-            strcatn(buf, sizeof(buf), "GARBAGE");
-            break;
-        default:
-            strcatn(buf, sizeof(buf), "***UNKNOWN TYPE***");
-            break;
-    }
-
-    if (FLAGS(thing) & ~TYPE_MASK & ~DUMP_MASK) {
-        /* print flags */
-        strcatn(buf, sizeof(buf), "  Flags:");
-
-        if (FLAGS(thing) & WIZARD)
-            strcatn(buf, sizeof(buf), " WIZARD");
-
-        if (FLAGS(thing) & QUELL)
-            strcatn(buf, sizeof(buf), " QUELL");
-
-        if (FLAGS(thing) & STICKY) {
-            if (Typeof(thing) == TYPE_PROGRAM) {
-                strcatn(buf, sizeof(buf), " SETUID");
-            } else if (Typeof(thing) == TYPE_PLAYER) {
-                strcatn(buf, sizeof(buf), " SILENT");
-            } else {
-                strcatn(buf, sizeof(buf), " STICKY");
-            }
-        }
-
-        if (FLAGS(thing) & DARK) {
-            if (Typeof(thing) == TYPE_PROGRAM) {
-                strcatn(buf, sizeof(buf), " DEBUG");
-            } else {
-                strcatn(buf, sizeof(buf), " DARK");
-            }
-        }
-
-        if (FLAGS(thing) & LINK_OK)
-            strcatn(buf, sizeof(buf), " LINK_OK");
-
-        if (FLAGS(thing) & KILL_OK)
-            strcatn(buf, sizeof(buf), " KILL_OK");
-
-        if ((jj = MLevRaw(thing))) {
-            strcatn(buf, sizeof(buf), " MUCKER");
-            strcatn(buf, sizeof(buf), (char[]){jj+48,0});	 
-        }
-
-        if (FLAGS(thing) & BUILDER) {
-            if (Typeof(thing) == TYPE_PROGRAM) {
-                strcatn(buf, sizeof(buf), " BOUND");
-            } else {
-                strcatn(buf, sizeof(buf), " BUILDER");
-            }
-        }
-
-        if (FLAGS(thing) & CHOWN_OK) {
-            if (Typeof(thing) == TYPE_PLAYER) {
-                strcatn(buf, sizeof(buf), " COLOR");
-            } else {
-                strcatn(buf, sizeof(buf), " CHOWN_OK");
-            }
-        }
-
-        if (FLAGS(thing) & JUMP_OK)
-            strcatn(buf, sizeof(buf), " JUMP_OK");
-
-        if (FLAGS(thing) & VEHICLE) {
-            if (Typeof(thing) == TYPE_PROGRAM) {
-                strcatn(buf, sizeof(buf), " VIEWABLE");
-            } else {
-                strcatn(buf, sizeof(buf), " VEHICLE");
-            }
-        }
-
-        if (FLAGS(thing) & YIELD)
-            strcatn(buf, sizeof(buf), " YIELD");
-
-        if (FLAGS(thing) & OVERT)
-            strcatn(buf, sizeof(buf), " OVERT");
-
-        if (FLAGS(thing) & XFORCIBLE) {
-            if (Typeof(thing) == TYPE_EXIT) {
-                strcatn(buf, sizeof(buf), " XPRESS");
-            } else {
-                strcatn(buf, sizeof(buf), " XFORCIBLE");
-            }
-        }
-
-        if (FLAGS(thing) & ZOMBIE)
-            strcatn(buf, sizeof(buf), " ZOMBIE");
-
-        if (FLAGS(thing) & GUEST) {
-            if (Typeof(thing) == TYPE_PLAYER || Typeof(thing) == TYPE_THING) {
-                strcatn(buf, sizeof(buf), " GUEST");
-            } else {
-                strcatn(buf, sizeof(buf), " NOGUEST");
-            }
-        }
-
-        if (FLAGS(thing) & HAVEN) {
-            if (Typeof(thing) == TYPE_PROGRAM) {
-                strcatn(buf, sizeof(buf), " HARDUID");
-            } else if (Typeof(thing) == TYPE_THING) {
-                strcatn(buf, sizeof(buf), " HIDE");
-            } else {
-                strcatn(buf, sizeof(buf), " HAVEN");
-            }
-        }
-
-        if (FLAGS(thing) & ABODE) {
-            if (Typeof(thing) == TYPE_PROGRAM) {
-                strcatn(buf, sizeof(buf), " AUTOSTART");
-            } else if (Typeof(thing) == TYPE_EXIT) {
-                strcatn(buf, sizeof(buf), " ABATE");
-            } else {
-                strcatn(buf, sizeof(buf), " ABODE");
-            }
-        }
-    }
-
-    return buf;
-}
-
-/**
  * List props on an object with support for wildcards.
  *
  * It supports the '*' wildcard and the '**' recursive wildcard.
@@ -619,8 +463,8 @@ listprops_wildcard(dbref player, dbref thing, const char *dir, const char *wild)
 {
     char propname[BUFFER_LEN];
     char wld[BUFFER_LEN];
-    char buf[BUFFER_LEN];
-    char buf2[BUFFER_LEN];
+    char buf[BUFFER_LEN+128];
+    char buf2[BUFFER_LEN+256];
     char *ptr, *wldcrd;
     PropPtr propadr, pptr;
     int i, cnt = 0;
@@ -692,7 +536,8 @@ void
 do_examine(int descr, dbref player, const char *name, const char *dir)
 {
     dbref thing;
-    char unparse_buf[BUFFER_LEN];
+    char unparse_buf[SMALL_BUFFER_LEN];
+    char flags_buf[MINI_BUFFER_LEN];
     char buf[BUFFER_LEN];
     const char *temp;
     dbref content;
@@ -705,7 +550,7 @@ do_examine(int descr, dbref player, const char *name, const char *dir)
         thing = LOCATION(player);
     } else {
         /* look it up */
-        init_match(descr, player, name, NOTYPE, &md);
+        init_match(descr, player, name, TYPE_ANY, &md);
         match_everything(&md);
 
         /* get result */
@@ -725,14 +570,14 @@ do_examine(int descr, dbref player, const char *name, const char *dir)
         return;
     }
 
-    unparse_object(player, thing, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(player, thing, unparse_buf, sizeof(unparse_buf));
 
-    switch (Typeof(thing)) {
+    switch (OBJECT_TYPE(thing)) {
         case TYPE_ROOM:
             snprintf(buf, sizeof(buf), "%.*s  Owner: %s  Parent: ",
                      (int) (BUFFER_LEN - strlen(NAME(OWNER(thing))) - 35),
                      unparse_buf, NAME(OWNER(thing)));
-            unparse_object(player, LOCATION(thing), unparse_buf, sizeof(unparse_buf));
+            flag_unparse_object(player, LOCATION(thing), unparse_buf, sizeof(unparse_buf));
             strcatn(buf, sizeof(buf), unparse_buf);
             break;
         case TYPE_THING:
@@ -758,7 +603,8 @@ do_examine(int descr, dbref player, const char *name, const char *dir)
 
     notify(player, buf);
 
-    notify(player, flag_description(thing));
+    flag_list_verbose(thing, flags_buf, sizeof(flags_buf));
+    notifyf(player, "Type: %s  Flags: %s", object_type_name(thing), flags_buf);
 
     if (GETDESC(thing))
         notify(player, GETDESC(thing));
@@ -837,7 +683,7 @@ do_examine(int descr, dbref player, const char *name, const char *dir)
     strftime(buf, BUFFER_LEN, "%c %Z", time_tm);
     notifyf(player, "Lastused: %s", buf);
 
-    if (Typeof(thing) == TYPE_PROGRAM) {
+    if (OBJECT_TYPE(thing) == TYPE_PROGRAM) {
         snprintf(buf, sizeof(buf), "Usecount: %d     Instances: %d",
                  DBFETCH(thing)->ts_usecount, PROGRAM_INSTANCES(thing));
     } else {
@@ -852,25 +698,25 @@ do_examine(int descr, dbref player, const char *name, const char *dir)
 
     /* show him the contents */
     if (CONTENTS(thing) != NOTHING) {
-        if (Typeof(thing) == TYPE_PLAYER)
+        if (OBJECT_TYPE(thing) == TYPE_PLAYER)
             notify(player, "Carrying:");
         else
             notify(player, "Contents:");
 
         DOLIST(content, CONTENTS(thing)) {
-            unparse_object(player, content, unparse_buf, sizeof(unparse_buf));
+            flag_unparse_object(player, content, unparse_buf, sizeof(unparse_buf));
             notify(player, unparse_buf);
         }
     }
 
-    switch (Typeof(thing)) {
+    switch (OBJECT_TYPE(thing)) {
         case TYPE_ROOM:
             /* tell him about exits */
             if (EXITS(thing) != NOTHING) {
                 notify(player, "Exits:");
 
                 DOLIST(exit, EXITS(thing)) {
-                    unparse_object(player, exit, unparse_buf, sizeof(unparse_buf));
+                    flag_unparse_object(player, exit, unparse_buf, sizeof(unparse_buf));
                     notify(player, unparse_buf);
                 }
             } else {
@@ -879,20 +725,20 @@ do_examine(int descr, dbref player, const char *name, const char *dir)
 
             /* print dropto if present */
             if (DBFETCH(thing)->sp.room.dropto != NOTHING) {
-                unparse_object(player, DBFETCH(thing)->sp.room.dropto, unparse_buf, sizeof(unparse_buf));
+                flag_unparse_object(player, DBFETCH(thing)->sp.room.dropto, unparse_buf, sizeof(unparse_buf));
                 notifyf(player, "Dropped objects go to: %s", unparse_buf);
             }
 
             break;
         case TYPE_THING:
             /* print home */
-            unparse_object(player, THING_HOME(thing), unparse_buf, sizeof(unparse_buf));
+            flag_unparse_object(player, THING_HOME(thing), unparse_buf, sizeof(unparse_buf));
             notifyf(player, "Home: %s", unparse_buf);
 
             /* print location if player can link to it */
             if (LOCATION(thing) != NOTHING && (controls(player, LOCATION(thing))
                 || can_see_flags(player, LOCATION(thing)))) {
-                unparse_object(player, LOCATION(thing), unparse_buf, sizeof(unparse_buf));
+                flag_unparse_object(player, LOCATION(thing), unparse_buf, sizeof(unparse_buf));
                 notifyf(player, "Location: %s", unparse_buf);
             }
 
@@ -901,7 +747,7 @@ do_examine(int descr, dbref player, const char *name, const char *dir)
                 notify(player, "Actions/exits:");
 
                 DOLIST(exit, EXITS(thing)) {
-                    unparse_object(player, exit, unparse_buf, sizeof(unparse_buf));
+                    flag_unparse_object(player, exit, unparse_buf, sizeof(unparse_buf));
                     notify(player, unparse_buf);
                 }
             } else {
@@ -911,13 +757,13 @@ do_examine(int descr, dbref player, const char *name, const char *dir)
             break;
         case TYPE_PLAYER:
             /* print home */
-            unparse_object(player, PLAYER_HOME(thing), unparse_buf, sizeof(unparse_buf));
+            flag_unparse_object(player, PLAYER_HOME(thing), unparse_buf, sizeof(unparse_buf));
             notifyf(player, "Home: %s", unparse_buf);       /* home */
 
             /* print location if player can link to it */
             if (LOCATION(thing) != NOTHING && (controls(player, LOCATION(thing))
                 || can_see_flags(player, LOCATION(thing)))) {
-                unparse_object(player, LOCATION(thing), unparse_buf, sizeof(unparse_buf));
+                flag_unparse_object(player, LOCATION(thing), unparse_buf, sizeof(unparse_buf));
                 notifyf(player, "Location: %s", unparse_buf);
             }
 
@@ -926,7 +772,7 @@ do_examine(int descr, dbref player, const char *name, const char *dir)
                 notify(player, "Actions/exits:");
 
                 DOLIST(exit, EXITS(thing)) {
-                    unparse_object(player, exit, unparse_buf, sizeof(unparse_buf));
+                    flag_unparse_object(player, exit, unparse_buf, sizeof(unparse_buf));
                     notify(player, unparse_buf);
                 }
             } else {
@@ -936,7 +782,7 @@ do_examine(int descr, dbref player, const char *name, const char *dir)
             break;
         case TYPE_EXIT:
             if (LOCATION(thing) != NOTHING) {
-                unparse_object(player, LOCATION(thing), unparse_buf, sizeof(unparse_buf));
+                flag_unparse_object(player, LOCATION(thing), unparse_buf, sizeof(unparse_buf));
                 notifyf(player, "Source: %s", unparse_buf);
             }
 
@@ -952,7 +798,7 @@ do_examine(int descr, dbref player, const char *name, const char *dir)
                         notify(player, "Destination: *HOME*");
                         break;
                     default:
-                        unparse_object(player, (DBFETCH(thing)->sp.exit.dest)[i], unparse_buf, sizeof(unparse_buf));
+                        flag_unparse_object(player, (DBFETCH(thing)->sp.exit.dest)[i], unparse_buf, sizeof(unparse_buf));
                         notifyf(player, "Destination: %s", unparse_buf);
                         break;
                 }
@@ -972,7 +818,7 @@ do_examine(int descr, dbref player, const char *name, const char *dir)
             /* print location if player can link to it */
             if (LOCATION(thing) != NOTHING && (controls(player, LOCATION(thing))
                 || can_see_flags(player, LOCATION(thing)))) {
-                unparse_object(player, LOCATION(thing), unparse_buf, sizeof(unparse_buf));
+                flag_unparse_object(player, LOCATION(thing), unparse_buf, sizeof(unparse_buf));
                 notifyf(player, "Location: %s", unparse_buf);
             }
 
@@ -1019,7 +865,7 @@ do_inventory(dbref player)
     } else {
         notify(player, "You are carrying:");
             DOLIST(thing, thing) {
-                unparse_object(player, thing, unparse_buf, sizeof(unparse_buf));
+                flag_unparse_object(player, thing, unparse_buf, sizeof(unparse_buf));
                 notify(player, unparse_buf);
             }
     }
@@ -1035,7 +881,7 @@ do_inventory(dbref player)
  * and loads the struct 'check' with the necessary filter paramters.
  *
  * Flags is parsed as follows; it may have an = in it, in which case
- * the "right" side of the = is 
+ * the "right" side of the = is
  *
  * owners (1), locations (3), links (2), count (4), size (5) or default (0)
  *
@@ -1378,47 +1224,47 @@ init_checkflags(dbref player, const char *flags, struct flgchkdat *check)
 int
 checkflags(dbref what, struct flgchkdat check)
 {
-    if (check.fortype && (Typeof(what) != check.istype))
+    if (check.fortype && (OBJECT_TYPE(what) != check.istype))
         return (0);
 
-    if (check.isnotroom && (Typeof(what) == TYPE_ROOM))
+    if (check.isnotroom && (OBJECT_TYPE(what) == TYPE_ROOM))
         return (0);
 
-    if (check.isnotexit && (Typeof(what) == TYPE_EXIT))
+    if (check.isnotexit && (OBJECT_TYPE(what) == TYPE_EXIT))
         return (0);
 
-    if (check.isnotthing && (Typeof(what) == TYPE_THING))
+    if (check.isnotthing && (OBJECT_TYPE(what) == TYPE_THING))
         return (0);
 
-    if (check.isnotplayer && (Typeof(what) == TYPE_PLAYER))
+    if (check.isnotplayer && (OBJECT_TYPE(what) == TYPE_PLAYER))
         return (0);
 
-    if (check.isnotprog && (Typeof(what) == TYPE_PROGRAM))
+    if (check.isnotprog && (OBJECT_TYPE(what) == TYPE_PROGRAM))
         return (0);
 
-    if (check.forlevel && (MLevRaw(what) != check.islevel))
+    if (check.forlevel && (OBJECT_MLEVEL(what) != check.islevel))
         return (0);
 
-    if (check.isnotzero && (MLevRaw(what) == 0))
+    if (check.isnotzero && (OBJECT_MLEVEL(what) == 0))
         return (0);
 
-    if (check.isnotone && (MLevRaw(what) == 1))
+    if (check.isnotone && (OBJECT_MLEVEL(what) == 1))
         return (0);
 
-    if (check.isnottwo && (MLevRaw(what) == 2))
+    if (check.isnottwo && (OBJECT_MLEVEL(what) == 2))
         return (0);
 
-    if (check.isnotthree && (MLevRaw(what) == 3))
+    if (check.isnotthree && (OBJECT_MLEVEL(what) == 3))
         return (0);
 
-    if (FLAGS(what) & check.clearflags)
+    if (FLAG_CHECK(what, check.clearflags))
         return (0);
 
-    if ((~FLAGS(what)) & check.setflags)
+    if (!FLAG_CHECK(what, check.setflags))
         return (0);
 
     if (check.forlink) {
-        switch (Typeof(what)) {
+        switch (OBJECT_TYPE(what)) {
             case TYPE_ROOM:
                 if ((DBFETCH(what)->sp.room.dropto == NOTHING) != (!check.islinked))
                     return (0);
@@ -1479,17 +1325,17 @@ display_objinfo(dbref player, dbref obj, int output_type)
     char buf2[BUFFER_LEN];
     char buf3[BUFFER_LEN];
 
-    unparse_object(player, obj, buf2, sizeof(buf2));
+    flag_unparse_object(player, obj, buf2, sizeof(buf2));
 
     switch (output_type) {
         case 1:         /* owners */
-            unparse_object(player, OWNER(obj), buf3, sizeof(buf3));
+            flag_unparse_object(player, OWNER(obj), buf3, sizeof(buf3));
             snprintf(buf, sizeof(buf), "%-38.512s  %.512s", buf2, buf3);
             break;
         case 2:         /* links */
-            switch (Typeof(obj)) {
+            switch (OBJECT_TYPE(obj)) {
                 case TYPE_ROOM:
-                    unparse_object(player, DBFETCH(obj)->sp.room.dropto,
+                    flag_unparse_object(player, DBFETCH(obj)->sp.room.dropto,
                                    buf3, sizeof(buf3));
                     snprintf(buf, sizeof(buf), "%-38.512s  %.512s", buf2, buf3);
 
@@ -1507,18 +1353,18 @@ display_objinfo(dbref player, dbref obj, int output_type)
                         break;
                     }
 
-                    unparse_object(player, DBFETCH(obj)->sp.exit.dest[0], buf3,
+                    flag_unparse_object(player, DBFETCH(obj)->sp.exit.dest[0], buf3,
                                    sizeof(buf3));
                     snprintf(buf, sizeof(buf), "%-38.512s  %.512s", buf2, buf3);
 
                     break;
                 case TYPE_PLAYER:
-                    unparse_object(player, PLAYER_HOME(obj), buf3, sizeof(buf3));
+                    flag_unparse_object(player, PLAYER_HOME(obj), buf3, sizeof(buf3));
                     snprintf(buf, sizeof(buf), "%-38.512s  %.512s", buf2, buf3);
 
                     break;
                 case TYPE_THING:
-                    unparse_object(player, THING_HOME(obj), buf3, sizeof(buf3));
+                    flag_unparse_object(player, THING_HOME(obj), buf3, sizeof(buf3));
                     snprintf(buf, sizeof(buf), "%-38.512s  %.512s", buf2, buf3);
 
                     break;
@@ -1529,7 +1375,7 @@ display_objinfo(dbref player, dbref obj, int output_type)
 
             break;
         case 3:     /* locations */
-            unparse_object(player, LOCATION(obj), buf3, sizeof(buf3));
+            flag_unparse_object(player, LOCATION(obj), buf3, sizeof(buf3));
             snprintf(buf, sizeof(buf), "%-38.512s  %.512s", buf2, buf3);
 
             break;
@@ -1580,7 +1426,7 @@ do_find(dbref player, const char *name, const char *flags)
         notifyf(player, "You don't have enough %s.", tp_pennies);
     } else {
         for (dbref i = 0; i < db_top; i++) {
-            if (Typeof(i) == TYPE_GARBAGE) continue;
+            if (OBJECT_TYPE(i) == TYPE_GARBAGE) continue;
 
             if ((Wizard(OWNER(player)) || OWNER(i) == OWNER(player)) &&
                 checkflags(i, check) && NAME(i) && (!*name
@@ -1666,7 +1512,7 @@ do_trace(int descr, dbref player, const char *name, int depth)
     if (*name == '\0' || !strcasecmp(name, "here")) {
         thing = LOCATION(player);
     } else {
-        init_match(descr, player, name, NOTYPE, &md);
+        init_match(descr, player, name, TYPE_ANY, &md);
         match_everything(&md);
 
         if ((thing = noisy_match_result(&md)) == NOTHING)
@@ -1674,7 +1520,7 @@ do_trace(int descr, dbref player, const char *name, int depth)
     }
 
     for (int i = 0; (!depth || i < depth) && thing != NOTHING; i++) {
-        unparse_object(player, thing, unparse_buf, sizeof(unparse_buf));
+        flag_unparse_object(player, thing, unparse_buf, sizeof(unparse_buf));
         notify(player, unparse_buf);
         thing = LOCATION(thing);
     }
@@ -1716,7 +1562,7 @@ do_entrances(int descr, dbref player, const char *name, const char *flags)
     if (*name == '\0' || !strcasecmp(name, "here")) {
         thing = LOCATION(player);
     } else {
-        init_match(descr, player, name, NOTYPE, &md);
+        init_match(descr, player, name, TYPE_ANY, &md);
         match_everything(&md);
 
         if ((thing = noisy_match_result(&md)) == NOTHING) {
@@ -1734,7 +1580,7 @@ do_entrances(int descr, dbref player, const char *name, const char *flags)
 
     for (dbref i = 0; i < db_top; i++) {
         if (checkflags(i, check)) {
-            switch (Typeof(i)) {
+            switch (OBJECT_TYPE(i)) {
                 case TYPE_EXIT:
                     for (int j = DBFETCH(i)->sp.exit.ndest; j--;) {
                         if (DBFETCH(i)->sp.exit.dest[j] == thing) {
@@ -1807,7 +1653,7 @@ do_contents(int descr, dbref player, const char *name, const char *flags)
     if (*name == '\0' || !strcasecmp(name, "here")) {
         thing = LOCATION(player);
     } else {
-        init_match(descr, player, name, NOTYPE, &md);
+        init_match(descr, player, name, TYPE_ANY, &md);
         match_everything(&md);
 
         if ((thing = noisy_match_result(&md)) == NOTHING) {
@@ -1830,7 +1676,7 @@ do_contents(int descr, dbref player, const char *name, const char *flags)
         }
     }
 
-    switch (Typeof(thing)) {
+    switch (OBJECT_TYPE(thing)) {
         case TYPE_EXIT:
         case TYPE_PROGRAM:
         case TYPE_GARBAGE:
@@ -1930,7 +1776,7 @@ exit_match_exists(dbref player, dbref obj, const char *name, int exactMatch)
     while (exit != NOTHING) {
         if (exit_matches_name(exit, name, exactMatch)) {
             char unparse_buf[BUFFER_LEN];
-            unparse_object(player, obj, unparse_buf, sizeof(unparse_buf));
+            flag_unparse_object(player, obj, unparse_buf, sizeof(unparse_buf));
             notifyf(player, "  %ss are trapped on %.2048s", name, unparse_buf);
             return 1;
         }
@@ -1970,7 +1816,7 @@ do_sweep(int descr, dbref player, const char *name)
     if (*name == '\0' || !strcasecmp(name, "here")) {
         thing = LOCATION(player);
     } else {
-        init_match(descr, player, name, NOTYPE, &md);
+        init_match(descr, player, name, TYPE_ANY, &md);
         match_everything(&md);
 
         if ((thing = noisy_match_result(&md)) == NOTHING) {
@@ -1984,8 +1830,8 @@ do_sweep(int descr, dbref player, const char *name)
                "Permission denied. (You can't perform a security sweep in a room you don't own)");
         return;
     }
-    
-    unparse_object(player, thing, unparse_buf, sizeof unparse_buf);
+
+    flag_unparse_object(player, thing, unparse_buf, sizeof unparse_buf);
     notifyf(player, "Listeners in %s:", unparse_buf);
 
     ref = CONTENTS(thing);
@@ -1993,14 +1839,14 @@ do_sweep(int descr, dbref player, const char *name)
     /* Check the contents for listeners */
     for (; ref != NOTHING; ref = NEXTOBJ(ref)) {
 
-        switch (Typeof(ref)) {
+        switch (OBJECT_TYPE(ref)) {
             case TYPE_PLAYER:
                 /* Players are pretty easy, though note this does not
                  * pick up dark players.  So this isn't much of a security
                  * sweep really.
                  */
                 if (!Dark(thing) || PLAYER_DESCRCOUNT(ref)) {
-                    unparse_object(player, ref, unparse_buf, sizeof unparse_buf);
+                    flag_unparse_object(player, ref, unparse_buf, sizeof unparse_buf);
                     notifyf(player, "  %s is a %splayer.", unparse_buf,
                             PLAYER_DESCRCOUNT(ref) ? "" : "sleeping ");
                 }
@@ -2008,13 +1854,13 @@ do_sweep(int descr, dbref player, const char *name)
                 break;
             case TYPE_THING:
                 /* Things are only picked up if they are listeners */
-                if (FLAGS(ref) & (ZOMBIE | LISTENER)) {
+                if (FLAG_CHECK(ref, 'Z') || (FLAGS(ref) & LISTENER)) {
                     tellflag = 0;
-                    unparse_object(player, ref, unparse_buf, sizeof unparse_buf);
+                    flag_unparse_object(player, ref, unparse_buf, sizeof unparse_buf);
                     snprintf(buf, sizeof(buf), "  %.255s is a", unparse_buf);
 
                     /* See if the zombie is sleeping */
-                    if (FLAGS(ref) & ZOMBIE) {
+                    if (FLAG_CHECK(ref, 'Z')) {
                         tellflag = 1;
 
                         if (!PLAYER_DESCRCOUNT(OWNER(ref))) {
@@ -2034,7 +1880,7 @@ do_sweep(int descr, dbref player, const char *name)
                     }
 
                     strcatn(buf, sizeof(buf), " object owned by ");
-                    unparse_object(player, OWNER(ref), unparse_buf, sizeof unparse_buf);
+                    flag_unparse_object(player, OWNER(ref), unparse_buf, sizeof unparse_buf);
                     strcatn(buf, sizeof(buf), unparse_buf);
                     strcatn(buf, sizeof(buf), ".");
 
@@ -2069,7 +1915,7 @@ do_sweep(int descr, dbref player, const char *name)
             (get_property(loc, LISTEN_PROPQUEUE) ||
              get_property(loc, WLISTEN_PROPQUEUE) ||
              get_property(loc, WOLISTEN_PROPQUEUE))) {
-            unparse_object(player, loc, unparse_buf, sizeof(unparse_buf));
+            flag_unparse_object(player, loc, unparse_buf, sizeof(unparse_buf));
             notifyf(player, "  %s is a listening room.", unparse_buf);
         }
 

--- a/src/match.c
+++ b/src/match.c
@@ -17,6 +17,7 @@
 #include "diskprop.h"
 #endif
 #include "fbstrings.h"
+#include "flags.h"
 #include "game.h"
 #include "interface.h"
 #include "match.h"
@@ -141,12 +142,12 @@ choose_thing(int descr, dbref thing1, dbref thing2, struct match_data *md)
     }
 
     /* Check for type preference */
-    if (preferred != NOTYPE) {
-        if (Typeof(thing1) == preferred) {
-            if (Typeof(thing2) != preferred) {
+    if (preferred != TYPE_ANY) {
+        if (OBJECT_TYPE(thing1) == preferred) {
+            if (OBJECT_TYPE(thing2) != preferred) {
                 return thing1;
             }
-        } else if (Typeof(thing2) == preferred) {
+        } else if (OBJECT_TYPE(thing2) == preferred) {
             return thing2;
         }
     }
@@ -549,17 +550,17 @@ match_exits(dbref obj, struct match_data *md)
 
         exitprog = 0;
 
-        if (FLAGS(exit) & HAVEN) {
+        if (FLAG_CHECK(exit, 'H')) {
             exitprog = 1;
         } else if (DBFETCH(exit)->sp.exit.dest) {
             for (int i = 0; i < DBFETCH(exit)->sp.exit.ndest; i++)
                 if ((DBFETCH(exit)->sp.exit.dest)[i] == NIL
-                    || Typeof((DBFETCH(exit)->sp.exit.dest)[i]) == TYPE_PROGRAM)
+                    || OBJECT_TYPE((DBFETCH(exit)->sp.exit.dest)[i]) == TYPE_PROGRAM)
                     exitprog = 1;
         }
 
         if (tp_enable_prefix && exitprog && md->partial_exits &&
-            (FLAGS(exit) & XFORCIBLE) && FLAGS(OWNER(exit)) & WIZARD) {
+            FLAG_CHECK(exit, 'X') && TrueWizard(OWNER(exit))) {
             partial = 1;
         } else {
             partial = 0;
@@ -583,11 +584,11 @@ match_exits(dbref obj, struct match_data *md)
             if ((partial && notnull) || ((*p == '\0')
                 || (*p == ' ' && exitprog))) {
                 skip_whitespace(&exitname);
-                lev = PLevel(exit);
+                lev = OBJECT_PRIORITY(exit);
 
                 if (tp_compatible_priorities && (lev == 1) &&
                     (LOCATION(exit) == NOTHING ||
-                     Typeof(LOCATION(exit)) != TYPE_THING ||
+                     OBJECT_TYPE(LOCATION(exit)) != TYPE_THING ||
                      controls(OWNER(exit), LOCATION(md->match_from))))
                     lev = 2;
 
@@ -624,7 +625,7 @@ match_exits(dbref obj, struct match_data *md)
                                         md->match_name);
                             }
                         } else if ((strlen(md->match_name) - strlen(p) ==
-                                   (size_t) md->longest_match) 
+                                   (size_t) md->longest_match)
                                    && !((lev == md->match_level)
                                    && (md->block_equals))) {
                             if (lev > md->match_level) {
@@ -693,7 +694,7 @@ match_invobj_actions(struct match_data *md)
         return;
 
     DOLIST(thing, CONTENTS(md->match_from)) {
-        if (Typeof(thing) == TYPE_THING && EXITS(thing) != NOTHING) {
+        if (OBJECT_TYPE(thing) == TYPE_THING && EXITS(thing) != NOTHING) {
             match_exits(thing, md);
         }
     }
@@ -719,7 +720,7 @@ match_roomobj_actions(struct match_data *md)
         return;
 
     DOLIST(thing, CONTENTS(loc)) {
-        if (Typeof(thing) == TYPE_THING && EXITS(thing) != NOTHING) {
+        if (OBJECT_TYPE(thing) == TYPE_THING && EXITS(thing) != NOTHING) {
             match_exits(thing, md);
         }
     }
@@ -738,7 +739,7 @@ match_roomobj_actions(struct match_data *md)
 static void
 match_player_actions(struct match_data *md)
 {
-    switch (Typeof(md->match_from)) {
+    switch (OBJECT_TYPE(md->match_from)) {
         case TYPE_PLAYER:
         case TYPE_ROOM:
         case TYPE_THING:
@@ -763,7 +764,7 @@ match_player_actions(struct match_data *md)
 static void
 match_room_exits(dbref loc, struct match_data *md)
 {
-    switch (Typeof(loc)) {
+    switch (OBJECT_TYPE(loc)) {
         case TYPE_PLAYER:
         case TYPE_ROOM:
         case TYPE_THING:
@@ -802,7 +803,7 @@ match_all_exits(struct match_data *md)
 
     if ((loc = LOCATION(md->match_from)) != NOTHING)
     {
-        if (FLAGS(loc) & YIELD)
+        if (FLAG_CHECK(loc, 'Y'))
             blocking = 1;
         match_room_exits(loc, md);
     }
@@ -826,7 +827,7 @@ match_all_exits(struct match_data *md)
         return;
 
     /* if player is in a vehicle, use environment of vehicle's home */
-    if (Typeof(loc) == TYPE_THING) {
+    if (OBJECT_TYPE(loc) == TYPE_THING) {
         loc = THING_HOME(loc);
 
         if (loc == NOTHING)
@@ -847,7 +848,7 @@ match_all_exits(struct match_data *md)
          * If we're blocking (because of a yield), only match a room if
          * and only if it has overt set on it.
          */
-        if ((blocking && FLAGS(loc) & OVERT) || !blocking) {
+        if ((blocking && FLAG_CHECK(loc, 'O')) || !blocking) {
             if (md->exact_match != NOTHING)
                 md->block_equals = 1;
 
@@ -858,7 +859,7 @@ match_all_exits(struct match_data *md)
             break;
 
         /* Does this room have env-chain exit blocking enabled? */
-        if (!blocking && FLAGS(loc) & YIELD) {
+        if (!blocking && FLAG_CHECK(loc, 'Y')) {
             blocking = 1;
         }
     }
@@ -1003,7 +1004,7 @@ match_rmatch(dbref arg1, struct match_data *md)
     if (arg1 == NOTHING)
         return;
 
-    switch (Typeof(arg1)) {
+    switch (OBJECT_TYPE(arg1)) {
         case TYPE_PLAYER:
         case TYPE_ROOM:
         case TYPE_THING:
@@ -1037,7 +1038,7 @@ match_controlled(int descr, dbref player, const char *name)
     dbref match;
     struct match_data md;
 
-    init_match(descr, player, name, NOTYPE, &md);
+    init_match(descr, player, name, TYPE_ANY, &md);
     match_everything(&md);
 
     match = noisy_match_result(&md);

--- a/src/mcp.c
+++ b/src/mcp.c
@@ -15,6 +15,7 @@
 #include "db.h"
 #include "edit.h"
 #include "fbstrings.h"
+#include "flags.h"
 #include "game.h"
 #include "inst.h"
 #include "interface.h"
@@ -1122,7 +1123,7 @@ mcp_frame_clear(McpFrame *mfr)
  * This removes the package from all McpFrames and renegotiates the ones
  * that need it.  If the package is removed, it will have max/min version 0.
  *
- * @param package the package to renegotiate 
+ * @param package the package to renegotiate
  */
 void
 mcp_frame_package_renegotiate(const char *package)
@@ -2033,7 +2034,7 @@ mcpedit_program(int descr, dbref player, dbref program)
     }
 
     /* Basic permission checking */
-    if ((Typeof(program) != TYPE_PROGRAM) || !controls(player, program)) {
+    if ((OBJECT_TYPE(program) != TYPE_PROGRAM) || !controls(player, program)) {
         show_mcp_error(mfr, "edit program", "Permission denied!");
         return;
     }
@@ -2150,7 +2151,7 @@ do_mcpprogram(int descr, dbref player, const char *name, const char *rname)
           return;
         }
 
-        unparse_object(player, program, unparse_buf, sizeof(unparse_buf));
+        flag_unparse_object(player, program, unparse_buf, sizeof(unparse_buf));
         notifyf(player, "Program %s created.", unparse_buf);
 
         if (*rname) {

--- a/src/mcppkgs.c
+++ b/src/mcppkgs.c
@@ -15,6 +15,7 @@
 #include "db.h"
 #include "edit.h"
 #include "fbstrings.h"
+#include "flags.h"
 #include "inst.h"
 #include "interface.h"
 #include "log.h"
@@ -308,12 +309,12 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
                 return;
             }
 
-            if (Typeof(obj) != TYPE_PROGRAM || !controls(player, obj)) {
+            if (OBJECT_TYPE(obj) != TYPE_PROGRAM || !controls(player, obj)) {
                 show_mcp_error(mfr, "simpleedit-set", "Permission denied.");
                 return;
             }
 
-            if (!Mucker(player)) {
+            if (OBJECT_MLEVEL(player) == 0) {
                 show_mcp_error(mfr, "simpleedit-set", "Permission denied.");
                 return;
             }
@@ -350,7 +351,7 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
             }
 
             /* Player ref should be fine by now */
-            unparse_object(player, obj, unparse_buf, sizeof(unparse_buf));
+            flag_unparse_object(player, obj, unparse_buf, sizeof(unparse_buf));
             log_status("PROGRAM SAVED: %s by %s(%d)",
                        unparse_buf, NAME(player), player);
 

--- a/src/mfuns.c
+++ b/src/mfuns.c
@@ -20,6 +20,7 @@
 #include "fbmath.h"
 #include "fbstrings.h"
 #include "fbtime.h"
+#include "flags.h"
 #include "game.h"
 #include "interface.h"
 #define NO_MFUN_LIST
@@ -1954,7 +1955,7 @@ mfn_dbeq(MFUNARGS)
 /**
  * MPI function that returns the boolean value arg0 != arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * For this call, that particular nuance doesn't matter too much.
@@ -1984,7 +1985,7 @@ mfn_ne(MFUNARGS)
 /**
  * MPI function that returns the boolean value arg0 == arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * For this call, that particular nuance doesn't matter too much.
@@ -2014,7 +2015,7 @@ mfn_eq(MFUNARGS)
 /**
  * MPI function that returns the boolean value arg0 > arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * @param descr the descriptor of the caller
@@ -2042,7 +2043,7 @@ mfn_gt(MFUNARGS)
 /**
  * MPI function that returns the boolean value arg0 < arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * @param descr the descriptor of the caller
@@ -2070,7 +2071,7 @@ mfn_lt(MFUNARGS)
 /**
  * MPI function that returns the boolean value arg0 >= arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * @param descr the descriptor of the caller
@@ -2098,7 +2099,7 @@ mfn_ge(MFUNARGS)
 /**
  * MPI function that returns the boolean value arg0 <= arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * @param descr the descriptor of the caller
@@ -2126,7 +2127,7 @@ mfn_le(MFUNARGS)
 /**
  * MPI function that returns the smaller of arg0 and arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * Returns the smaller of the two.
@@ -2156,7 +2157,7 @@ mfn_min(MFUNARGS)
 /**
  * MPI function that returns the larger of arg0 and arg1
  *
- * If arg0 and arg1 are both strings containing numbers, they will be 
+ * If arg0 and arg1 are both strings containing numbers, they will be
  * compared as numbers.  Otherwise, they will be compared as strings.
  *
  * Returns the larger of the two.
@@ -3147,7 +3148,7 @@ mfn_convtime(MFUNARGS)
         ABORT_MPI("CONVTIME", error);
 
     snprintf(buf, BUFFER_LEN, "%lld", (long long)seconds);
-    
+
     return buf;
 #endif
 }
@@ -3494,7 +3495,7 @@ mfn_money(MFUNARGS)
     if (tp_pennies_muf_mlev > 1 && !(mesgtyp & MPI_ISBLESSED))
         ABORT_MPI("MONEY", "Permission denied.");
 
-    switch (Typeof(obj)) {
+    switch (OBJECT_TYPE(obj)) {
         case TYPE_THING:
             snprintf(buf, BUFFER_LEN, "%d", GETVALUE(obj));
             break;
@@ -3515,7 +3516,7 @@ mfn_money(MFUNARGS)
 /**
  * MPI function that returns the object flags for provided object as a string.
  *
- * The string is the return of @see unparse_flags
+ * The string is the return of @see flag_list
  *
  * @param descr the descriptor of the caller
  * @param player the ref of the calling player
@@ -3539,7 +3540,8 @@ mfn_flags(MFUNARGS)
     if (obj == PERMDENIED)
         ABORT_MPI("FLAGS", "Permission denied.");
 
-    return unparse_flags(obj);
+    flag_list(obj, buf, sizeof(buf));
+    return buf;
 }
 
 /**
@@ -3583,7 +3585,7 @@ mfn_tell(MFUNARGS)
     if (obj == PERMDENIED)
         ABORT_MPI("TELL", "Permission denied.");
 
-    if ((mesgtyp & MPI_ISLISTENER) && (Typeof(what) != TYPE_ROOM))
+    if ((mesgtyp & MPI_ISLISTENER) && (OBJECT_TYPE(what) != TYPE_ROOM))
         ABORT_MPI("TELL", "Permission denied.");
 
     *buf = '\0';
@@ -3598,8 +3600,8 @@ mfn_tell(MFUNARGS)
             ptr2 = ptr + strlen(ptr);
         }
 
-        if (Typeof(what) == TYPE_ROOM || OWNER(what) == obj || player == obj ||
-            (Typeof(what) == TYPE_EXIT && Typeof(LOCATION(what)) == TYPE_ROOM) ||
+        if (OBJECT_TYPE(what) == TYPE_ROOM || OWNER(what) == obj || player == obj ||
+            (OBJECT_TYPE(what) == TYPE_EXIT && OBJECT_TYPE(LOCATION(what)) == TYPE_ROOM) ||
             string_prefix(argv[0], NAME(player))) {
             snprintf(buf, BUFFER_LEN, "%s%.4093s",
                      ((obj == OWNER(perms) || obj == player) ? "" : "> "), ptr);
@@ -3688,7 +3690,7 @@ mfn_otell(MFUNARGS)
     if (obj == PERMDENIED)
         ABORT_MPI("OTELL", "Permission denied.");
 
-    if ((mesgtyp & MPI_ISLISTENER) && (Typeof(what) != TYPE_ROOM))
+    if ((mesgtyp & MPI_ISLISTENER) && (OBJECT_TYPE(what) != TYPE_ROOM))
         ABORT_MPI("OTELL", "Permission denied.");
 
     if (argc > 2)
@@ -3710,8 +3712,8 @@ mfn_otell(MFUNARGS)
          *       merge this somehow?
          */
         if (((OWNER(what) == OWNER(obj) || isancestor(what, obj)) &&
-             (Typeof(what) == TYPE_ROOM ||
-              (Typeof(what) == TYPE_EXIT && Typeof(LOCATION(what)) == TYPE_ROOM))) ||
+             (OBJECT_TYPE(what) == TYPE_ROOM ||
+              (OBJECT_TYPE(what) == TYPE_EXIT && OBJECT_TYPE(LOCATION(what)) == TYPE_ROOM))) ||
                 string_prefix(argv[0], NAME(player))) {
             strcpyn(buf, buflen, ptr);
         } else {

--- a/src/mfuns2.c
+++ b/src/mfuns2.c
@@ -2285,45 +2285,14 @@ mfn_type(MFUNARGS)
 {
     dbref obj = mesg_dbref_raw(descr, player, what, argv[0]);
 
-    /*
-     * TODO: This seems like its duplicated in a number of places.
-     *       The 'examine' command for instance does something very
-     *       similar.  Can we centralize this logic?
-     *
-     *       Doing a grep case TYPE_ reveals 331 results.  Not all of them
-     *       are this exact thing, but some are close.
-     */
-
-    if (obj == NOTHING || obj == AMBIGUOUS || obj == UNKNOWN)
-        return ("Bad");
-
-    if (obj == HOME)
-        return ("Room");
-
     if (obj == PERMDENIED)
         ABORT_MPI("TYPE", "Permission Denied.");
 
-    switch (OBJECT_TYPE(obj)) {
-        case TYPE_PLAYER:
-            return "Player";
+    if (obj == HOME)
+        return "Room";
 
-        case TYPE_ROOM:
-            return "Room";
-
-        case TYPE_EXIT:
-            return "Exit";
-
-        case TYPE_THING:
-            return "Thing";
-
-        case TYPE_PROGRAM:
-            return "Program";
-
-        default:
-            return "Bad";
-    }
+    return object_type_name_mpi(obj);
 }
-
 
 /**
  * MPI function that returns true if arg0 is of type arg1
@@ -2346,48 +2315,14 @@ mfn_type(MFUNARGS)
 const char *
 mfn_istype(MFUNARGS)
 {
-    dbref obj;
-    obj = mesg_dbref_raw(descr, player, what, argv[0]);
-
-    if (obj == NOTHING || obj == AMBIGUOUS || obj == UNKNOWN)
-        return (strcasecmp(argv[1], "Bad") ? "0" : "1");
-
-    /*
-     * TODO This check is redundant -- it is identical to the above check
-     *      except it also adds perm denied.  Delete this altogether, then
-     *      move the check for PERMDENIED (the next if statement) up to
-     *      the top because Bad shouldn't bypass permission checks.
-     */
-    if ((strcasecmp(argv[1], "Bad") == 0) &&
-        (obj == NOTHING || obj == AMBIGUOUS || obj == UNKNOWN
-         || obj == PERMDENIED))
-        return "1";
+    dbref obj = mesg_dbref_raw(descr, player, what, argv[0]);
 
     if (obj == PERMDENIED)
         ABORT_MPI("TYPE", "Permission Denied.");
 
-    if (obj == HOME)
-        return (strcasecmp(argv[1], "Room") ? "0" : "1");
+    const char *type = (obj == HOME) ? "Room": object_type_name_mpi(obj);
 
-    switch (OBJECT_TYPE(obj)) {
-        case TYPE_PLAYER:
-            return (strcasecmp(argv[1], "Player") ? "0" : "1");
-
-        case TYPE_ROOM:
-            return (strcasecmp(argv[1], "Room") ? "0" : "1");
-
-        case TYPE_EXIT:
-            return (strcasecmp(argv[1], "Exit") ? "0" : "1");
-
-        case TYPE_THING:
-            return (strcasecmp(argv[1], "Thing") ? "0" : "1");
-
-        case TYPE_PROGRAM:
-            return (strcasecmp(argv[1], "Program") ? "0" : "1");
-
-        default:
-            return (strcasecmp(argv[1], "Bad") ? "0" : "1");
-    }
+    return (strcasecmp(argv[1], type) ? "0" : "1");
 }
 
 /**

--- a/src/mfuns2.c
+++ b/src/mfuns2.c
@@ -19,6 +19,7 @@
 #include "db.h"
 #include "fbmath.h"
 #include "fbstrings.h"
+#include "flags.h"
 #include "game.h"
 #include "inst.h"
 #include "interp.h"
@@ -179,7 +180,7 @@ mfn_links(MFUNARGS)
     if (obj == PERMDENIED)
         ABORT_MPI("LINKS", "Permission denied.");
 
-    switch (Typeof(obj)) {
+    switch (OBJECT_TYPE(obj)) {
         case TYPE_ROOM:
             obj = DBFETCH(obj)->sp.room.dropto;
             break;
@@ -307,7 +308,7 @@ mfn_testlock(MFUNARGS)
     if (who == PERMDENIED)
         ABORT_MPI("TESTLOCK", "Permission denied. (arg3)");
 
-    if (Typeof(who) != TYPE_PLAYER && Typeof(who) != TYPE_THING)
+    if (OBJECT_TYPE(who) != TYPE_PLAYER && OBJECT_TYPE(who) != TYPE_THING)
         ABORT_MPI("TESTLOCK", "Invalid object type. (arg3)");
 
     if (obj == AMBIGUOUS || obj == UNKNOWN || obj == NOTHING || obj == HOME)
@@ -385,7 +386,7 @@ mfn_contents(MFUNARGS)
     if (obj == PERMDENIED)
         ABORT_MPI("CONTENTS", "Permission denied.");
 
-    typchk = NOTYPE;
+    typchk = TYPE_ANY;
 
     if (argc > 1) {
         if (!strcasecmp(argv[1], "Room")) {
@@ -414,11 +415,11 @@ mfn_contents(MFUNARGS)
          * This if statement is a monster, but it does all the type
          * checking along with permission controls.
          */
-        if ((typchk == NOTYPE || Typeof(obj) == typchk) &&
+        if ((typchk == TYPE_ANY || OBJECT_TYPE(obj) == typchk) &&
             (ownroom || controls(perms, obj) ||
-             !((FLAGS(obj) & DARK) || (FLAGS(LOCATION(obj)) & DARK) ||
-               (Typeof(obj) == TYPE_PROGRAM && !(FLAGS(obj) & VEHICLE)))) &&
-            !(Typeof(obj) == TYPE_ROOM && typchk != TYPE_ROOM)) {
+             !(Dark(obj) || Dark(LOCATION(obj)) ||
+               (OBJECT_TYPE(obj) == TYPE_PROGRAM && !FLAG_CHECK(obj, 'V')))) &&
+            !(OBJECT_TYPE(obj) == TYPE_ROOM && typchk != TYPE_ROOM)) {
             ref2str(obj, buf2, sizeof(buf2));
             nextlen = strlen(buf2);
 
@@ -483,7 +484,7 @@ mfn_exits(MFUNARGS)
     if (obj == PERMDENIED)
         ABORT_MPI("EXITS", "Permission denied.");
 
-    switch (Typeof(obj)) {
+    switch (OBJECT_TYPE(obj)) {
         case TYPE_ROOM:
         case TYPE_THING:
         case TYPE_PLAYER:
@@ -666,7 +667,7 @@ mfn_name(MFUNARGS)
 
     strcpyn(buf, buflen, NAME(obj));
 
-    if (Typeof(obj) == TYPE_EXIT) {
+    if (OBJECT_TYPE(obj) == TYPE_EXIT) {
         ptr = strchr(buf, EXIT_DELIMITER);
 
         if (ptr)
@@ -2251,9 +2252,9 @@ mfn_awake(MFUNARGS)
 
         return ("0");
 
-    if (Typeof(obj) == TYPE_THING && (FLAGS(obj) & ZOMBIE)) {
+    if (OBJECT_TYPE(obj) == TYPE_THING && FLAG_CHECK(obj, 'Z')) {
         obj = OWNER(obj);
-    } else if (Typeof(obj) != TYPE_PLAYER) {
+    } else if (OBJECT_TYPE(obj) != TYPE_PLAYER) {
         return ("0");
     }
 
@@ -2302,7 +2303,7 @@ mfn_type(MFUNARGS)
     if (obj == PERMDENIED)
         ABORT_MPI("TYPE", "Permission Denied.");
 
-    switch (Typeof(obj)) {
+    switch (OBJECT_TYPE(obj)) {
         case TYPE_PLAYER:
             return "Player";
 
@@ -2368,7 +2369,7 @@ mfn_istype(MFUNARGS)
     if (obj == HOME)
         return (strcasecmp(argv[1], "Room") ? "0" : "1");
 
-    switch (Typeof(obj)) {
+    switch (OBJECT_TYPE(obj)) {
         case TYPE_PLAYER:
             return (strcasecmp(argv[1], "Player") ? "0" : "1");
 
@@ -2665,13 +2666,13 @@ mfn_muf(MFUNARGS)
     if (obj == UNKNOWN)
         ABORT_MPI("MUF", "Match failed.");
 
-    if (obj <= NOTHING || Typeof(obj) != TYPE_PROGRAM)
+    if (obj <= NOTHING || OBJECT_TYPE(obj) != TYPE_PROGRAM)
         ABORT_MPI("MUF", "Bad program reference.");
 
-    if (!(FLAGS(obj) & LINK_OK) && !controls(perms, obj))
+    if (!FLAG_CHECK(obj, 'L') && !controls(perms, obj))
         ABORT_MPI("MUF", "Permission denied.");
 
-    if ((mesgtyp & (MPI_ISLISTENER | MPI_ISLOCK)) && (MLevel(obj) < 3))
+    if ((mesgtyp & (MPI_ISLISTENER | MPI_ISLOCK)) && (OBJECT_MLEVEL(obj) < 3))
         ABORT_MPI("MUF", "Permission denied.");
 
     if (++mpi_muf_call_levels > 18)
@@ -2764,7 +2765,7 @@ mfn_force(MFUNARGS)
     if (obj == PERMDENIED)
         ABORT_MPI("FORCE", "Permission denied. (arg1)");
 
-    if (Typeof(obj) != TYPE_THING && Typeof(obj) != TYPE_PLAYER)
+    if (OBJECT_TYPE(obj) != TYPE_THING && OBJECT_TYPE(obj) != TYPE_PLAYER)
         ABORT_MPI("FORCE", "Bad object reference. (arg1)");
 
     if (!*argv[1])
@@ -2793,15 +2794,15 @@ mfn_force(MFUNARGS)
         char objname[BUFFER_LEN], *ptr2;
         dbref loc = LOCATION(obj);
 
-        if (Typeof(obj) == TYPE_THING) {
-            if (FLAGS(obj) & DARK)
+        if (OBJECT_TYPE(obj) == TYPE_THING) {
+            if (Dark(obj))
                 ABORT_MPI("FORCE", "Cannot force a dark puppet.");
 
-            if ((FLAGS(OWNER(obj)) & ZOMBIE))
+            if (FLAG_CHECK(OWNER(obj), 'Z'))
                 ABORT_MPI("FORCE", "Permission denied.");
 
-            if (loc != NOTHING && (FLAGS(loc) & ZOMBIE)
-                && Typeof(loc) == TYPE_ROOM)
+            if (loc != NOTHING && FLAG_CHECK(loc, 'Z')
+                && OBJECT_TYPE(loc) == TYPE_ROOM)
                 ABORT_MPI("FORCE",
                           "Cannot force a Puppet in a no-puppets room.");
 
@@ -2815,7 +2816,7 @@ mfn_force(MFUNARGS)
                           "Cannot force a thing named after a player.");
         }
 
-        if (!(FLAGS(obj) & XFORCIBLE)) {
+        if (!FLAG_CHECK(obj, 'X')) {
             ABORT_MPI("FORCE",
                       "Permission denied: forced object not @set Xforcible.");
         }
@@ -2853,7 +2854,7 @@ mfn_force(MFUNARGS)
 
         *ptr3 = '\0';
 
-        if (lookup_player(objname) != NOTHING && Typeof(obj) != TYPE_PLAYER) {
+        if (lookup_player(objname) != NOTHING && OBJECT_TYPE(obj) != TYPE_PLAYER) {
             ABORT_MPI("FORCE",
                       "Cannot force a thing named after a player. [2]");
         }
@@ -3466,9 +3467,9 @@ mfn_width(MFUNARGS)
 
 /**
  * MPI function that returns if an object if it has the given flag (re)set.
- * 
- * @see has_flag
- * 
+ *
+ * @see flag_eval
+ *
  * @param descr the descriptor of the caller
  * @param player the ref of the calling player
  * @param what the dbref of the trigger
@@ -3477,7 +3478,7 @@ mfn_width(MFUNARGS)
  * @param argv the array of strings for arguments
  * @param buf the working buffer
  * @param buflen the size of the buffer
- * @param mesgtyp the type of the message   
+ * @param mesgtyp the type of the message
  * @return string parsed results
  */
 
@@ -3491,9 +3492,51 @@ mfn_flagp(MFUNARGS)
         ABORT_MPI("FLAG?", "Failed match. (arg1)");
     }
 
-    if (has_flag(obj, argv[1])) {
+    char *pbuf = buf;
+    strcpyn(buf, BUFFER_LEN, argv[1]);
+    toupper_string(&pbuf);
+
+    if (flag_eval(obj, buf)) {
         return "1";
     } else {
         return "0";
     }
 }
+
+/**
+ * MPI function that returns if an object's flags match the given pattern.
+ *
+ * @see flag_eval_pattern
+ *
+ * @param descr the descriptor of the caller
+ * @param player the ref of the calling player
+ * @param what the dbref of the trigger
+ * @param perms the dbref for permission consideration
+ * @param argc the number of arguments
+ * @param argv the array of strings for arguments
+ * @param buf the working buffer
+ * @param buflen the size of the buffer
+ * @param mesgtyp the type of the message
+ * @return string parsed results
+ */
+
+const char *
+mfn_flagsp(MFUNARGS)
+{
+    dbref obj = mesg_dbref_local(descr, player, what, perms, argv[0], mesgtyp);
+
+    if (obj == PERMDENIED || obj == AMBIGUOUS || obj == UNKNOWN || obj == NOTHING ||
+        obj == HOME) {
+        ABORT_MPI("FLAG?", "Failed match. (arg1)");
+    }
+
+    strcpyn(buf, BUFFER_LEN, argv[1]);
+    toupper_string(&buf);
+
+    if (flag_eval_pattern(obj, buf)) {
+        return "1";
+    } else {
+        return "0";
+    }
+}
+

--- a/src/mfuns2.c
+++ b/src/mfuns2.c
@@ -2288,10 +2288,15 @@ mfn_type(MFUNARGS)
     if (obj == PERMDENIED)
         ABORT_MPI("TYPE", "Permission Denied.");
 
-    if (obj == HOME)
-        return "Room";
+    if (obj == UNKNOWN || obj == AMBIGUOUS || obj == NOTHING)
+        return "Bad";
 
-    return object_type_name_mpi(obj);
+    const struct object_type *type_info = OBJECT_TYPE_INFO(obj);
+
+    if (!type_info)
+       return (strcasecmp(argv[1], "Bad") == 0) ? "1" : "0";
+
+    return type_info ? type_info->titlecase : "Bad";
 }
 
 /**
@@ -2318,11 +2323,12 @@ mfn_istype(MFUNARGS)
     dbref obj = mesg_dbref_raw(descr, player, what, argv[0]);
 
     if (obj == PERMDENIED)
-        ABORT_MPI("TYPE", "Permission Denied.");
+        ABORT_MPI("ISTYPE", "Permission Denied.");
 
-    const char *type = (obj == HOME) ? "Room": object_type_name_mpi(obj);
+    if (obj == UNKNOWN || obj == AMBIGUOUS || obj == NOTHING)
+        return (strcasecmp(argv[1], "Bad") == 0) ? "1" : "0";
 
-    return (strcasecmp(argv[1], type) ? "0" : "1");
+    return (strcasecmp(argv[1], OBJECT_TYPE_INFO(obj)->titlecase) ? "0" : "1");
 }
 
 /**

--- a/src/move.c
+++ b/src/move.c
@@ -57,9 +57,9 @@ maybe_dropto(int descr, dbref loc, dbref dropto)
 
     /* check for players */
     DOLIST(thing, CONTENTS(loc)) {
-        if (Typeof(thing) == TYPE_PLAYER ||
-            (tp_allow_zombies && Typeof(thing) == TYPE_THING &&
-            FLAGS(thing) & ZOMBIE))
+        if (OBJECT_TYPE(thing) == TYPE_PLAYER ||
+            (tp_allow_zombies && OBJECT_TYPE(thing) == TYPE_THING &&
+            FLAG_CHECK(thing, 'Z')))
             return;
     }
 
@@ -96,7 +96,7 @@ maybe_dropto(int descr, dbref loc, dbref dropto)
  *
  *   Finally, the "X has arrived" notification is sent to the target room.
  *   To make propqueues run after autolook, this message is disconnected from
- *   the arrive propqueue processing which is done further down. 
+ *   the arrive propqueue processing which is done further down.
  *   This notification follows the same rules as the "has left"  message
  *
  * - If 'player' is not a thing, or if 'player' is a ZOMBIE or VEHICLE, then
@@ -134,7 +134,7 @@ enter_room(int descr, dbref player, dbref loc, dbref exit)
     old = LOCATION(player);
 
     if (parent_loop_check(player, loc)) {
-        switch (Typeof(player)) {
+        switch (OBJECT_TYPE(player)) {
             case TYPE_PLAYER:
                 loc = PLAYER_HOME(player);
                 break;
@@ -186,37 +186,37 @@ enter_room(int descr, dbref player, dbref loc, dbref exit)
             /* notify others unless DARK */
             if (!tp_quiet_moves &&
                 !Dark(old) && !Dark(player) &&
-                ((Typeof(player) != TYPE_THING) ||
-                 ((Typeof(player) == TYPE_THING) &&
-                  (FLAGS(player) & (ZOMBIE | VEHICLE))))
-                && (Typeof(exit) != TYPE_EXIT || !Dark(exit))) {
+                ((OBJECT_TYPE(player) != TYPE_THING) ||
+                 ((OBJECT_TYPE(player) == TYPE_THING) &&
+                  (FLAG_CHECK(player, 'Z') || FLAG_CHECK(player, 'V'))))
+                && (OBJECT_TYPE(exit) != TYPE_EXIT || !Dark(exit))) {
                 snprintf(buf, sizeof(buf), "%s has left.", NAME(player));
                 notify_except(CONTENTS(old), player, buf, player);
             }
         }
 
         /* if old location has STICKY dropto, send stuff through it */
-        if (old != NOTHING && Typeof(old) == TYPE_ROOM
+        if (old != NOTHING && OBJECT_TYPE(old) == TYPE_ROOM
             && (dropto = DBFETCH(old)->sp.room.dropto) != NOTHING
-            && (FLAGS(old) & STICKY)) {
+            && FLAG_CHECK(old, 'S')) {
             maybe_dropto(descr, old, dropto);
         }
 
         /* tell other folks in new location if not DARK */
         if (!tp_quiet_moves &&
             !Dark(loc) && !Dark(player) &&
-            ((Typeof(player) != TYPE_THING) ||
-             ((Typeof(player) == TYPE_THING)
-              && (FLAGS(player) & (ZOMBIE | VEHICLE))))
-            && (Typeof(exit) != TYPE_EXIT || !Dark(exit))) {
+            ((OBJECT_TYPE(player) != TYPE_THING) ||
+             ((OBJECT_TYPE(player) == TYPE_THING)
+              && (FLAG_CHECK(player, 'Z') || FLAG_CHECK(player, 'V'))))
+            && (OBJECT_TYPE(exit) != TYPE_EXIT || !Dark(exit))) {
             snprintf(buf, sizeof(buf), "%s has arrived.", NAME(player));
             notify_except(CONTENTS(loc), player, buf, player);
         }
     }
 
     /* autolook */
-    if ((Typeof(player) != TYPE_THING) ||
-        ((Typeof(player) == TYPE_THING) && (FLAGS(player) & (ZOMBIE | VEHICLE)))) {
+    if ((OBJECT_TYPE(player) != TYPE_THING) ||
+        ((OBJECT_TYPE(player) == TYPE_THING) && (FLAG_CHECK(player, 'Z') || FLAG_CHECK(player, 'V')))) {
         if (donelook < 8) {
             donelook++;
 
@@ -277,7 +277,7 @@ moveto(dbref what, dbref where)
     dbref loc;
 
     /* do NOT move garbage */
-    if (what != NOTHING && Typeof(what) == TYPE_GARBAGE) {
+    if (what != NOTHING && OBJECT_TYPE(what) == TYPE_GARBAGE) {
         return;
     }
 
@@ -293,7 +293,7 @@ moveto(dbref what, dbref where)
             return; /* NOTHING doesn't have contents */
 
         case HOME:
-            switch (Typeof(what)) {
+            switch (OBJECT_TYPE(what)) {
                 case TYPE_PLAYER:
                     where = PLAYER_HOME(what);
                     break;
@@ -323,7 +323,7 @@ moveto(dbref what, dbref where)
 
         default:
             if (parent_loop_check(what, where)) {
-                switch (Typeof(what)) {
+                switch (OBJECT_TYPE(what)) {
                     case TYPE_PLAYER:
                         where = PLAYER_HOME(what);
                         break;
@@ -384,13 +384,13 @@ send_contents(int descr, dbref loc, dbref dest)
     while (first != NOTHING) {
         rest = NEXTOBJ(first);
 
-        if ((Typeof(first) != TYPE_THING)
-            && (Typeof(first) != TYPE_PROGRAM)) {
+        if ((OBJECT_TYPE(first) != TYPE_THING)
+            && (OBJECT_TYPE(first) != TYPE_PROGRAM)) {
             moveto(first, loc);
         } else {
-            where = FLAGS(first) & STICKY ? HOME : dest;
+            where = FLAG_CHECK(first, 'S') ? HOME : dest;
 
-            if (tp_secure_thing_movement && (Typeof(first) == TYPE_THING)) {
+            if (tp_secure_thing_movement && (OBJECT_TYPE(first) == TYPE_THING)) {
                 enter_room(descr, first,
                            parent_loop_check(first, where) ? loc : where,
                            LOCATION(first));
@@ -419,7 +419,7 @@ send_contents(int descr, dbref loc, dbref dest)
 void
 send_home(int descr, dbref thing, int puppethome)
 {
-    switch (Typeof(thing)) {
+    switch (OBJECT_TYPE(thing)) {
         case TYPE_PLAYER:
             /*
              * Send his possessions home first!
@@ -435,7 +435,7 @@ send_home(int descr, dbref thing, int puppethome)
                 send_contents(descr, thing, HOME);
 
             if (tp_secure_thing_movement
-                || (FLAGS(thing) & (ZOMBIE | LISTENER))) {
+                || (FLAG_CHECK(thing, 'Z') || (FLAGS(thing) & LISTENER))) {
                 enter_room(descr, thing, PLAYER_HOME(thing), LOCATION(thing));
                 break;
             }
@@ -500,7 +500,7 @@ trigger(int descr, dbref player, dbref exit, int pflag)
         if (dest == HOME) {
             dest = PLAYER_HOME(player);
 
-            if (Typeof(dest) == TYPE_THING) {
+            if (OBJECT_TYPE(dest) == TYPE_THING) {
                 notify(player, "That would be an undefined operation.");
                 continue;
             }
@@ -510,7 +510,7 @@ trigger(int descr, dbref player, dbref exit, int pflag)
             succ = 1; /* Exits that go nowhere do nothing, no error */
         } else {
             /* What happens depends on the type of the target object */
-            switch (Typeof(dest)) {
+            switch (OBJECT_TYPE(dest)) {
                 case TYPE_ROOM:
                     /* Rooms are straight forward */
                     if (pflag) {
@@ -520,20 +520,20 @@ trigger(int descr, dbref player, dbref exit, int pflag)
                         }
 
                         if (!Wizard(OWNER(player))
-                            && Typeof(player) == TYPE_THING
-                            && (FLAGS(dest) & ZOMBIE)) {
+                            && OBJECT_TYPE(player) == TYPE_THING
+                            && FLAG_CHECK(dest, 'Z')) {
                             notify(player, "You can't go that way.");
                             break;
                         }
 
-                        if ((FLAGS(player) & VEHICLE)
-                            && ((FLAGS(dest) | FLAGS(exit)) & VEHICLE)) {
+                        if (FLAG_CHECK(player, 'V')
+                            && (FLAG_CHECK(dest, 'V') || FLAG_CHECK(exit, 'V'))) {
                             notify(player, "You can't go that way.");
                             break;
                         }
 
                         if (ISGUEST(player)
-                            && ((FLAGS(dest) | FLAGS(exit)) & GUEST)) {
+                            && (ISGUEST(dest) || ISGUEST(exit))) {
                             notify(player, "You can't go that way.");
                             break;
                         }
@@ -559,7 +559,7 @@ trigger(int descr, dbref player, dbref exit, int pflag)
                      * Things have different behaviors.  If the thing is a
                      * vehicle, then we will enter the vehicle.
                      */
-                    if (dest == LOCATION(exit) && (FLAGS(dest) & VEHICLE)) {
+                    if (dest == LOCATION(exit) && FLAG_CHECK(dest, 'V')) {
                         if (pflag) {
                             if (parent_loop_check(player, dest)) {
                                 notify(player, "That would cause a paradox.");
@@ -587,7 +587,7 @@ trigger(int descr, dbref player, dbref exit, int pflag)
                          * Otherwise it brings the object to the exit's
                          * source.
                          */
-                        if (Typeof(LOCATION(exit)) == TYPE_THING) {
+                        if (OBJECT_TYPE(LOCATION(exit)) == TYPE_THING) {
                             if (parent_loop_check(dest,
                                                   LOCATION(LOCATION(exit)))) {
                                 notify(player, "That would cause a paradox.");
@@ -601,7 +601,7 @@ trigger(int descr, dbref player, dbref exit, int pflag)
                                 moveto(dest, LOCATION(LOCATION(exit)));
                             }
 
-                            if (!(FLAGS(exit) & STICKY)) {
+                            if (!FLAG_CHECK(exit, 'S')) {
                                 /* send home source object */
                                 sobjact = 1;
                             }
@@ -649,7 +649,7 @@ trigger(int descr, dbref player, dbref exit, int pflag)
 
                         succ = 1;
 
-                        if (FLAGS(dest) & JUMP_OK) {
+                        if (FLAG_CHECK(dest, 'J')) {
                             if (GETDROP(exit)) {
                                 exec_or_notify_prop(descr, player, exit,
                                                     MESGPROP_DROP, "(@Drop)");
@@ -673,11 +673,11 @@ trigger(int descr, dbref player, dbref exit, int pflag)
 
                 case TYPE_PROGRAM:
                     /*
-                     * Execute a MUF program, assuming the player is not
-                     * a GUEST and the program isn't set GUEST.
+                     * Execute a MUF program, if the player passes the
+                     * GUEST restrictions on the program and exit.
                      */
                     if (ISGUEST(player)
-                        && ((FLAGS(dest) | FLAGS(exit)) & GUEST)) {
+                        && (ISGUEST(dest) || ISGUEST(exit))) {
                         notify(player, "You can't go that way.");
                         break;
                     }
@@ -776,19 +776,19 @@ do_leave(int descr, dbref player)
 
     loc = LOCATION(player);
 
-    if (Typeof(loc) == TYPE_ROOM) {
+    if (OBJECT_TYPE(loc) == TYPE_ROOM) {
         notify(player, "You can't go that way.");
         return;
     }
 
-    if (!(FLAGS(loc) & VEHICLE)) {
+    if (!FLAG_CHECK(loc, 'V')) {
         notify(player, "You can only exit vehicles.");
         return;
     }
 
     dest = LOCATION(loc);
 
-    if (Typeof(dest) != TYPE_ROOM && Typeof(dest) != TYPE_THING) {
+    if (OBJECT_TYPE(dest) != TYPE_ROOM && OBJECT_TYPE(dest) != TYPE_THING) {
         notify(player, "You can't exit a vehicle inside of a player.");
         return;
     }
@@ -869,8 +869,8 @@ do_get(int descr, dbref player, const char *what, const char *obj)
      * I believe this means zombies can't take things from other
      * people's containers.
      */
-    if (Typeof(player) != TYPE_PLAYER) {
-        if (LOCATION(thing) != NOTHING && Typeof(LOCATION(thing)) != TYPE_ROOM) {
+    if (OBJECT_TYPE(player) != TYPE_PLAYER) {
+        if (LOCATION(thing) != NOTHING && OBJECT_TYPE(LOCATION(thing)) != TYPE_ROOM) {
             if (OWNER(player) != OWNER(thing)) {
                 notify(player, "Zombies aren't allowed to be thieves!");
                 return;
@@ -883,7 +883,7 @@ do_get(int descr, dbref player, const char *what, const char *obj)
         return;
     }
 
-    if (Typeof(cont) == TYPE_PLAYER) {
+    if (OBJECT_TYPE(cont) == TYPE_PLAYER) {
         notify(player, "You can't steal stuff from players.");
         return;
     }
@@ -893,7 +893,7 @@ do_get(int descr, dbref player, const char *what, const char *obj)
         return;
     }
 
-    switch (Typeof(thing)) {
+    switch (OBJECT_TYPE(thing)) {
         case TYPE_THING:
             ts_useobject(thing);
             /* fall through */
@@ -910,7 +910,7 @@ do_get(int descr, dbref player, const char *what, const char *obj)
                 }
 
                 if (cando) {
-                    if (tp_secure_thing_movement && (Typeof(thing) == TYPE_THING)) {
+                    if (tp_secure_thing_movement && (OBJECT_TYPE(thing) == TYPE_THING)) {
                         enter_room(descr, thing, player, LOCATION(thing));
                     } else {
                         moveto(thing, player);
@@ -962,7 +962,7 @@ do_drop(int descr, dbref player, const char *name, const char *obj)
 
     loc = LOCATION(player);
 
-    init_match(descr, player, name, NOTYPE, &md);
+    init_match(descr, player, name, TYPE_ANY, &md);
     match_possession(&md);
 
     if ((thing = noisy_match_result(&md)) == NOTHING)
@@ -971,7 +971,7 @@ do_drop(int descr, dbref player, const char *name, const char *obj)
     cont = loc;
 
     if (obj && *obj) {
-        init_match(descr, player, obj, NOTYPE, &md);
+        init_match(descr, player, obj, TYPE_ANY, &md);
         match_possession(&md);
         match_neighbor(&md);
 
@@ -983,7 +983,7 @@ do_drop(int descr, dbref player, const char *name, const char *obj)
         }
     }
 
-    switch (Typeof(thing)) {
+    switch (OBJECT_TYPE(thing)) {
         case TYPE_THING:
             ts_useobject(thing);
             /* fall through */
@@ -994,13 +994,13 @@ do_drop(int descr, dbref player, const char *name, const char *obj)
                 break;
             }
 
-            if (Typeof(cont) != TYPE_ROOM && Typeof(cont) != TYPE_PLAYER &&
-                Typeof(cont) != TYPE_THING) {
+            if (OBJECT_TYPE(cont) != TYPE_ROOM && OBJECT_TYPE(cont) != TYPE_PLAYER &&
+                OBJECT_TYPE(cont) != TYPE_THING) {
                 notify(player, "You can't put anything in that.");
                 break;
             }
 
-            if (Typeof(cont) != TYPE_ROOM &&
+            if (OBJECT_TYPE(cont) != TYPE_ROOM &&
                 !test_lock_false_default(descr, player, cont, MESGPROP_CONLOCK)) {
                 notify(player, "You don't have permission to put something in that.");
                 break;
@@ -1011,15 +1011,15 @@ do_drop(int descr, dbref player, const char *name, const char *obj)
                 break;
             }
 
-            if (Typeof(cont) == TYPE_ROOM && (FLAGS(thing) & STICKY) &&
-                Typeof(thing) == TYPE_THING) {
+            if (OBJECT_TYPE(cont) == TYPE_ROOM && FLAG_CHECK(thing, 'S') &&
+                OBJECT_TYPE(thing) == TYPE_THING) {
                 send_home(descr, thing, 0);
             } else {
-                int immediate_dropto = (Typeof(cont) == TYPE_ROOM &&
+                int immediate_dropto = (OBJECT_TYPE(cont) == TYPE_ROOM &&
                                         DBFETCH(cont)->sp.room.dropto != NOTHING
-                                        && !(FLAGS(cont) & STICKY));
+                                        && !FLAG_CHECK(cont, 'S'));
 
-                if (tp_secure_thing_movement && (Typeof(thing) == TYPE_THING)) {
+                if (tp_secure_thing_movement && (OBJECT_TYPE(thing) == TYPE_THING)) {
                     enter_room(descr, thing,
                                immediate_dropto ? DBFETCH(cont)->sp.room.dropto : cont, player);
                 } else {
@@ -1027,10 +1027,10 @@ do_drop(int descr, dbref player, const char *name, const char *obj)
                 }
             }
 
-            if (Typeof(cont) == TYPE_THING) {
+            if (OBJECT_TYPE(cont) == TYPE_THING) {
                 notify(player, "Put away.");
                 return;
-            } else if (Typeof(cont) == TYPE_PLAYER) {
+            } else if (OBJECT_TYPE(cont) == TYPE_PLAYER) {
                 notifyf(cont, "%s hands you %s", NAME(player), NAME(thing));
                 notifyf(player, "You hand %s to %s", NAME(thing), NAME(cont));
                 return;
@@ -1099,7 +1099,7 @@ recycle(int descr, dbref player, dbref thing)
             return;
         }
 
-        if ((Typeof(thing) == TYPE_PROGRAM)
+        if ((OBJECT_TYPE(thing) == TYPE_PROGRAM)
              && (PROGRAM_INSTANCES(thing) != 0)) {
             log_status("SANITYCHECK: Trying to recycle a running program "
                        "(#%d) from FORCE!", thing);
@@ -1114,7 +1114,7 @@ recycle(int descr, dbref player, dbref thing)
 
     int cost = MAX(0, GETVALUE(thing));
 
-    switch (Typeof(thing)) {
+    switch (OBJECT_TYPE(thing)) {
         case TYPE_ROOM:
             cost = tp_room_cost;
             notify_except(CONTENTS(thing), NOTHING,
@@ -1152,7 +1152,7 @@ recycle(int descr, dbref player, dbref thing)
     }
 
     for (rest = 0; rest < db_top; rest++) {
-        switch (Typeof(rest)) {
+        switch (OBJECT_TYPE(rest)) {
             case TYPE_ROOM:
                 if (DBFETCH(rest)->sp.room.dropto == thing) {
                     DBFETCH(rest)->sp.room.dropto = NOTHING;
@@ -1231,7 +1231,7 @@ recycle(int descr, dbref player, dbref thing)
                 break;
 
             case TYPE_PLAYER:
-                if (Typeof(thing) == TYPE_PROGRAM
+                if (OBJECT_TYPE(thing) == TYPE_PROGRAM
                     && (FLAGS(rest) & INTERACTIVE)
                     && (PLAYER_CURR_PROG(rest) == thing)) {
                     if (FLAGS(rest) & READMODE) {
@@ -1287,9 +1287,9 @@ recycle(int descr, dbref player, dbref thing)
     looplimit = db_top;
 
     while ((looplimit-- > 0) && ((first = CONTENTS(thing)) != NOTHING)) {
-        if (Typeof(first) == TYPE_PLAYER ||
-            (Typeof(first) == TYPE_THING &&
-             (FLAGS(first) & (ZOMBIE | VEHICLE) || tp_secure_thing_movement))
+        if (OBJECT_TYPE(first) == TYPE_PLAYER ||
+            (OBJECT_TYPE(first) == TYPE_THING &&
+             (FLAG_CHECK(first, 'Z') || FLAG_CHECK(first, 'V') || tp_secure_thing_movement))
             ) {
             enter_room(descr, first, HOME, LOCATION(thing));
 

--- a/src/mpihelp.raw
+++ b/src/mpihelp.raw
@@ -933,6 +933,19 @@ The "Mucker" flag returns the most significant bit of the mucker level and
 the "Nucker" flag returns the least significant bit.
 ~
 ~
+FLAGS?
+{flags?:obj,pattern}
+  Determines if object d has the flag pattern given by string s. A flag
+pattern consists of at least one single-character flag with an optional
+! token in front to negate the specific check. Flag patterns also recognize 
+object types.
+
+  Does not recognize full flag names, including the virtual alias
+"truewizard"; "T" checks for an object of type thing.
+
+  Examples of flag patterns include "PB3", "L!A", and "!O".
+~
+~
 OWNER
 {owner:obj}
     Returns the owner of the given object.  The object must be in the

--- a/src/msgparse.c
+++ b/src/msgparse.c
@@ -440,7 +440,7 @@ get_list_count(dbref player, dbref obj, dbref perms, char *listname,
  * How the string is concatinated is controlled by 'mode'.  If mode is
  * 0, then the list is delimited by \r characters such as with the {list}
  * macro.
- * 
+ *
  * For mode 1, most lines are separated by a single space.  If a line ends in '.', '?',
  * or '!' then a second space is added as well to the delimiter.
  *
@@ -598,15 +598,15 @@ isneighbor(dbref d1, dbref d2)
     if (d1 == d2)
         return 1;
 
-    if (Typeof(d1) != TYPE_ROOM)
+    if (OBJECT_TYPE(d1) != TYPE_ROOM)
         if (LOCATION(d1) == d2)
             return 1;
 
-    if (Typeof(d2) != TYPE_ROOM)
+    if (OBJECT_TYPE(d2) != TYPE_ROOM)
         if (LOCATION(d2) == d1)
             return 1;
 
-    if (Typeof(d1) != TYPE_ROOM && Typeof(d2) != TYPE_ROOM)
+    if (OBJECT_TYPE(d1) != TYPE_ROOM && OBJECT_TYPE(d2) != TYPE_ROOM)
         if (LOCATION(d1) == LOCATION(d2))
             return 1;
 
@@ -697,7 +697,7 @@ mesg_dbref_raw(int descr, dbref player, dbref what, const char *buf)
         } else if (!strcasecmp(buf, "home")) {
             obj = HOME;
         } else {
-            init_match(descr, player, buf, NOTYPE, &md);
+            init_match(descr, player, buf, TYPE_ANY, &md);
             match_absolute(&md);
             match_all_exits(&md);
             match_neighbor(&md);
@@ -706,7 +706,7 @@ mesg_dbref_raw(int descr, dbref player, dbref what, const char *buf)
             obj = match_result(&md);
 
             if (obj == NOTHING) {
-                init_match_remote(descr, player, what, buf, NOTYPE, &md);
+                init_match_remote(descr, player, what, buf, TYPE_ANY, &md);
                 match_player(&md);
                 match_all_exits(&md);
                 match_neighbor(&md);
@@ -770,7 +770,7 @@ mesg_dbref(int descr, dbref player, dbref what, dbref perms, char *buf,
  * @param buf the string to match dbref
  * @param mesgtyp the mesgtyp from the MPI call containg blessed perms
  * @return matched ref, UNKNOWN, or PERMDENIED as appropriate
- */ 
+ */
 dbref
 mesg_dbref_strict(int descr, dbref player, dbref what, dbref perms, char *buf,
                   int mesgtyp)
@@ -804,7 +804,7 @@ mesg_dbref_strict(int descr, dbref player, dbref what, dbref perms, char *buf,
  * @param buf the string to match dbref
  * @param mesgtyp the mesgtyp from the MPI call containg blessed perms
  * @return matched ref, UNKNOWN, or PERMDENIED as appropriate
- */ 
+ */
 dbref
 mesg_dbref_local(int descr, dbref player, dbref what, dbref perms, char *buf,
                  int mesgtyp)
@@ -1387,14 +1387,14 @@ mesg_parse(int descr, dbref player, dbref what, dbref perms, const char *inbuf,
     }
 
     /* Sanity check player */
-    if (Typeof(player) == TYPE_GARBAGE) {
+    if (OBJECT_TYPE(player) == TYPE_GARBAGE) {
         mesg_rec_cnt--;
         outbuf[0] = '\0';
         return NULL;
     }
 
     /* Sanity check trigger */
-    if (Typeof(what) == TYPE_GARBAGE) {
+    if (OBJECT_TYPE(what) == TYPE_GARBAGE) {
         notify_nolisten(player, "MPI Error: Garbage trigger.", 1);
         mesg_rec_cnt--;
         outbuf[0] = '\0';
@@ -1442,7 +1442,7 @@ mesg_parse(int descr, dbref player, dbref what, dbref perms, const char *inbuf,
                 }
 
                 /* If 's' is a valid function name, let's process it */
-                if ( ( s <= MAX_MFUN_NAME_LEN || 
+                if ( ( s <= MAX_MFUN_NAME_LEN ||
                       ( s <= MAX_MFUN_NAME_LEN + 1 && *ptr == '&' ) ) &&
                     (wbuf[p] == MFUN_ARGSTART || wbuf[p] == MFUN_ARGEND)) {
                     int varflag;
@@ -1508,7 +1508,7 @@ mesg_parse(int descr, dbref player, dbref what, dbref perms, const char *inbuf,
                              */
                             if (argc < 0) {
                                 argc = mesg_args((wbuf + p + 1),
-                                                 ((sizeof(wbuf) - 
+                                                 ((sizeof(wbuf) -
                                                   (size_t)p) - 1),
                                                  &argv[(varflag ? 1 : 0)],
                                                  MFUN_LEADCHAR, MFUN_ARGSEP,
@@ -1516,7 +1516,7 @@ mesg_parse(int descr, dbref player, dbref what, dbref perms, const char *inbuf,
                                                  (-argc) + (varflag ? 1 : 0));
                             } else {
                                 argc = mesg_args((wbuf + p + 1),
-                                                 ((sizeof(wbuf) - 
+                                                 ((sizeof(wbuf) -
                                                   (size_t)p) - 1),
                                                  &argv[(varflag ? 1 : 0)],
                                                  MFUN_LEADCHAR, MFUN_ARGSEP,

--- a/src/mufevent.c
+++ b/src/mufevent.c
@@ -698,7 +698,7 @@ get_mufevent_pids(stk_array * nw, dbref ref)
  * STARTED which is an integer value UNIX timestamp of the start time
  * SUBTYPE which is hard coded to empty string (events never have a subtype)
  * TYPE which is hard coded to MUFEVENT (this is always a MUF event)
- * 
+ *
  * @param nw the dictionary to put informatin into
  * @param pid the PID to get information for
  * @param pinned pinned value for the "FILTERS" array in the dictionary
@@ -1190,7 +1190,7 @@ muf_event_process(void)
                 /*
                  * We do NOT want to free this program after every EVENT_WAIT.
                  */
-                proc->fr = NULL; 
+                proc->fr = NULL;
                 proc->deleted = 1;
             }
         }

--- a/src/mufman.raw
+++ b/src/mufman.raw
@@ -4164,7 +4164,22 @@ a program's READ, or if they are in the MUF editor.
 The "Truewizard" flag will check for a W flag with or without the QUELL set.
 The "Mucker" flag returns the most significant bit of the mucker level and
 the "Nucker" flag returns the least significant bit. (Use MLEVEL instead.)
-~~alsosee SET,MLEVEL
+~~alsosee SET,MLEVEL,FLAGS?
+~
+~
+FLAGS?
+FLAGS? (d s -- i )
+
+  Determines if object d has the flag pattern given by string s. A flag
+pattern consists of at least one single-character flag with an optional
+! token in front to negate the specific check. Flag patterns also recognize
+object types.
+
+  Does not recognize full flag names, including the virtual alias
+"truewizard"; "T" checks for an object of type thing.
+
+  Examples of flag patterns include "PB3", "L!A", and "!O".
+~~alsosee SET,MLEVEL,FLAG?
 ~
 ~
 MLEVEL

--- a/src/p_array.c
+++ b/src/p_array.c
@@ -71,7 +71,7 @@ static dbref ref;
  * @private
  * @var This breaks thread safety for fun.
  */
-static char buf[BUFFER_LEN];
+static char buf[BUFFER_LEN*2];
 
 /**
  * Implementation of MUF ARRAY_MAKE
@@ -1653,8 +1653,8 @@ void
 prim_array_get_propdirs(PRIM_PROTOTYPE)
 {
     stk_array *nu;
-    char propname[BUFFER_LEN];
-    char dir[BUFFER_LEN];
+    char propname[BUFFER_LEN*2];
+    char dir[BUFFER_LEN*2];
     PropPtr propadr, pptr;
     PropPtr prptr;
     int count = 0;
@@ -1918,7 +1918,7 @@ prim_array_get_proplist(PRIM_PROTOTYPE)
     stk_array *nu;
     const char *strval;
     char dir[BUFFER_LEN];
-    char propname[BUFFER_LEN];
+    char propname[BUFFER_LEN+16];
     PropPtr prptr;
     int count = 1;
     int maxcount;
@@ -2123,8 +2123,8 @@ void
 prim_array_put_propvals(PRIM_PROTOTYPE)
 {
     stk_array *arr;
-    char propname[BUFFER_LEN];
-    char dir[BUFFER_LEN];
+    char propname[BUFFER_LEN*2];
+    char dir[BUFFER_LEN*2];
     PData propdat;
 
     /* dbref strPropDir array -- */

--- a/src/p_connects.c
+++ b/src/p_connects.c
@@ -59,10 +59,10 @@ prim_awakep(PRIM_PROTOTYPE)
 
     ref = oper1->data.objref;
 
-    if (Typeof(ref) == TYPE_THING && (FLAGS(ref) & ZOMBIE))
+    if (OBJECT_TYPE(ref) == TYPE_THING && FLAG_CHECK(ref, 'Z'))
         ref = OWNER(ref);
 
-    if (Typeof(ref) != TYPE_PLAYER)
+    if (OBJECT_TYPE(ref) != TYPE_PLAYER)
         abort_interp("invalid argument.");
 
     result = PLAYER_DESCRCOUNT(ref);
@@ -168,7 +168,7 @@ prim_online_array(PRIM_PROTOTYPE)
     struct descriptor_data* d = descriptor_list;
 
     CHECKOP(0);
- 
+
     if (mlev < 3)
         abort_interp("Mucker level 3 primitive.");
 
@@ -1022,7 +1022,7 @@ prim_lastdescr(PRIM_PROTOTYPE)
     if (ref == NOTHING) {
         result = plastdescr();
     } else {
-        if (Typeof(ref) != TYPE_PLAYER)
+        if (OBJECT_TYPE(ref) != TYPE_PLAYER)
             abort_interp("invalid argument");
 
         if (PLAYER_DESCRCOUNT(ref)) {
@@ -1242,7 +1242,7 @@ prim_width(PRIM_PROTOTYPE)
     CLEAR(oper1);
 
     /* Convert short int to int */
-    result = d->detected_width; 
+    result = d->detected_width;
 
     PushInt(result);
 }
@@ -1282,7 +1282,7 @@ prim_height(PRIM_PROTOTYPE)
     CLEAR(oper1);
 
     /* Convert short int to int */
-    result = d->detected_height; 
+    result = d->detected_height;
 
     PushInt(result);
 }

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -21,6 +21,7 @@
 #include "edit.h"
 #include "fbstrings.h"
 #include "fbtime.h"
+#include "flags.h"
 #include "game.h"
 #include "inst.h"
 #include "interface.h"
@@ -75,7 +76,7 @@ prim_addpennies(PRIM_PROTOTYPE)
         abort_interp("Permission Denied (mlev < tp_addpennies_muf_mlev)");
     }
 
-    if (!valid_object(oper2) || (Typeof(oper2->data.objref) != TYPE_PLAYER && Typeof(oper2->data.objref) != TYPE_THING)) {
+    if (!valid_object(oper2) || (OBJECT_TYPE(oper2->data.objref) != TYPE_PLAYER && OBJECT_TYPE(oper2->data.objref) != TYPE_THING)) {
         abort_interp("Invalid player or thing argument.");
     }
 
@@ -85,7 +86,7 @@ prim_addpennies(PRIM_PROTOTYPE)
 
     ref = oper2->data.objref;
 
-    if (mlev < 4 && Typeof(ref) == TYPE_THING) {
+    if (mlev < 4 && OBJECT_TYPE(ref) == TYPE_THING) {
         abort_interp("Permission denied.");
     }
 
@@ -206,22 +207,22 @@ prim_moveto(PRIM_PROTOTYPE)
     victim = oper2->data.objref;
     dest = oper1->data.objref;
 
-    if (Typeof(dest) == TYPE_EXIT) {
+    if (OBJECT_TYPE(dest) == TYPE_EXIT) {
         abort_interp("Destination argument is an exit.");
     }
 
-    if (Typeof(victim) == TYPE_EXIT && (mlev < 3)) {
+    if (OBJECT_TYPE(victim) == TYPE_EXIT && (mlev < 3)) {
         abort_interp("Permission denied.");
     }
 
-    if (!(FLAGS(victim) & JUMP_OK) && !permissions(ProgUID, victim) && (mlev < 3)) {
+    if (!FLAG_CHECK(victim, 'J') && !permissions(ProgUID, victim) && (mlev < 3)) {
         abort_interp("Object can't be moved.");
     }
 
-    switch (Typeof(victim)) {
+    switch (OBJECT_TYPE(victim)) {
         case TYPE_PLAYER:
-            if (Typeof(dest) != TYPE_ROOM
-                    && !(Typeof(dest) == TYPE_THING && (FLAGS(dest) & VEHICLE))) {
+            if (OBJECT_TYPE(dest) != TYPE_ROOM
+                    && !(OBJECT_TYPE(dest) == TYPE_THING && FLAG_CHECK(dest, 'V'))) {
                 abort_interp("Bad destination.");
             }
             /* fall through */
@@ -232,35 +233,35 @@ prim_moveto(PRIM_PROTOTYPE)
             }
 
             if ((mlev < 3)) {
-                if (!(FLAGS(LOCATION(victim)) & JUMP_OK) && !permissions(ProgUID, LOCATION(victim))) {
+                if (!FLAG_CHECK(LOCATION(victim), 'J') && !permissions(ProgUID, LOCATION(victim))) {
                     abort_interp("Source not JUMP_OK.");
                 }
 
-                if (!is_home(oper1) && !(FLAGS(dest) & JUMP_OK) && !permissions(ProgUID, dest)) {
+                if (!is_home(oper1) && !FLAG_CHECK(dest, 'J') && !permissions(ProgUID, dest)) {
                     abort_interp("Destination not JUMP_OK.");
                 }
 
-                if (Typeof(dest) == TYPE_THING && LOCATION(victim) != LOCATION(dest)) {
+                if (OBJECT_TYPE(dest) == TYPE_THING && LOCATION(victim) != LOCATION(dest)) {
                     abort_interp("Not in same location as vehicle.");
                 }
 
-                if (ISGUEST(victim) && (FLAGS(dest) & GUEST) && Typeof(dest) == TYPE_ROOM) {
+                if (ISGUEST(victim) && ISGUEST(dest) && OBJECT_TYPE(dest) == TYPE_ROOM) {
                     abort_interp("Destination doesn't accept guests.");
                 }
             }
 
-            if (Typeof(victim) == TYPE_PLAYER) {
+            if (OBJECT_TYPE(victim) == TYPE_PLAYER) {
                 enter_room(fr->descr, victim, dest, program);
                 break;
             }
 
-            if (mlev < 3 && (FLAGS(victim) & VEHICLE) &&
-                    (FLAGS(dest) & VEHICLE) && Typeof(dest) != TYPE_THING) {
+            if (mlev < 3 && FLAG_CHECK(victim, 'V') &&
+                    FLAG_CHECK(dest, 'V') && OBJECT_TYPE(dest) != TYPE_THING) {
                 abort_interp("Destination doesn't accept vehicles.");
             }
 
-            if (mlev < 3 && (FLAGS(victim) & ZOMBIE) &&
-                    (FLAGS(dest) & ZOMBIE) && Typeof(dest) != TYPE_THING) {
+            if (mlev < 3 && FLAG_CHECK(victim, 'Z') &&
+                    FLAG_CHECK(dest, 'Z') && OBJECT_TYPE(dest) != TYPE_THING) {
                 abort_interp("Destination doesn't accept zombies.");
             }
 
@@ -270,7 +271,7 @@ prim_moveto(PRIM_PROTOTYPE)
         case TYPE_PROGRAM: {
             dbref matchroom = NOTHING;
 
-            if (Typeof(dest) != TYPE_ROOM && Typeof(dest) != TYPE_PLAYER && Typeof(dest) != TYPE_THING) {
+            if (OBJECT_TYPE(dest) != TYPE_ROOM && OBJECT_TYPE(dest) != TYPE_PLAYER && OBJECT_TYPE(dest) != TYPE_THING) {
                 abort_interp("Bad destination.");
             }
 
@@ -283,15 +284,15 @@ prim_moveto(PRIM_PROTOTYPE)
                     matchroom = LOCATION(victim);
                 }
 
-                if (matchroom != NOTHING && !(FLAGS(matchroom) & JUMP_OK)
+                if (matchroom != NOTHING && !FLAG_CHECK(matchroom, 'J')
                             && !permissions(ProgUID, victim)) {
                     abort_interp("Permission denied.");
                 }
             }
 
-            if (Typeof(victim) == TYPE_THING
+            if (OBJECT_TYPE(victim) == TYPE_THING
                     && (tp_secure_thing_movement
-                    || (FLAGS(victim) & ZOMBIE))) {
+                    || FLAG_CHECK(victim, 'Z'))) {
                 enter_room(fr->descr, victim, dest, program);
             } else {
                 moveto(victim, dest);
@@ -304,8 +305,8 @@ prim_moveto(PRIM_PROTOTYPE)
                 abort_interp("Permission denied.");
             }
 
-            if ((Typeof(dest) != TYPE_ROOM && Typeof(dest) != TYPE_THING
-                    && Typeof(dest) != TYPE_PLAYER) || dest == HOME) {
+            if ((OBJECT_TYPE(dest) != TYPE_ROOM && OBJECT_TYPE(dest) != TYPE_THING
+                    && OBJECT_TYPE(dest) != TYPE_PLAYER) || dest == HOME) {
                 abort_interp("Bad destination object.");
             }
 
@@ -315,7 +316,7 @@ prim_moveto(PRIM_PROTOTYPE)
             break;
 
         case TYPE_ROOM:
-            if (!tp_secure_thing_movement && Typeof(dest) != TYPE_ROOM) {
+            if (!tp_secure_thing_movement && OBJECT_TYPE(dest) != TYPE_ROOM) {
                 abort_interp("Bad destination.");
             }
 
@@ -380,7 +381,7 @@ prim_pennies(PRIM_PROTOTYPE)
         abort_interp("Permission Denied (mlev < tp_pennies_muf_mlev)");
     }
 
-    if (!valid_object(oper1) || (Typeof(oper1->data.objref) != TYPE_PLAYER && Typeof(oper1->data.objref) != TYPE_THING)) {
+    if (!valid_object(oper1) || (OBJECT_TYPE(oper1->data.objref) != TYPE_PLAYER && OBJECT_TYPE(oper1->data.objref) != TYPE_THING)) {
         abort_interp("Invalid player or thing argument.");
     }
 
@@ -454,7 +455,7 @@ prim_contents(PRIM_PROTOTYPE)
     CHECKREMOTE(oper1->data.objref);
     ref = CONTENTS(oper1->data.objref);
 
-    while (mlev < 2 && ref != NOTHING && (FLAGS(ref) & DARK) && !controls(ProgUID, ref)) {
+    while (mlev < 2 && ref != NOTHING && Dark(ref) && !controls(ProgUID, ref)) {
         ref = NEXTOBJ(ref);
     }
 
@@ -486,7 +487,7 @@ prim_exits(PRIM_PROTOTYPE)
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1) || Typeof(oper1->data.objref) == TYPE_PROGRAM || Typeof(oper1->data.objref) == TYPE_EXIT) {
+    if (!valid_object(oper1) || OBJECT_TYPE(oper1->data.objref) == TYPE_PROGRAM || OBJECT_TYPE(oper1->data.objref) == TYPE_EXIT) {
         abort_interp("Invalid player, thing, or room object.");
     }
 
@@ -534,8 +535,8 @@ prim_next(PRIM_PROTOTYPE)
 
     ref = NEXTOBJ(oper1->data.objref);
 
-    while (mlev < 2 && ref != NOTHING && Typeof(ref) != TYPE_EXIT
-            && ((FLAGS(ref) & DARK) || Typeof(ref) == TYPE_ROOM)
+    while (mlev < 2 && ref != NOTHING && OBJECT_TYPE(ref) != TYPE_EXIT
+            && (Dark(ref) || OBJECT_TYPE(ref) == TYPE_ROOM)
             && !controls(ProgUID, ref)) {
         ref = NEXTOBJ(ref);
     }
@@ -581,7 +582,7 @@ prim_nextowned(PRIM_PROTOTYPE)
 
     ownr = OWNER(ref);
 
-    if (Typeof(ref) == TYPE_PLAYER) {
+    if (OBJECT_TYPE(ref) == TYPE_PLAYER) {
         ref = 0;
     } else {
         ref++;
@@ -628,7 +629,7 @@ prim_name(PRIM_PROTOTYPE)
 
     ref = oper1->data.objref;
 
-    if (Typeof(ref) == TYPE_GARBAGE) {
+    if (OBJECT_TYPE(ref) == TYPE_GARBAGE) {
         strcpyn(buf, sizeof(buf), "<garbage>");
     } else {
         CHECKREMOTE(ref);
@@ -690,7 +691,7 @@ prim_setname(PRIM_PROTOTYPE)
 
     const char *b = DoNullInd(oper1->data.string);
 
-    if (Typeof(ref) == TYPE_PLAYER) {
+    if (OBJECT_TYPE(ref) == TYPE_PLAYER) {
         strcpyn(buf, sizeof(buf), b);
         b = buf;
 
@@ -722,7 +723,7 @@ prim_setname(PRIM_PROTOTYPE)
         change_player_name(ref, b);
         add_player(ref);
     } else {
-        if (!ok_object_name(b, Typeof(ref))) {
+        if (!ok_object_name(b, OBJECT_TYPE(ref))) {
             abort_interp("Invalid name.");
         }
 
@@ -811,7 +812,7 @@ prim_match(PRIM_PROTOTYPE)
 
     strip_ansi(buf2, DoNullInd(oper1->data.string));
 
-    init_match(fr->descr, player, buf2, NOTYPE, &md);
+    init_match(fr->descr, player, buf2, TYPE_ANY, &md);
 
     if (buf2[0] == REGISTERED_TOKEN) {
         match_registered(&md);
@@ -871,7 +872,7 @@ prim_rmatch(PRIM_PROTOTYPE)
         abort_interp("Invalid argument (2)");
     }
 
-    if (!valid_object(oper2) || Typeof(oper2->data.objref) == TYPE_PROGRAM || Typeof(oper2->data.objref) == TYPE_EXIT) {
+    if (!valid_object(oper2) || OBJECT_TYPE(oper2->data.objref) == TYPE_PROGRAM || OBJECT_TYPE(oper2->data.objref) == TYPE_EXIT) {
         abort_interp("Invalid argument (1)");
     }
 
@@ -939,7 +940,7 @@ prim_copyobj(PRIM_PROTOTYPE)
     }
 
     ref = oper1->data.objref;
-    if (Typeof(ref) != TYPE_THING) {
+    if (OBJECT_TYPE(ref) != TYPE_THING) {
         abort_interp("Invalid object type.");
     }
 
@@ -1060,9 +1061,8 @@ prim_set(PRIM_PROTOTYPE)
 /**
  * Implementation of MUF MLEVEL
  *
- * Consumes a dbref, and returns its raw MUCKER level.  Objects with the
- * WIZARD flag and a MUCKER level are returned as 4.  Requires remote-read
- * privileges when applicable.
+ * Consumes a dbref, and returns its raw MUCKER level, without considering
+ * the WIZARD flag.  Requires remote-read privileges when applicable.
  *
  * If the given dbref is NOTHING, returns the effective MUCKER level of
  * the running program.
@@ -1095,7 +1095,7 @@ prim_mlevel(PRIM_PROTOTYPE)
 
         CHECKREMOTE(ref);
 
-        result = MLevRaw(ref);
+        result = OBJECT_MLEVEL(ref);
     }
 
     CLEAR(oper1);
@@ -1124,6 +1124,7 @@ prim_flagp(PRIM_PROTOTYPE)
 {
     int result;
     dbref ref;
+    char buf[BUFFER_LEN];
 
     CHECKOP(2);
     oper1 = POP();
@@ -1140,7 +1141,59 @@ prim_flagp(PRIM_PROTOTYPE)
     ref = oper2->data.objref;
     CHECKREMOTE(ref);
 
-    result = has_flag(ref, DoNullInd(oper1->data.string));
+    char *pbuf = buf;
+    strcpyn(buf, sizeof(buf), DoNullInd(oper1->data.string));
+    toupper_string(&pbuf);
+
+    result = flag_eval(ref, buf);
+
+    CLEAR(oper1);
+    CLEAR(oper2);
+    PushInt(result);
+}
+
+/**
+ * Implementation of MUF FLAGS?
+ *
+ * Consumes a dbref and a flag pattern string ("C!A"), and returns a boolean
+ * that represents if the object's flags are set accordingly.  Requires
+ * remote-read priviliges when applicable.
+ *
+ * @param player the player running the MUF program
+ * @param program the program being run
+ * @param mlev the effective MUCKER level
+ * @param pc the program counter pointer
+ * @param arg the argument stack
+ * @param top the top-most item of the stack
+ * @param fr the program frame
+ */
+void
+prim_flagsp(PRIM_PROTOTYPE)
+{
+    int result;
+    dbref ref;
+    char buf[BUFFER_LEN];
+
+    CHECKOP(2);
+    oper1 = POP();
+    oper2 = POP();
+
+    if (oper1->type != PROG_STRING) {
+        abort_interp("Invalid argument type (2)");
+    }
+
+    if (!valid_object(oper2)) {
+        abort_interp("Invalid object.");
+    }
+
+    ref = oper2->data.objref;
+    CHECKREMOTE(ref);
+
+    char *pbuf = buf;
+    strcpyn(buf, sizeof(buf), DoNullInd(oper1->data.string));
+    toupper_string(&pbuf);
+
+    result = flag_eval_pattern(ref, buf);
 
     CLEAR(oper1);
     CLEAR(oper2);
@@ -1182,7 +1235,7 @@ prim_playerp(PRIM_PROTOTYPE)
         ref = oper1->data.objref;
         CHECKREMOTE(ref);
 
-        result = (Typeof(ref) == TYPE_PLAYER);
+        result = (OBJECT_TYPE(ref) == TYPE_PLAYER);
     }
 
     CLEAR(oper1);
@@ -1224,7 +1277,7 @@ prim_thingp(PRIM_PROTOTYPE)
         ref = oper1->data.objref;
         CHECKREMOTE(ref);
 
-        result = (Typeof(ref) == TYPE_THING);
+        result = (OBJECT_TYPE(ref) == TYPE_THING);
     }
     CLEAR(oper1);
     PushInt(result);
@@ -1268,7 +1321,7 @@ prim_roomp(PRIM_PROTOTYPE)
         ref = oper1->data.objref;
         CHECKREMOTE(ref);
 
-        result = (Typeof(ref) == TYPE_ROOM);
+        result = (OBJECT_TYPE(ref) == TYPE_ROOM);
     }
 
     CLEAR(oper1);
@@ -1310,7 +1363,7 @@ prim_programp(PRIM_PROTOTYPE)
         ref = oper1->data.objref;
         CHECKREMOTE(ref);
 
-        result = (Typeof(ref) == TYPE_PROGRAM);
+        result = (OBJECT_TYPE(ref) == TYPE_PROGRAM);
     }
 
     CLEAR(oper1);
@@ -1352,7 +1405,7 @@ prim_exitp(PRIM_PROTOTYPE)
         ref = oper1->data.objref;
         CHECKREMOTE(ref);
 
-        result = (Typeof(ref) == TYPE_EXIT);
+        result = (OBJECT_TYPE(ref) == TYPE_EXIT);
     }
 
     CLEAR(oper1);
@@ -1531,7 +1584,7 @@ prim_getlink(PRIM_PROTOTYPE)
     /**
      * @TODO Combine with other link resolution logic as possible.
      */
-    switch (Typeof(oper1->data.objref)) {
+    switch (OBJECT_TYPE(oper1->data.objref)) {
         case TYPE_EXIT:
             ref = (DBFETCH(oper1->data.objref)->sp.exit.ndest) ?
                     (DBFETCH(oper1->data.objref)->sp.exit.dest)[0] : NOTHING;
@@ -1595,7 +1648,7 @@ prim_getlinks(PRIM_PROTOTYPE)
 
     my_obj = oper1->data.objref;
 
-    switch (Typeof(my_obj)) {
+    switch (OBJECT_TYPE(my_obj)) {
         case TYPE_EXIT:
             count = DBFETCH(my_obj)->sp.exit.ndest;
 
@@ -1699,17 +1752,17 @@ prog_can_link_to(int mlev, dbref who, object_flag_type what_type, dbref where)
     }
 
     /* Players can only be linked to rooms */
-    if (what_type == TYPE_PLAYER && Typeof(where) != TYPE_ROOM) {
+    if (what_type == TYPE_PLAYER && OBJECT_TYPE(where) != TYPE_ROOM) {
         return 0;
     }
 
     /* Rooms can only be linked to things or other rooms */
-    if (what_type == TYPE_ROOM && Typeof(where) != TYPE_THING && Typeof(where) != TYPE_ROOM) {
+    if (what_type == TYPE_ROOM && OBJECT_TYPE(where) != TYPE_THING && OBJECT_TYPE(where) != TYPE_ROOM) {
         return 0;
     }
 
     /* Things cannot be linked to exits or programs */
-    if (what_type == TYPE_THING && (Typeof(where) == TYPE_EXIT || Typeof(where) == TYPE_PROGRAM)) {
+    if (what_type == TYPE_THING && (OBJECT_TYPE(where) == TYPE_EXIT || OBJECT_TYPE(where) == TYPE_PROGRAM)) {
         return 0;
     }
 
@@ -1768,7 +1821,7 @@ prim_setlink(PRIM_PROTOTYPE)
 
     ref = oper2->data.objref;
 
-    if (Typeof(ref) == TYPE_PROGRAM) {
+    if (OBJECT_TYPE(ref) == TYPE_PROGRAM) {
         abort_interp("Program links cannot be modified. (1)");
     }
 
@@ -1777,23 +1830,23 @@ prim_setlink(PRIM_PROTOTYPE)
             abort_interp("Permission denied.");
         }
 
-        if (Typeof(ref) != TYPE_EXIT && Typeof(ref) != TYPE_ROOM) {
+        if (OBJECT_TYPE(ref) != TYPE_EXIT && OBJECT_TYPE(ref) != TYPE_ROOM) {
             abort_interp("Invalid object. (1)");
         }
 
-        if (Typeof(ref) == TYPE_EXIT) {
+        if (OBJECT_TYPE(ref) == TYPE_EXIT) {
             DBSTORE(ref, sp.exit.ndest, 0);
             free(DBFETCH(ref)->sp.exit.dest);
             DBSTORE(ref, sp.exit.dest, NULL);
 
-            if (MLevRaw(ref)) {
+            if (OBJECT_MLEVEL(ref)) {
                 SetMLevel(ref, 0);
             }
         } else {
             DBSTORE(ref, sp.room.dropto, NOTHING);
         }
     } else {
-        if (!prog_can_link_to(mlev, ProgUID, Typeof(ref), oper1->data.objref)) {
+        if (!prog_can_link_to(mlev, ProgUID, OBJECT_TYPE(ref), oper1->data.objref)) {
             abort_interp("Can't link source to destination.");
         }
 
@@ -1801,7 +1854,7 @@ prim_setlink(PRIM_PROTOTYPE)
             abort_interp("Permission denied.");
         }
 
-        switch (Typeof(ref)) {
+        switch (OBJECT_TYPE(ref)) {
             case TYPE_EXIT:
                 if (DBFETCH(ref)->sp.exit.ndest != 0 && (DBFETCH(ref)->sp.exit.dest)[0] != NIL) {
                     abort_interp("Exit is already linked.");
@@ -1883,7 +1936,7 @@ prim_setown(PRIM_PROTOTYPE)
     oper1 = POP();              /* dbref: new owner */
     oper2 = POP();              /* dbref: what */
 
-    if (!valid_object(oper2) || Typeof(oper2->data.objref) == TYPE_PLAYER) {
+    if (!valid_object(oper2) || OBJECT_TYPE(oper2->data.objref) == TYPE_PLAYER) {
         abort_interp("Invalid argument (1)");
     }
 
@@ -1898,15 +1951,15 @@ prim_setown(PRIM_PROTOTYPE)
             abort_interp("Permission denied. (2)");
         }
 
-        if (!(FLAGS(ref) & CHOWN_OK) || !test_lock(fr->descr, player, ref, MESGPROP_CHLOCK)) {
+        if (!FLAG_CHECK(ref, 'C') || !test_lock(fr->descr, player, ref, MESGPROP_CHLOCK)) {
             abort_interp("Permission denied. (1)");
         }
 
-        if (Typeof(ref) == TYPE_ROOM && LOCATION(player) != ref) {
+        if (OBJECT_TYPE(ref) == TYPE_ROOM && LOCATION(player) != ref) {
             abort_interp("Permission denied: not in room. (1)");
         }
 
-        if (Typeof(ref) == TYPE_THING && LOCATION(ref) != player) {
+        if (OBJECT_TYPE(ref) == TYPE_THING && LOCATION(ref) != player) {
             abort_interp("Permission denied: object not carried. (1)");
         }
     }
@@ -1953,7 +2006,7 @@ prim_newobject(PRIM_PROTOTYPE)
     CHECKOFLOW(1);
 
     ref = oper2->data.objref;
-    if (!valid_object(oper2) || (Typeof(oper2->data.objref) != TYPE_PLAYER && Typeof(oper2->data.objref) != TYPE_ROOM)) {
+    if (!valid_object(oper2) || (OBJECT_TYPE(oper2->data.objref) != TYPE_PLAYER && OBJECT_TYPE(oper2->data.objref) != TYPE_ROOM)) {
         abort_interp("Invalid player or room object (1)");
     }
 
@@ -2016,7 +2069,7 @@ prim_newroom(PRIM_PROTOTYPE)
     CHECKOFLOW(1);
 
     ref = oper2->data.objref;
-    if (ref != NOTHING && (!valid_object(oper2) || Typeof(ref) != TYPE_ROOM)) {
+    if (ref != NOTHING && (!valid_object(oper2) || OBJECT_TYPE(ref) != TYPE_ROOM)) {
         abort_interp("Invalid argument (1)");
     }
 
@@ -2035,7 +2088,7 @@ prim_newroom(PRIM_PROTOTYPE)
     if (ref == NOTHING) {
         ref = LOCATION(LOCATION(player));
 
-        while ((ref != NOTHING) && !(FLAGS(ref) & ABODE)) {
+        while ((ref != NOTHING) && !FLAG_CHECK(ref, 'A')) {
             ref = LOCATION(ref);
         }
 
@@ -2087,7 +2140,7 @@ prim_newexit(PRIM_PROTOTYPE)
 
     CHECKOFLOW(1);
 
-    if (!valid_object(oper2) || Typeof(oper2->data.objref) == TYPE_EXIT || Typeof(oper2->data.objref) == TYPE_PROGRAM) {
+    if (!valid_object(oper2) || OBJECT_TYPE(oper2->data.objref) == TYPE_EXIT || OBJECT_TYPE(oper2->data.objref) == TYPE_PROGRAM) {
         abort_interp("Invalid argument (1)");
     }
 
@@ -2144,7 +2197,7 @@ prim_lockedp(PRIM_PROTOTYPE)
         abort_interp("Interp call loops not allowed.");
     }
 
-    if (!valid_object(oper2) || (Typeof(oper2->data.objref) != TYPE_PLAYER && Typeof(oper2->data.objref) == TYPE_THING)) {
+    if (!valid_object(oper2) || (OBJECT_TYPE(oper2->data.objref) != TYPE_PLAYER && OBJECT_TYPE(oper2->data.objref) == TYPE_THING)) {
         abort_interp("Invalid player or thing argument. (1)");
     }
 
@@ -2210,7 +2263,7 @@ prim_recycle(PRIM_PROTOTYPE)
         abort_interp("Cannot recycle the global environment.");
     }
 
-    if (Typeof(result) == TYPE_PLAYER) {
+    if (OBJECT_TYPE(result) == TYPE_PLAYER) {
         abort_interp("Cannot recycle a player.");
     }
 
@@ -2230,7 +2283,7 @@ prim_recycle(PRIM_PROTOTYPE)
         }
     }
 
-    if (Typeof(result) == TYPE_EXIT) {
+    if (OBJECT_TYPE(result) == TYPE_EXIT) {
         unset_source(result);
     }
 
@@ -2439,11 +2492,11 @@ prim_movepennies(PRIM_PROTOTYPE)
         abort_interp("Permission denied (mlev < tp_movepennies_muf_mlev)");
     }
 
-    if (!valid_object(oper3) || (Typeof(oper3->data.objref) != TYPE_PLAYER || Typeof(oper3->data.objref) == TYPE_THING)) {
+    if (!valid_object(oper3) || (OBJECT_TYPE(oper3->data.objref) != TYPE_PLAYER || OBJECT_TYPE(oper3->data.objref) == TYPE_THING)) {
         abort_interp("Invalid player or thing argument (1)");
     }
 
-    if (!valid_object(oper2) || (Typeof(oper2->data.objref) != TYPE_PLAYER || Typeof(oper2->data.objref) == TYPE_THING)) {
+    if (!valid_object(oper2) || (OBJECT_TYPE(oper2->data.objref) != TYPE_PLAYER || OBJECT_TYPE(oper2->data.objref) == TYPE_THING)) {
         abort_interp("Invalid player or thing argument (2)");
     }
 
@@ -2451,14 +2504,14 @@ prim_movepennies(PRIM_PROTOTYPE)
         abort_interp("Argument must be a non-negative integer. (3)");
     }
 
-    if (mlev < 4 && Typeof(oper3->data.objref) == TYPE_THING) {
+    if (mlev < 4 && OBJECT_TYPE(oper3->data.objref) == TYPE_THING) {
         abort_interp("Permission denied. (2)");
     }
 
     ref = oper3->data.objref;
     ref2 = oper2->data.objref;
 
-    if (Typeof(ref) == TYPE_PLAYER) {
+    if (OBJECT_TYPE(ref) == TYPE_PLAYER) {
         if (mlev < 4) {
             if (GETVALUE(ref) < (GETVALUE(ref) - oper1->data.number)) {
                 abort_interp("Would roll over player's score. (1)");
@@ -2570,7 +2623,7 @@ prim_findnext(PRIM_PROTOTYPE)
 
     for (dbref i = item; i < db_top; i++) {
         if ((who == NOTHING || OWNER(i) == who) &&
-            checkflags(i, check) && NAME(i) && Typeof(i) != TYPE_GARBAGE &&
+            checkflags(i, check) && NAME(i) && OBJECT_TYPE(i) != TYPE_GARBAGE &&
             (!*name || equalstr(buf, (char *) NAME(i)))) {
             ref = i;
             break;
@@ -2636,7 +2689,7 @@ prim_nextentrance(PRIM_PROTOTYPE)
         oper2->data.objref = ref;
 
         if (valid_object(oper2)) {
-            switch (Typeof(ref)) {
+            switch (OBJECT_TYPE(ref)) {
                 case TYPE_PLAYER:
                     if (PLAYER_HOME(ref) == linkref) {
                         foundref = 1;
@@ -2889,7 +2942,7 @@ prim_toadplayer(PRIM_PROTOTYPE)
     }
 #endif
 
-    if ((FLAGS(victim) & WIZARD)) {
+    if (TrueWizard(victim)) {
         abort_interp("You can't toad a wizard.");
     }
 
@@ -2961,7 +3014,7 @@ prim_instances(PRIM_PROTOTYPE)
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1) || Typeof(oper1->data.objref) != TYPE_PROGRAM) {
+    if (!valid_object(oper1) || OBJECT_TYPE(oper1->data.objref) != TYPE_PROGRAM) {
         abort_interp("Invalid program object.");
     }
 
@@ -2993,7 +3046,7 @@ prim_compiledp(PRIM_PROTOTYPE)
     CHECKOP(1);
     oper1 = POP();
 
-    if (!valid_object(oper1) || Typeof(oper1->data.objref) != TYPE_PROGRAM) {
+    if (!valid_object(oper1) || OBJECT_TYPE(oper1->data.objref) != TYPE_PROGRAM) {
         abort_interp("Invalid program object.");
     }
 
@@ -3139,7 +3192,7 @@ prim_compile(PRIM_PROTOTYPE)
         abort_interp("Permission denied.  Requires Wizbit.");
     }
 
-    if (!valid_object(oper1) || Typeof(oper1->data.objref) != TYPE_PROGRAM) {
+    if (!valid_object(oper1) || OBJECT_TYPE(oper1->data.objref) != TYPE_PROGRAM) {
         abort_interp("Invalid program argument. (1)");
     }
 
@@ -3194,7 +3247,7 @@ prim_uncompile(PRIM_PROTOTYPE)
         abort_interp("Permission denied.  Requires Wizbit.");
     }
 
-    if (!valid_object(oper1) || Typeof(oper1->data.objref) != TYPE_PROGRAM) {
+    if (!valid_object(oper1) || OBJECT_TYPE(oper1->data.objref) != TYPE_PROGRAM) {
         abort_interp("Invalid program argument. (1)");
     }
 
@@ -3377,7 +3430,7 @@ prim_contents_array(PRIM_PROTOTYPE)
     }
 
     ref = oper1->data.objref;
-    if ((Typeof(ref) == TYPE_PROGRAM) || (Typeof(ref) == TYPE_EXIT)) {
+    if ((OBJECT_TYPE(ref) == TYPE_PROGRAM) || (OBJECT_TYPE(ref) == TYPE_EXIT)) {
         CLEAR(oper1);
         PushArrayRaw(new_array_packed(0, fr->pinning));
         return;
@@ -3386,7 +3439,7 @@ prim_contents_array(PRIM_PROTOTYPE)
     CHECKREMOTE(oper1->data.objref);
 
     for (ref = CONTENTS(oper1->data.objref); ObjExists(ref); ref = NEXTOBJ(ref)) {
-        if (mlev < 2 && ref != NOTHING && (FLAGS(ref) & DARK) && !controls(ProgUID, ref)) {
+        if (mlev < 2 && ref != NOTHING && Dark(ref) && !controls(ProgUID, ref)) {
             continue;
         }
 
@@ -3396,7 +3449,7 @@ prim_contents_array(PRIM_PROTOTYPE)
     nw = new_array_packed(count, fr->pinning);
 
     for (ref = CONTENTS(oper1->data.objref), count = 0; ObjExists(ref); ref = NEXTOBJ(ref)) {
-        if (mlev < 2 && ref != NOTHING && (FLAGS(ref) & DARK) && !controls(ProgUID, ref)) {
+        if (mlev < 2 && ref != NOTHING && Dark(ref) && !controls(ProgUID, ref)) {
             continue;
         }
 
@@ -3444,7 +3497,7 @@ prim_exits_array(PRIM_PROTOTYPE)
     ref = oper1->data.objref;
     CHECKREMOTE(oper1->data.objref);
 
-    if ((Typeof(ref) == TYPE_PROGRAM) || (Typeof(ref) == TYPE_EXIT)) {
+    if ((OBJECT_TYPE(ref) == TYPE_PROGRAM) || (OBJECT_TYPE(ref) == TYPE_EXIT)) {
         PushArrayRaw(new_array_packed(0, fr->pinning));
         return;
     }
@@ -3480,7 +3533,7 @@ array_getlinks(dbref obj, int pinned)
         return nw;
     }
 
-    switch (Typeof(obj)) {
+    switch (OBJECT_TYPE(obj)) {
         case TYPE_ROOM:
             array_set_intkey_refval(&nw, count++, DBFETCH(obj)->sp.room.dropto);
             break;
@@ -3581,7 +3634,7 @@ prim_entrances_array(PRIM_PROTOTYPE)
     nw = new_array_packed(0, fr->pinning);
 
     for (dbref i = 0; i < db_top; i++) {
-        switch (Typeof(i)) {
+        switch (OBJECT_TYPE(i)) {
             case TYPE_EXIT:
                 for (dbref j = DBFETCH(i)->sp.exit.ndest; j--;) {
                     if (DBFETCH(i)->sp.exit.dest[j] == ref) {
@@ -3647,7 +3700,7 @@ prim_program_getlines(PRIM_PROTOTYPE)
     oper2 = POP();
     oper1 = POP();
 
-    if (!valid_object(oper1) || Typeof(oper1->data.objref) != TYPE_PROGRAM) {
+    if (!valid_object(oper1) || OBJECT_TYPE(oper1->data.objref) != TYPE_PROGRAM) {
         abort_interp("Invalid pRogram dbref. (1)");
     }
 
@@ -3663,7 +3716,7 @@ prim_program_getlines(PRIM_PROTOTYPE)
     start = oper2->data.number;
     end = oper3->data.number;
 
-    if (mlev < 4 && !controls(ProgUID, ref) && !(FLAGS(ref) & VEHICLE)) {
+    if (mlev < 4 && !controls(ProgUID, ref) && !FLAG_CHECK(ref, 'V')) {
         abort_interp("Permission denied.");
     }
 
@@ -3782,7 +3835,7 @@ prim_program_setlines(PRIM_PROTOTYPE)
         abort_interp("Non-array argument. (2)");
     }
 
-    if (!valid_object(oper1) || Typeof(oper1->data.objref) != TYPE_PROGRAM) {
+    if (!valid_object(oper1) || OBJECT_TYPE(oper1->data.objref) != TYPE_PROGRAM) {
         abort_interp("Invalid program object. (1)");
     }
 
@@ -3822,7 +3875,7 @@ prim_program_setlines(PRIM_PROTOTYPE)
     }
 
     write_program(lines, oper1->data.objref);
-    unparse_object(player, oper1->data.objref, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(player, oper1->data.objref, unparse_buf, sizeof(unparse_buf));
     log_status("PROGRAM SAVED: %s by %s(%d)", unparse_buf, NAME(player), player);
 
     if (tp_log_programs)
@@ -3890,7 +3943,7 @@ prim_setlinks_array(PRIM_PROTOTYPE)
         abort_interp("Too many destinations. (2)");
     }
 
-    if ((dest_count > 1) && (Typeof(oper1->data.objref) != TYPE_EXIT)) {
+    if ((dest_count > 1) && (OBJECT_TYPE(oper1->data.objref) != TYPE_EXIT)) {
         abort_interp("Only exits may be linked to multiple destinations.");
     }
 
@@ -3909,18 +3962,18 @@ prim_setlinks_array(PRIM_PROTOTYPE)
                 abort_interp("Invalid object. (2)");
             }
 
-            if (!prog_can_link_to(mlev, ProgUID, Typeof(what), where)) {
+            if (!prog_can_link_to(mlev, ProgUID, OBJECT_TYPE(what), where)) {
                 CLEAR(&idx);
                 abort_interp("Can't link source to destination. (2)");
             }
 
-            switch (Typeof(what)) {
+            switch (OBJECT_TYPE(what)) {
                 case TYPE_EXIT:
                     if (where == NIL) {
                         break;
                     }
 
-                    switch (Typeof(where)) {
+                    switch (OBJECT_TYPE(where)) {
                         case TYPE_PLAYER:
                         case TYPE_ROOM:
                         case TYPE_PROGRAM:
@@ -3982,8 +4035,8 @@ prim_setlinks_array(PRIM_PROTOTYPE)
         } while (array_next(arr, &idx));
     }
 
-    if (Typeof(what) == TYPE_EXIT) {
-        if (MLevRaw(what)) {
+    if (OBJECT_TYPE(what) == TYPE_EXIT) {
+        if (OBJECT_MLEVEL(what)) {
             SetMLevel(what, 0);
         }
 
@@ -3991,7 +4044,7 @@ prim_setlinks_array(PRIM_PROTOTYPE)
     }
 
     if (dest_count == 0) {
-        switch (Typeof(what)) {
+        switch (OBJECT_TYPE(what)) {
             case TYPE_EXIT:
                 DBSTORE(what, sp.exit.ndest, 0);
                 DBSTORE(what, sp.exit.dest, NULL);
@@ -4005,7 +4058,7 @@ prim_setlinks_array(PRIM_PROTOTYPE)
                 abort_interp("Only exits and rooms may be linked to nothing.");
         }
     } else {
-        switch (Typeof(what)) {
+        switch (OBJECT_TYPE(what)) {
             case TYPE_EXIT: {
                 dbref *dests = malloc(sizeof(dbref) * dest_count);
 

--- a/src/p_math.c
+++ b/src/p_math.c
@@ -448,7 +448,7 @@ prim_divide(PRIM_PROTOTYPE)
  * @see prim_fmod
  * @see prim_modf
  *
- * Returns the modulo of the lower number by the top number.  
+ * Returns the modulo of the lower number by the top number.
  *
  * Dbrefs and variable numbers can also be manipulated with this.
  *

--- a/src/p_mcp.c
+++ b/src/p_mcp.c
@@ -62,7 +62,7 @@ struct mcpevent_context {
 
 /*
  * This allows using GUI if the player owns the MUF, which drops the
- * requirement from an M3. This is not .top because .top will usually 
+ * requirement from an M3. This is not .top because .top will usually
  * be $lib/gui. This could be expanded to check the entire MUF chain.
  */
 #define CHECKMCPPERM() \
@@ -692,7 +692,7 @@ prim_mcp_bind(PRIM_PROTOTYPE)
         abort_interp("Package name cannot be a null string. (1)");
 
     if (!ObjExists(oper3->data.addr->progref) ||
-        Typeof(oper3->data.addr->progref) != TYPE_PROGRAM) {
+        OBJECT_TYPE(oper3->data.addr->progref) != TYPE_PROGRAM) {
         abort_interp("Invalid address. (3)");
     }
 

--- a/src/p_misc.c
+++ b/src/p_misc.c
@@ -473,7 +473,7 @@ prim_queue(PRIM_PROTOTYPE)
         abort_interp("Non-integer argument (1).");
     }
 
-    if (!valid_object(oper2) || Typeof(oper2->data.objref) != TYPE_PROGRAM) {
+    if (!valid_object(oper2) || OBJECT_TYPE(oper2->data.objref) != TYPE_PROGRAM) {
         abort_interp("Invalid program dbref argument (2).");
     }
 
@@ -574,7 +574,7 @@ prim_force(PRIM_PROTOTYPE)
         abort_interp("Non-string argument (2).");
     }
 
-    if (!valid_object(oper2) || (Typeof(oper2->data.objref) != TYPE_PLAYER && Typeof(oper2->data.objref) != TYPE_THING)) {
+    if (!valid_object(oper2) || (OBJECT_TYPE(oper2->data.objref) != TYPE_PLAYER && OBJECT_TYPE(oper2->data.objref) != TYPE_THING)) {
         abort_interp("Invalid player or thing argument (1).");
     }
 
@@ -609,7 +609,7 @@ prim_force(PRIM_PROTOTYPE)
     }
 
     for (int i = 1; i <= fr->caller.top; i++) {
-        if (Typeof(fr->caller.st[i]) != TYPE_PROGRAM) {
+        if (OBJECT_TYPE(fr->caller.st[i]) != TYPE_PROGRAM) {
 #ifdef DEBUG
             notifyf_nolisten(player, "[debug] prim_force: fr->caller.st[%d] isn't a program.", i);
 #endif                          /* DEBUG */
@@ -1135,7 +1135,7 @@ prim_testlock(PRIM_PROTOTYPE)
         abort_interp("Interp call loops not allowed.");
     }
 
-    if (!valid_object(oper2) || (Typeof(oper2->data.objref) != TYPE_PLAYER && Typeof(oper2->data.objref) != TYPE_THING)) {
+    if (!valid_object(oper2) || (OBJECT_TYPE(oper2->data.objref) != TYPE_PLAYER && OBJECT_TYPE(oper2->data.objref) != TYPE_THING)) {
         abort_interp("Invalid player or thing argument (1).");
     }
 
@@ -1216,7 +1216,7 @@ prim_cancallp(PRIM_PROTOTYPE)
     oper2 = POP();              /* string: public function name */
     oper1 = POP();              /* dbref: Program dbref to check */
 
-    if (!valid_object(oper1) || Typeof(oper1->data.objref) != TYPE_PROGRAM) {
+    if (!valid_object(oper1) || OBJECT_TYPE(oper1->data.objref) != TYPE_PROGRAM) {
         abort_interp("Invalid program dbref argument. (1)");
     }
 
@@ -1661,7 +1661,7 @@ prim_ext_name_okp(PRIM_PROTOTYPE)
             abort_interp("Invalid argument (2).");
         }
 
-        result = ok_object_name(b, Typeof(oper2->data.objref));
+        result = ok_object_name(b, OBJECT_TYPE(oper2->data.objref));
     } else {
         char buf[BUFFER_LEN];
 
@@ -2128,7 +2128,7 @@ prim_debug_off(PRIM_PROTOTYPE)
 void
 prim_debug_line(PRIM_PROTOTYPE)
 {
-    if (((FLAGS(program) & DARK) == 0) && controls(player, program)) {
+    if (!Dark(program) && controls(player, program)) {
         char buf[BUFFER_LEN];
         const char *msg = debug_inst(fr, 0, pc, fr->pid, arg, buf, sizeof(buf),
                 *top, program);

--- a/src/p_props.c
+++ b/src/p_props.c
@@ -823,7 +823,7 @@ prim_unblessprop(PRIM_PROTOTYPE)
     CHECKOP(2);
     oper2 = POP();
     oper1 = POP();
- 
+
     if (oper2->type != PROG_STRING)
         abort_interp("Non-string argument (2)");
 
@@ -908,7 +908,7 @@ prim_setprop(PRIM_PROTOTYPE)
 
     char tname[BUFFER_LEN];
     strcpyn(tname, sizeof(tname), DoNullInd(oper2->data.string));
-    
+
     if (!prop_write_perms(ProgUID, oper3->data.objref, tname, mlev))
         abort_interp("Permission denied.");
 
@@ -2035,7 +2035,7 @@ prim_prop_name_okp(PRIM_PROTOTYPE)
         abort_interp("Property name string expected.");
 
     result = is_valid_propname(DoNullInd(oper1->data.string));
-    
+
     CLEAR(oper1);
     PushInt(result);
 }

--- a/src/p_regex.c
+++ b/src/p_regex.c
@@ -584,7 +584,7 @@ _prim_regsplit(PRIM_PROTOTYPE, int empty)
         abort_interp("Out of memory");
     }
 
-    while(*text != '\0') {
+    while (*text != '\0') {
         if ((matchcnt = pcre_exec(re->re, NULL, textstart, len, text-textstart,
                                   0, matches, MATCH_ARR_SIZE)) < 0) {
             if (matchcnt != PCRE_ERROR_NOMATCH) {

--- a/src/p_stack.c
+++ b/src/p_stack.c
@@ -1315,7 +1315,7 @@ prim_checkargs(PRIM_PROTOTYPE)
                             if ((ref < 0) && (ref != HOME))
                                 ABORT_CHECKARGS("Invalid dbref.");
 
-                            if (Typeof(ref) == TYPE_GARBAGE)
+                            if (OBJECT_TYPE(ref) == TYPE_GARBAGE)
                                 ABORT_CHECKARGS("Invalid dbref.");
                             /* fall through */
 
@@ -1331,7 +1331,7 @@ prim_checkargs(PRIM_PROTOTYPE)
                             /* fall through */
 
                         case 'p':
-                            if ((ref >= 0) && (Typeof(ref) != TYPE_PLAYER))
+                            if ((ref >= 0) && (OBJECT_TYPE(ref) != TYPE_PLAYER))
                                 ABORT_CHECKARGS("Expected player dbref.");
 
                             if (ref == HOME)
@@ -1345,7 +1345,7 @@ prim_checkargs(PRIM_PROTOTYPE)
                             /* fall through */
 
                         case 'r':
-                            if ((ref >= 0) && (Typeof(ref) != TYPE_ROOM))
+                            if ((ref >= 0) && (OBJECT_TYPE(ref) != TYPE_ROOM))
                                 ABORT_CHECKARGS("Expected room dbref.");
 
                             break;
@@ -1356,7 +1356,7 @@ prim_checkargs(PRIM_PROTOTYPE)
                             /* fall through */
 
                         case 't':
-                            if ((ref >= 0) && (Typeof(ref) != TYPE_THING))
+                            if ((ref >= 0) && (OBJECT_TYPE(ref) != TYPE_THING))
                                 ABORT_CHECKARGS("Expected thing dbref.");
 
                             if (ref == HOME)
@@ -1370,7 +1370,7 @@ prim_checkargs(PRIM_PROTOTYPE)
                             /* fall through */
 
                         case 'e':
-                            if ((ref >= 0) && (Typeof(ref) != TYPE_EXIT))
+                            if ((ref >= 0) && (OBJECT_TYPE(ref) != TYPE_EXIT))
                                 ABORT_CHECKARGS("Expected exit dbref.");
 
                             if (ref == HOME)
@@ -1384,7 +1384,7 @@ prim_checkargs(PRIM_PROTOTYPE)
                             /* fall through */
 
                         case 'f':
-                            if ((ref >= 0) && (Typeof(ref) != TYPE_PROGRAM))
+                            if ((ref >= 0) && (OBJECT_TYPE(ref) != TYPE_PROGRAM))
                                 ABORT_CHECKARGS("Expected program dbref.");
 
                             if (ref == HOME)
@@ -1740,7 +1740,7 @@ prim_interp(PRIM_PROTOTYPE)
     oper2 = POP();              /* dbref  --  trigger */
     oper1 = POP();              /* dbref  --  Program to run */
 
-    if (!valid_object(oper1) || Typeof(oper1->data.objref) != TYPE_PROGRAM)
+    if (!valid_object(oper1) || OBJECT_TYPE(oper1->data.objref) != TYPE_PROGRAM)
         abort_interp("Bad program reference. (1)");
 
     if (!valid_object(oper2))

--- a/src/p_strings.c
+++ b/src/p_strings.c
@@ -19,6 +19,7 @@
 #include "db.h"
 #include "fbmath.h"
 #include "fbstrings.h"
+#include "flags.h"
 #include "game.h"
 #include "inst.h"
 #include "interface.h"
@@ -796,7 +797,7 @@ prim_array_fmtstrings(PRIM_PROTOTYPE)
          */
         do {
             strcpyn(sstr, sizeof(sstr), fmtstr);
-            
+
             /* End of current string, must be smaller than BUFFER_LEN */
             result = 0;
             tmp = 0; /* Number of props to search for/found */
@@ -879,7 +880,7 @@ prim_array_fmtstrings(PRIM_PROTOTYPE)
                             }
 
                             if (sstr[scnt] != ']') {
-                                abort_message = 
+                                abort_message =
                                     "Specified format field didn't have an "
                                     "array index terminator ']'.";
                                 goto cleanup_and_abort;
@@ -1864,7 +1865,7 @@ prim_midstr(PRIM_PROTOTYPE)
         } else {
             start = (size_t)oper2->data.number - 1;
 
-            if (((size_t)oper1->data.number + start) > 
+            if (((size_t)oper1->data.number + start) >
                 oper3->data.string->length) {
                 range = oper3->data.string->length - start;
             } else {
@@ -2422,17 +2423,17 @@ prim_notify_exclude(PRIM_PROTOTYPE)
 
         where = oper1->data.objref;
 
-        if (Typeof(where) != TYPE_ROOM && Typeof(where) != TYPE_THING &&
-            Typeof(where) != TYPE_PLAYER)
+        if (OBJECT_TYPE(where) != TYPE_ROOM && OBJECT_TYPE(where) != TYPE_THING &&
+            OBJECT_TYPE(where) != TYPE_PLAYER)
             abort_interp("Invalid location argument (1)");
-        
+
         CHECKREMOTE(where);
         what = CONTENTS(where);
         CLEAR(oper1);
 
         if (*buf) {
             while (what != NOTHING) {
-                if (Typeof(what) != TYPE_ROOM) {
+                if (OBJECT_TYPE(what) != TYPE_ROOM) {
                     for (tmp = 0, i = count; i-- > 0;) {
                         if (excluded[i] == what)
                             tmp = 1;
@@ -2505,7 +2506,7 @@ prim_otell(PRIM_PROTOTYPE)
 
     if (*buf) {
         for (; what != NOTHING; what = NEXTOBJ(what)) {
-            if (Typeof(what) != TYPE_ROOM && what != player) {
+            if (OBJECT_TYPE(what) != TYPE_ROOM && what != player) {
                 notify_listeners(player, program, what, where, buf, 0);
             }
         }
@@ -3149,7 +3150,7 @@ prim_tolower(PRIM_PROTOTYPE)
  * Consumes a dbref and puts a string on the stack.  The string is the name
  * with the ref and flags appended to it like "One(#1PW)"
  *
- * @see unparse_flags
+ * @see flag_list
  *
  * @param player the player running the MUF program
  * @param program the program being run
@@ -3162,39 +3163,18 @@ prim_tolower(PRIM_PROTOTYPE)
 void
 prim_unparseobj(PRIM_PROTOTYPE)
 {
+    char unparse_buf[BUFFER_LEN];
+
     CHECKOP(1);
     oper1 = POP();
 
     if (oper1->type != PROG_OBJECT)
         abort_interp("Non-object argument.");
 
-    {
-        result = oper1->data.objref;
+    flag_unparse_object(NOTHING, oper1->data.objref, unparse_buf, sizeof(unparse_buf));
 
-        switch (result) {
-            case NOTHING:
-                snprintf(buf, sizeof(buf), "*NOTHING*");
-                break;
-
-            case HOME:
-                snprintf(buf, sizeof(buf), "*HOME*");
-                break;
-
-            case NIL:
-                snprintf(buf, sizeof(buf), "*NIL*");
-                break;
-
-            default:
-                if (!ObjExists(result))
-                    snprintf(buf, sizeof(buf), "*INVALID*");
-                else
-                    snprintf(buf, sizeof(buf), "%s(#%d%s)", NAME(result),
-                             result, unparse_flags(result));
-        }
-
-        CLEAR(oper1);
-        PushString(buf);
-    }
+    CLEAR(oper1);
+    PushString(unparse_buf);
 }
 
 /**
@@ -3314,7 +3294,7 @@ prim_stringpfx(PRIM_PROTOTYPE)
     CHECKOP(2);
     oper1 = POP();
     oper2 = POP();
- 
+
     if (oper1->type != PROG_STRING || oper2->type != PROG_STRING)
         abort_interp("Non-string argument.");
 

--- a/src/pennies.c
+++ b/src/pennies.c
@@ -57,7 +57,7 @@ do_give(int descr, dbref player, const char *recipient, int amount)
     }
 
     if (!Wizard(OWNER(player))) {
-        if (Typeof(who) != TYPE_PLAYER) {
+        if (OBJECT_TYPE(who) != TYPE_PLAYER) {
             notify(player, "You can only give to other players.");
             return;
         } else if (GETVALUE(who) + amount > tp_max_pennies) {
@@ -71,7 +71,7 @@ do_give(int descr, dbref player, const char *recipient, int amount)
         return;
     }
 
-    switch (Typeof(who)) {
+    switch (OBJECT_TYPE(who)) {
         case TYPE_PLAYER:
             SETVALUE(who, GETVALUE(who) + amount);
 

--- a/src/player.c
+++ b/src/player.c
@@ -279,7 +279,7 @@ toad_player(int descr, dbref player, dbref victim, dbref recipient)
 
     for (dbref stuff = 0; stuff < db_top; stuff++) {
         if (OWNER(stuff) == victim) {
-            switch (Typeof(stuff)) {
+            switch (OBJECT_TYPE(stuff)) {
                 case TYPE_PROGRAM:
                     dequeue_prog(stuff, 0);
                     if (TrueWizard(recipient)) {
@@ -297,7 +297,7 @@ toad_player(int descr, dbref player, dbref victim, dbref recipient)
             }
         }
 
-        if (Typeof(stuff) == TYPE_THING && THING_HOME(stuff) == victim) {
+        if (OBJECT_TYPE(stuff) == TYPE_THING && THING_HOME(stuff) == victim) {
             THING_SET_HOME(stuff, tp_lost_and_found);
         }
     }
@@ -442,7 +442,7 @@ delete_player(dbref who)
         clear_players();
 
         for (dbref i = 0; i < db_top; i++) {
-            if (Typeof(i) == TYPE_PLAYER) {
+            if (OBJECT_TYPE(i) == TYPE_PLAYER) {
                 found = lookup_player(NAME(i));
 
                 if (found != NOTHING) {
@@ -532,7 +532,7 @@ payfor(dbref who, int cost)
  *
  * * Passwords cannot be blank
  * * They cannot contain non-printable characters
- * * And also no space characters 
+ * * And also no space characters
  *
  * @param password the password to check
  * @return boolean true if it is valid, false otherwise

--- a/src/predicates.c
+++ b/src/predicates.c
@@ -28,7 +28,7 @@
  * Checks if 'who' can link an object of type 'what_type' to 'where'
  *
  * Because this may be called prior to the object existing, it is
- * checked by type; however, 'Typeof(dbref)' is often used to see
+ * checked by type; however, 'OBJECT_TYPE(dbref)' is often used to see
  * if some existing objet's ref can link to where.
  *
  * @param who the person we are checking link permissions for
@@ -52,24 +52,24 @@ can_link_to(dbref who, object_flag_type what_type, dbref where)
         return 0;
 
     /* Players can only be linked to rooms */
-    if (what_type == TYPE_PLAYER && Typeof(where) != TYPE_ROOM)
+    if (what_type == TYPE_PLAYER && OBJECT_TYPE(where) != TYPE_ROOM)
         return 0;
 
     /* Rooms can only be linked to things or other rooms */
     if (what_type == TYPE_ROOM
-        && Typeof(where) != TYPE_THING && Typeof(where) != TYPE_ROOM)
+        && OBJECT_TYPE(where) != TYPE_THING && OBJECT_TYPE(where) != TYPE_ROOM)
         return 0;
- 
+
     /* Things cannot be linked to exits or programs */
     if (what_type == TYPE_THING
-        && (Typeof(where) == TYPE_EXIT || Typeof(where) == TYPE_PROGRAM))
+        && (OBJECT_TYPE(where) == TYPE_EXIT || OBJECT_TYPE(where) == TYPE_PROGRAM))
         return 0;
 
     /* Program links cannot be modified */
     if (what_type == TYPE_PROGRAM)
         return 0;
 
-    /* Target must be controlled or publicly linkable with its linklock passed */ 
+    /* Target must be controlled or publicly linkable with its linklock passed */
     return controls(who, where) || (Linkable(where) && test_lock(NOTHING, who, where, MESGPROP_LINKLOCK));
 }
 
@@ -90,8 +90,8 @@ can_teleport_to(dbref who, dbref where)
 {
     return (controls(who, where) ||
            (test_lock(NOTHING, who, where, MESGPROP_LINKLOCK) &&
-           ((FLAGS(where) & LINK_OK) ||
-            (Typeof(where) != TYPE_THING && (FLAGS(where) & ABODE)))));
+           (FLAG_CHECK(where, 'L') ||
+            (OBJECT_TYPE(where) != TYPE_THING && FLAG_CHECK(where, 'A')))));
 }
 
 /**
@@ -122,7 +122,7 @@ int
 can_link(dbref who, dbref what)
 {
     /* Anyone can link an exit that is currently unlinked. */
-    return (controls(who, what) || ((Typeof(what) == TYPE_EXIT)
+    return (controls(who, what) || ((OBJECT_TYPE(what) == TYPE_EXIT)
             && DBFETCH(what)->sp.exit.ndest == 0));
 }
 
@@ -143,7 +143,7 @@ could_doit(int descr, dbref player, dbref thing)
 {
     dbref source, dest, owner;
 
-    if (Typeof(thing) == TYPE_EXIT) {
+    if (OBJECT_TYPE(thing) == TYPE_EXIT) {
         /* If exit is unlinked, can't do it. */
         if (DBFETCH(thing)->sp.exit.ndest == 0) {
             return 0;
@@ -156,7 +156,7 @@ could_doit(int descr, dbref player, dbref thing)
         if (dest == NIL)
             return (eval_boolexp(descr, player, GETLOCK(thing, MESGPROP_LOCK), thing));
 
-        if (Typeof(dest) == TYPE_PLAYER) {
+        if (OBJECT_TYPE(dest) == TYPE_PLAYER) {
             /* Check for additional restrictions related to player dests */
             dbref destplayer = dest;
 
@@ -164,31 +164,31 @@ could_doit(int descr, dbref player, dbref thing)
             /* If the dest player isn't JUMP_OK, or if the dest player's loc
              * is set BOUND, can't do it.
              */
-            if (!(FLAGS(destplayer) & JUMP_OK) || (FLAGS(dest) & BUILDER)) {
+            if (!FLAG_CHECK(destplayer, 'J') || FLAG_CHECK(dest, 'B')) {
                 return 0;
             }
         }
 
-        if (dest != HOME && Typeof(dest) == TYPE_ROOM &&
-            (FLAGS(dest) & GUEST) && ISGUEST(player)) {
+        if (dest != HOME && OBJECT_TYPE(dest) == TYPE_ROOM &&
+            ISGUEST(dest) && ISGUEST(player)) {
             return 0;
         }
 
         /* for actions */
         if ((LOCATION(thing) != NOTHING) &&
-            (Typeof(LOCATION(thing)) != TYPE_ROOM)) {
+            (OBJECT_TYPE(LOCATION(thing)) != TYPE_ROOM)) {
             /* If this is an exit on a Thing or a Player... */
 
             /* If the destination is a room or player, and the current
              * location is set BOUND (note: if the player is in a vehicle
              * set BUILDER this will also return failure)
              */
-            if ((Typeof(dest) == TYPE_ROOM || Typeof(dest) == TYPE_PLAYER) &&
-                (FLAGS(source) & BUILDER))
+            if ((OBJECT_TYPE(dest) == TYPE_ROOM || OBJECT_TYPE(dest) == TYPE_PLAYER) &&
+                FLAG_CHECK(source, 'B'))
                 return 0;
 
             /* If secure_teleport is true, and if the destination is a room */
-            if (tp_secure_teleport && Typeof(dest) == TYPE_ROOM) {
+            if (tp_secure_teleport && OBJECT_TYPE(dest) == TYPE_ROOM) {
                 /* if player doesn't control the source and the source isn't
                  * set Jump_OK, then if the destination isn't HOME,
                  * can't do it.  (Should this include getlink(owner)?  Not
@@ -196,7 +196,7 @@ could_doit(int descr, dbref player, dbref thing)
                  * be treated specially. -winged)
                  */
                 if ((dest != HOME) && (!controls(owner, source))
-                    && ((FLAGS(source) & JUMP_OK) == 0)) {
+                    && !FLAG_CHECK(source, 'J')) {
                     return 0;
                 }
 
@@ -238,7 +238,7 @@ can_doit(int descr, dbref player, dbref thing, const char *default_fail_msg)
     if ((loc = LOCATION(player)) == NOTHING)
         return 0;
 
-    if (!Wizard(OWNER(player)) && tp_allow_zombies && Typeof(player) == TYPE_THING && (FLAGS(thing) & ZOMBIE)) {
+    if (!Wizard(OWNER(player)) && tp_allow_zombies && OBJECT_TYPE(player) == TYPE_THING && FLAG_CHECK(thing, 'Z')) {
         notify(player, "Sorry, but zombies can't do that.");
         return 0;
     }
@@ -291,7 +291,7 @@ exit_loop_check(dbref source, dbref dest)
     if (source == dest)
         return 1;               /* That's an easy one! */
 
-    if (!ObjExists(dest) || Typeof(dest) != TYPE_EXIT)
+    if (!ObjExists(dest) || OBJECT_TYPE(dest) != TYPE_EXIT)
         return 0;
 
     for (int i = 0; i < DBFETCH(dest)->sp.exit.ndest; i++) {
@@ -304,7 +304,7 @@ exit_loop_check(dbref source, dbref dest)
             return 1;           /* Found a loop! */
         }
 
-        if (Typeof(current) == TYPE_EXIT) {
+        if (OBJECT_TYPE(current) == TYPE_EXIT) {
             if (exit_loop_check(source, current)) {
                 return 1;       /* Found one recursively */
             }
@@ -411,7 +411,7 @@ parent_loop_check(dbref source, dbref dest)
     dbref pstack[MAX_PARENT_DEPTH + 2];
 
     if (dest == HOME) {
-        switch (Typeof(source)) {
+        switch (OBJECT_TYPE(source)) {
             case TYPE_PLAYER:
                 dest = PLAYER_HOME(source);
                 break;

--- a/src/propdirs.c
+++ b/src/propdirs.c
@@ -147,7 +147,7 @@ propdir_delete_elem(PropPtr root, char *path)
 
 /**
  * Fetches a given property from the property path structure 'root'.
- * As this is something of a low level call you may prefer to use 
+ * As this is something of a low level call you may prefer to use
  * get_property
  *
  * @see get_property

--- a/src/property.c
+++ b/src/property.c
@@ -23,6 +23,7 @@
 #include "fbmath.h"
 #include "fbstrings.h"
 #include "fbtime.h"
+#include "flags.h"
 #include "game.h"
 #include "interface.h"
 #include "interp.h"
@@ -41,8 +42,8 @@
  * This method (unlike some others) does full property name validation.
  * Leading / are trimmed off, and if there is a ':' the prop name will
  * be terminated at that point (the : becomes a \0).  The : is defined
- * as PROP_DELIMITER.  
- * 
+ * as PROP_DELIMITER.
+ *
  * If there is no property name after cleanup, this just returns with nothing
  * done.
  *
@@ -217,8 +218,8 @@ set_property_nofetch(dbref player, const char *pname, PData * dat)
  * This method (unlike some others) does full property name validation.
  * Leading / are trimmed off, and if there is a ':' the prop name will
  * be terminated at that point (the : becomes a \0).  The : is defined
- * as PROP_DELIMITER.  
- * 
+ * as PROP_DELIMITER.
+ *
  * If there is no property name after cleanup, this just returns with nothing
  * done.
  *
@@ -1279,7 +1280,7 @@ envpropstr(dbref * where, const char *propname)
  * Any errors (no such property) will be written to the buffer.
  *
  * @param player is the player doing the call, and is used to determine
- *        permissions for unparse_object ('ref' type props)
+ *        permissions for flag_unparse_object ('ref' type props)
  * @param obj is the object who's property is being examined.
  * @param name is the property name
  * @param buf is a buffer that you provide for property information to
@@ -1320,7 +1321,7 @@ displayprop(dbref player, dbref obj, const char *name, char *buf, size_t bufsiz)
                      PropDataStr(p));
             break;
         case PROP_REFTYP:
-            unparse_object(player, PropDataRef(p), unparse_buf, sizeof(unparse_buf));
+            flag_unparse_object(player, PropDataRef(p), unparse_buf, sizeof(unparse_buf));
             snprintf(buf, bufsiz, "%c ref %s:%s", blesschar, mybuf, unparse_buf);
             break;
         case PROP_INTTYP:
@@ -2500,7 +2501,7 @@ exec_or_notify(int descr, dbref player, dbref thing,
          *        edge case, and maybe its useful to have a route where
          *        MPI is not parsed.
          */
-        if (!ObjExists(i) || (Typeof(i) != TYPE_PROGRAM)) {
+        if (!ObjExists(i) || (OBJECT_TYPE(i) != TYPE_PROGRAM)) {
             if (*p) {
                 notify(player, p);
             } else {

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -77,7 +77,7 @@ int notify(int player, const char *msg);
  */
 int notify(int player, const char *msg) {
     (void)player;
-    return printf("%s\n", msg);		
+    return printf("%s\n", msg);
 }
 
 /*
@@ -427,8 +427,8 @@ static const char * get_username_v6(struct in6_addr *a, in_port_t prt,
  */
 static const char * addrout_v6(struct in6_addr *a, in_port_t prt,
                                in_port_t myprt) {
-    static char buf[SMALL_BUFFER_LEN+7];
-    char tmpbuf[SMALL_BUFFER_LEN+7];
+    char tmpbuf[SMALL_BUFFER_LEN];
+    static char buf[MEDIUM_BUFFER_LEN];
     const char *ptr, *ptr2;
     struct hostent *he;
 
@@ -748,8 +748,8 @@ static const char * get_username(in_addr_t a, in_port_t prt, in_port_t myprt) {
  * @return the host string
  */
 static const char * addrout(in_addr_t a, in_port_t prt, in_port_t myprt) {
-    static char buf[SMALL_BUFFER_LEN+7];
-    char tmpbuf[SMALL_BUFFER_LEN+7];
+    char tmpbuf[SMALL_BUFFER_LEN];
+    static char buf[MEDIUM_BUFFER_LEN];
     const char *ptr, *ptr2;
     struct hostent *he;
     struct in_addr addr;
@@ -848,7 +848,7 @@ static int do_resolve(void) {
     char *result;
     const char *ptr;
     char buf[1024];
-    char outbuf[1024];
+    char outbuf[2072];
     char *bufptr = NULL;
     in_addr_t fullip;
 
@@ -873,7 +873,7 @@ static int do_resolve(void) {
                 return 0;
             }
 
-            /* 
+            /*
              * This will hang the thread while we wait on input, and will
              * deadlock the other threads.  This, however, is on purpose
              * so it essentially forces the threads to queue.
@@ -940,7 +940,7 @@ static int do_resolve(void) {
         }
 
         /*
-         * TODO: This should just be an else I think -- because 
+         * TODO: This should just be an else I think -- because
          *       we will never want to fall into this block if the IPv6
          *       block runs.  There's no reason to do if bufptr then if !bufptr
          */

--- a/src/sanity.c
+++ b/src/sanity.c
@@ -24,6 +24,7 @@
 #include "diskprop.h"
 #endif
 #include "fbstrings.h"
+#include "flags.h"
 #include "interface.h"
 #include "log.h"
 #include "match.h"
@@ -167,7 +168,7 @@ static void
 SanPrintObject(dbref player, const char *prefix, dbref ref)
 {
     char unparse_buf[16384];
-    unparse_object(NOTHING, ref, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(NOTHING, ref, unparse_buf, sizeof(unparse_buf));
     SanPrint(player, "%s%s\n", prefix, unparse_buf);
 }
 
@@ -191,7 +192,7 @@ do_examine_sanity(int descr, dbref player, const char *arg)
     struct match_data md;
 
     if (player > 0) {
-        init_match(descr, player, arg, NOTYPE, &md);
+        init_match(descr, player, arg, TYPE_ANY, &md);
         match_everything(&md);
 
         if ((d = noisy_match_result(&md)) == NOTHING) {
@@ -206,7 +207,7 @@ do_examine_sanity(int descr, dbref player, const char *arg)
         }
     }
 
-    if (Typeof(d) == TYPE_GARBAGE) {
+    if (OBJECT_TYPE(d) == TYPE_GARBAGE) {
         SanPrint(player, "Object:         *GARBAGE* #%d", d);
     } else {
         SanPrintObject(player, "Object:         ", d);
@@ -218,7 +219,7 @@ do_examine_sanity(int descr, dbref player, const char *arg)
     SanPrintObject(player, "  Exits Start:    ", EXITS(d));
     SanPrintObject(player, "  Next:           ", NEXTOBJ(d));
 
-    switch (Typeof(d)) {
+    switch (OBJECT_TYPE(d)) {
         case TYPE_THING:
             SanPrintObject(player, "  Home:           ", THING_HOME(d));
             SanPrint(player, "  Value:          %d", GETVALUE(d));
@@ -289,7 +290,7 @@ static void
 violate(dbref player, dbref i, const char *s)
 {
     char unparse_buf[16384];
-    unparse_object(NOTHING, i, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(NOTHING, i, unparse_buf, sizeof(unparse_buf));
     SanPrint(player, "Object \"%s\" %s!", unparse_buf, s);
     sanity_violated = 1;
 }
@@ -441,7 +442,7 @@ check_room(dbref player, dbref obj)
 
     if (!OkRef(i) && i != HOME) {
         violate(player, obj, "has its dropto set to an invalid object");
-    } else if (i >= 0 && Typeof(i) != TYPE_THING && Typeof(i) != TYPE_ROOM) {
+    } else if (i >= 0 && OBJECT_TYPE(i) != TYPE_THING && OBJECT_TYPE(i) != TYPE_ROOM) {
         violate(player, obj, "has its dropto set to a non-room, non-thing object");
     }
 }
@@ -470,7 +471,7 @@ check_thing(dbref player, dbref obj)
 
     if (!OkObj(i)) {
         violate(player, obj, "has its home set to an invalid object");
-    } else if (Typeof(i) != TYPE_ROOM && Typeof(i) != TYPE_THING && Typeof(i) != TYPE_PLAYER) {
+    } else if (OBJECT_TYPE(i) != TYPE_ROOM && OBJECT_TYPE(i) != TYPE_THING && OBJECT_TYPE(i) != TYPE_PLAYER) {
         violate(player, obj,
             "has its home set to an object that is not a room, thing, or player");
     }
@@ -529,7 +530,7 @@ check_player(dbref player, dbref obj)
 
     if (!OkObj(i)) {
         violate(player, obj, "has its home set to an invalid object");
-    } else if (i >= 0 && Typeof(i) != TYPE_ROOM) {
+    } else if (i >= 0 && OBJECT_TYPE(i) != TYPE_ROOM) {
         violate(player, obj, "has its home set to a non-room object");
     }
 }
@@ -552,7 +553,7 @@ check_player(dbref player, dbref obj)
 static void
 check_garbage(dbref player, dbref obj)
 {
-    if (NEXTOBJ(obj) != NOTHING && Typeof(NEXTOBJ(obj)) != TYPE_GARBAGE) {
+    if (NEXTOBJ(obj) != NOTHING && OBJECT_TYPE(NEXTOBJ(obj)) != TYPE_GARBAGE) {
         violate(player, obj,
             "has a non-garbage object as the 'next' object in the garbage chain");
     }
@@ -585,11 +586,11 @@ check_contents_list(dbref player, dbref obj)
     dbref i;
     int limit;
 
-    if (Typeof(obj) != TYPE_PROGRAM && Typeof(obj) != TYPE_EXIT &&
-        Typeof(obj) != TYPE_GARBAGE) {
+    if (OBJECT_TYPE(obj) != TYPE_PROGRAM && OBJECT_TYPE(obj) != TYPE_EXIT &&
+        OBJECT_TYPE(obj) != TYPE_GARBAGE) {
         for (i = CONTENTS(obj), limit = db_top;
              OkObj(i) && --limit && LOCATION(i) == obj &&
-             Typeof(i) != TYPE_EXIT; i = NEXTOBJ(i)) ;
+             OBJECT_TYPE(i) != TYPE_EXIT; i = NEXTOBJ(i)) ;
 
         if (i != NOTHING) {
             if (!limit) {
@@ -600,7 +601,7 @@ check_contents_list(dbref player, dbref obj)
                 if (!OkObj(i)) {
                     violate(player, obj, "has an invalid object in its contents list");
                 } else {
-                    if (Typeof(i) == TYPE_EXIT) {
+                    if (OBJECT_TYPE(i) == TYPE_EXIT) {
                         violate(player, obj,
                             "has an exit in its contents list (it shouldn't)");
                     }
@@ -614,9 +615,9 @@ check_contents_list(dbref player, dbref obj)
         }
     } else {
         if (CONTENTS(obj) != NOTHING) {
-            if (Typeof(obj) == TYPE_EXIT) {
+            if (OBJECT_TYPE(obj) == TYPE_EXIT) {
                 violate(player, obj, "is an exit/action whose contents aren't #-1");
-            } else if (Typeof(obj) == TYPE_GARBAGE) {
+            } else if (OBJECT_TYPE(obj) == TYPE_GARBAGE) {
                 violate(player, obj, "is a garbage object whose contents aren't #-1");
             } else {
                 violate(player, obj, "is a program whose contents aren't #-1");
@@ -652,11 +653,11 @@ check_exits_list(dbref player, dbref obj)
     dbref i;
     int limit;
 
-    if (Typeof(obj) != TYPE_PROGRAM && Typeof(obj) != TYPE_EXIT &&
-        Typeof(obj) != TYPE_GARBAGE) {
+    if (OBJECT_TYPE(obj) != TYPE_PROGRAM && OBJECT_TYPE(obj) != TYPE_EXIT &&
+        OBJECT_TYPE(obj) != TYPE_GARBAGE) {
         for (i = EXITS(obj), limit = db_top;
              OkObj(i) && --limit && LOCATION(i) == obj &&
-             Typeof(i) == TYPE_EXIT; i = NEXTOBJ(i)) ;
+             OBJECT_TYPE(i) == TYPE_EXIT; i = NEXTOBJ(i)) ;
 
         if (i != NOTHING) {
             if (!limit) {
@@ -666,7 +667,7 @@ check_exits_list(dbref player, dbref obj)
             } else if (!OkObj(i)) {
                 violate(player, obj, "has an invalid object in its exits list");
             } else {
-                if (Typeof(i) != TYPE_EXIT) {
+                if (OBJECT_TYPE(i) != TYPE_EXIT) {
                     violate(player, obj, "has a non-exit in its exits list");
                 }
 
@@ -678,9 +679,9 @@ check_exits_list(dbref player, dbref obj)
         }
     } else {
         if (EXITS(obj) != NOTHING) {
-            if (Typeof(obj) == TYPE_EXIT) {
+            if (OBJECT_TYPE(obj) == TYPE_EXIT) {
                 violate(player, obj, "is an exit/action whose exits list isn't #-1");
-            } else if (Typeof(obj) == TYPE_GARBAGE) {
+            } else if (OBJECT_TYPE(obj) == TYPE_GARBAGE) {
                 violate(player, obj, "is a garbage object whose exits list isn't #-1");
             } else {
                 violate(player, obj, "is a program whose exits list isn't #-1");
@@ -730,15 +731,15 @@ check_object(dbref player, dbref obj)
     /*
      * Check the ownership
      */
-    if (Typeof(obj) != TYPE_GARBAGE) {
+    if (OBJECT_TYPE(obj) != TYPE_GARBAGE) {
         if (!OkObj(OWNER(obj))) {
             violate(player, obj, "has an invalid object as its owner.");
-        } else if (Typeof(OWNER(obj)) != TYPE_PLAYER) {
+        } else if (OBJECT_TYPE(OWNER(obj)) != TYPE_PLAYER) {
             violate(player, obj, "has a non-player object as its owner.");
         }
 
-        /* 
-         * check location 
+        /*
+         * check location
          */
         if (!OkObj(LOCATION(obj)) && !(obj == GLOBAL_ENVIRONMENT &&
             LOCATION(obj) == NOTHING)) {
@@ -747,18 +748,18 @@ check_object(dbref player, dbref obj)
     }
 
     if (LOCATION(obj) != NOTHING &&
-        (Typeof(LOCATION(obj)) == TYPE_GARBAGE ||
-         Typeof(LOCATION(obj)) == TYPE_EXIT ||
-         Typeof(LOCATION(obj)) == TYPE_PROGRAM))
+        (OBJECT_TYPE(LOCATION(obj)) == TYPE_GARBAGE ||
+         OBJECT_TYPE(LOCATION(obj)) == TYPE_EXIT ||
+         OBJECT_TYPE(LOCATION(obj)) == TYPE_PROGRAM))
         violate(player, obj, "thinks it is located in a non-container object");
 
-    if ((Typeof(obj) == TYPE_GARBAGE) && (LOCATION(obj) != NOTHING))
+    if ((OBJECT_TYPE(obj) == TYPE_GARBAGE) && (LOCATION(obj) != NOTHING))
         violate(player, obj, "is a garbage object with a location that isn't #-1");
 
     check_contents_list(player, obj);
     check_exits_list(player, obj);
 
-    switch (Typeof(obj)) {
+    switch (OBJECT_TYPE(obj)) {
         case TYPE_ROOM:
             check_room(player, obj);
             break;
@@ -854,11 +855,11 @@ san_fixed_log(const char *format, int unparse, dbref ref1, dbref ref2)
 
     if (unparse) {
         if (ref1 >= 0) {
-            unparse_object(NOTHING, ref1, buf1, sizeof(buf1));
+            flag_unparse_object(NOTHING, ref1, buf1, sizeof(buf1));
         }
 
         if (ref2 >= 0) {
-            unparse_object(NOTHING, ref2, buf2, sizeof(buf2));
+            flag_unparse_object(NOTHING, ref2, buf2, sizeof(buf2));
         }
 
         log_sanfix(format, buf1, buf2);
@@ -905,7 +906,7 @@ cut_bad_recyclable(void)
     prev = NOTHING;
 
     while (loop != NOTHING) {
-        if (!OkRef(loop) || Typeof(loop) != TYPE_GARBAGE ||
+        if (!OkRef(loop) || OBJECT_TYPE(loop) != TYPE_GARBAGE ||
             FLAGS(loop) & SANEBIT) {
             SanFixed(loop, "Recyclable object %s is not TYPE_GARBAGE");
 
@@ -952,10 +953,10 @@ cut_bad_contents(dbref obj)
 
     while (loop != NOTHING) {
         if (!OkObj(loop) || FLAGS(loop) & SANEBIT ||
-            Typeof(loop) == TYPE_EXIT || LOCATION(loop) != obj || loop == obj) {
+            OBJECT_TYPE(loop) == TYPE_EXIT || LOCATION(loop) != obj || loop == obj) {
             if (!OkObj(loop)) {
                 SanFixed(obj, "Contents chain for %s cut at invalid dbref");
-            } else if (Typeof(loop) == TYPE_EXIT) {
+            } else if (OBJECT_TYPE(loop) == TYPE_EXIT) {
                 SanFixed2(obj, loop, "Contents chain for %s cut at exit %s");
             } else if (loop == obj) {
                 SanFixed(obj, "Contents chain for %s cut at self-reference");
@@ -1010,10 +1011,10 @@ cut_bad_exits(dbref obj)
 
     while (loop != NOTHING) {
         if (!OkObj(loop) || FLAGS(loop) & SANEBIT ||
-            Typeof(loop) != TYPE_EXIT || LOCATION(loop) != obj) {
+            OBJECT_TYPE(loop) != TYPE_EXIT || LOCATION(loop) != obj) {
             if (!OkObj(loop)) {
                 SanFixed(obj, "Exits chain for %s cut at invalid dbref");
-            } else if (Typeof(loop) != TYPE_EXIT) {
+            } else if (OBJECT_TYPE(loop) != TYPE_EXIT) {
                 SanFixed2(obj, loop, "Exits chain for %s cut at non-exit %s");
             } else if (LOCATION(loop) != obj) {
                 SanFixed2(obj, loop, "Exits chain for %s cut at misplaced exit %s");
@@ -1061,8 +1062,8 @@ hacksaw_bad_chains(void)
     cut_bad_recyclable();
 
     for (dbref loop = 0; loop < db_top; loop++) {
-        if (Typeof(loop) != TYPE_ROOM && Typeof(loop) != TYPE_THING &&
-            Typeof(loop) != TYPE_PLAYER) {
+        if (OBJECT_TYPE(loop) != TYPE_ROOM && OBJECT_TYPE(loop) != TYPE_THING &&
+            OBJECT_TYPE(loop) != TYPE_PLAYER) {
             cut_all_chains(loop);
         } else {
             cut_bad_contents(loop);
@@ -1136,7 +1137,7 @@ create_lostandfound(dbref * player, dbref * room)
     }
 
     if (strlen(player_name) >= (unsigned int)tp_player_name_limit) {
-        unparse_object(NOTHING, GOD, unparse_buf, sizeof(unparse_buf));
+        flag_unparse_object(NOTHING, GOD, unparse_buf, sizeof(unparse_buf));
         log_sanfix("WARNING: Unable to get lost+found player, using %s", unparse_buf);
         *player = GOD;
     } else {
@@ -1158,7 +1159,7 @@ create_lostandfound(dbref * player, dbref * room)
         PUSH(*player, CONTENTS(*room));
         DBDIRTY(*player);
         add_player(*player);
-        unparse_object(NOTHING, *player, unparse_buf, sizeof(unparse_buf));
+        flag_unparse_object(NOTHING, *player, unparse_buf, sizeof(unparse_buf));
         log_sanfix("Using %s (with password %s) to resolve unknown owner",
                    unparse_buf, rpass);
     }
@@ -1190,7 +1191,7 @@ fix_room(dbref obj)
         SanFixed(obj, "Removing invalid drop-to from %s");
         DBFETCH(obj)->sp.room.dropto = NOTHING;
         DBDIRTY(obj);
-    } else if (i >= 0 && Typeof(i) != TYPE_THING && Typeof(i) != TYPE_ROOM) {
+    } else if (i >= 0 && OBJECT_TYPE(i) != TYPE_THING && OBJECT_TYPE(i) != TYPE_ROOM) {
         SanFixed2(obj, i, "Removing drop-to on %s to %s");
         DBFETCH(obj)->sp.room.dropto = NOTHING;
         DBDIRTY(obj);
@@ -1212,8 +1213,8 @@ fix_thing(dbref obj)
 
     i = THING_HOME(obj);
 
-    if (!OkObj(i) || (Typeof(i) != TYPE_ROOM && Typeof(i) != TYPE_THING &&
-        Typeof(i) != TYPE_PLAYER)) {
+    if (!OkObj(i) || (OBJECT_TYPE(i) != TYPE_ROOM && OBJECT_TYPE(i) != TYPE_THING &&
+        OBJECT_TYPE(i) != TYPE_PLAYER)) {
         SanFixed2(obj, OWNER(obj), "Setting the home on %s to %s, its owner");
         THING_SET_HOME(obj, OWNER(obj));
         DBDIRTY(obj);
@@ -1262,7 +1263,7 @@ fix_player(dbref obj)
 
     i = PLAYER_HOME(obj);
 
-    if (!OkObj(i) || Typeof(i) != TYPE_ROOM) {
+    if (!OkObj(i) || OBJECT_TYPE(i) != TYPE_ROOM) {
         SanFixed2(obj, tp_player_start, "Setting the home on %s to %s");
         PLAYER_SET_HOME(obj, tp_player_start);
         DBDIRTY(obj);
@@ -1296,18 +1297,18 @@ find_misplaced_objects(void)
     dbref player = NOTHING, room = NOTHING;
 
     for (dbref loop = 0; loop < db_top; loop++) {
-        if (Typeof(loop) != TYPE_ROOM &&
-            Typeof(loop) != TYPE_THING &&
-            Typeof(loop) != TYPE_PLAYER &&
-            Typeof(loop) != TYPE_EXIT &&
-            Typeof(loop) != TYPE_PROGRAM && Typeof(loop) != TYPE_GARBAGE) {
+        if (OBJECT_TYPE(loop) != TYPE_ROOM &&
+            OBJECT_TYPE(loop) != TYPE_THING &&
+            OBJECT_TYPE(loop) != TYPE_PLAYER &&
+            OBJECT_TYPE(loop) != TYPE_EXIT &&
+            OBJECT_TYPE(loop) != TYPE_PROGRAM && OBJECT_TYPE(loop) != TYPE_GARBAGE) {
             SanFixedRef(loop, "Object #%d is of unknown type");
             sanity_violated = 1;
             continue;
         }
 
         if (!NAME(loop) || !(*NAME(loop))) {
-            switch Typeof(loop) {
+            switch OBJECT_TYPE(loop) {
                 case TYPE_GARBAGE:
                     NAME(loop) = "<garbage>";
                     break;
@@ -1338,9 +1339,9 @@ find_misplaced_objects(void)
             DBDIRTY(loop);
         }
 
-        if (Typeof(loop) != TYPE_GARBAGE) {
+        if (OBJECT_TYPE(loop) != TYPE_GARBAGE) {
             /* Check ownership issues */
-            if (!OkObj(OWNER(loop)) || Typeof(OWNER(loop)) != TYPE_PLAYER) {
+            if (!OkObj(OWNER(loop)) || OBJECT_TYPE(OWNER(loop)) != TYPE_PLAYER) {
                 if (player == NOTHING) {
                     create_lostandfound(&player, &room);
                 }
@@ -1352,14 +1353,14 @@ find_misplaced_objects(void)
 
             /* Check for invalid location */
             if (loop != GLOBAL_ENVIRONMENT && (!OkObj(LOCATION(loop)) ||
-                Typeof(LOCATION(loop)) == TYPE_GARBAGE ||
-                Typeof(LOCATION(loop)) == TYPE_EXIT ||
-                Typeof(LOCATION(loop)) == TYPE_PROGRAM ||
-                (Typeof(loop) == TYPE_PLAYER &&
-                 Typeof(LOCATION(loop)) == TYPE_PLAYER))) {
-                if (Typeof(loop) == TYPE_PLAYER) {
+                OBJECT_TYPE(LOCATION(loop)) == TYPE_GARBAGE ||
+                OBJECT_TYPE(LOCATION(loop)) == TYPE_EXIT ||
+                OBJECT_TYPE(LOCATION(loop)) == TYPE_PROGRAM ||
+                (OBJECT_TYPE(loop) == TYPE_PLAYER &&
+                 OBJECT_TYPE(LOCATION(loop)) == TYPE_PLAYER))) {
+                if (OBJECT_TYPE(loop) == TYPE_PLAYER) {
                     /* Players cannot contain players. */
-                    if (OkObj(LOCATION(loop)) && Typeof(LOCATION(loop)) == TYPE_PLAYER) {
+                    if (OkObj(LOCATION(loop)) && OBJECT_TYPE(LOCATION(loop)) == TYPE_PLAYER) {
                         dbref loop1;
 
                         loop1 = LOCATION(loop);
@@ -1401,7 +1402,7 @@ find_misplaced_objects(void)
                 DBDIRTY(loop);
                 DBDIRTY(LOCATION(loop));
 
-                if (Typeof(loop) == TYPE_EXIT) {
+                if (OBJECT_TYPE(loop) == TYPE_EXIT) {
                     PUSH(loop, EXITS(LOCATION(loop)));
                 } else {
                     PUSH(loop, CONTENTS(LOCATION(loop)));
@@ -1425,7 +1426,7 @@ find_misplaced_objects(void)
         }
 
         /* Run individual fix routine */
-        switch (Typeof(loop)) {
+        switch (OBJECT_TYPE(loop)) {
             case TYPE_ROOM:
                 fix_room(loop);
                 break;
@@ -1467,7 +1468,7 @@ adopt_orphans(void)
         if (!(FLAGS(loop) & SANEBIT)) {
             DBDIRTY(loop);
 
-            switch (Typeof(loop)) {
+            switch (OBJECT_TYPE(loop)) {
                 case TYPE_ROOM:
                 case TYPE_THING:
                 case TYPE_PLAYER:
@@ -1546,7 +1547,7 @@ do_sanfix(dbref player)
 
     FLAGS(GLOBAL_ENVIRONMENT) |= SANEBIT;
 
-    if (!OkObj(tp_player_start) || Typeof(tp_player_start) != TYPE_ROOM) {
+    if (!OkObj(tp_player_start) || OBJECT_TYPE(tp_player_start) != TYPE_ROOM) {
         SanFixed(GLOBAL_ENVIRONMENT, "Reset invalid player_start to %s");
         tp_player_start = GLOBAL_ENVIRONMENT;
     }
@@ -1657,35 +1658,35 @@ do_sanchange(dbref player, const char *command)
         return;
     }
 
-    unparse_object(NOTHING, v, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(NOTHING, v, unparse_buf, sizeof(unparse_buf));
 
     if (!strcasecmp(field, "next")) {
-        unparse_object(NOTHING, NEXTOBJ(d), buf2, sizeof(buf2));
+        flag_unparse_object(NOTHING, NEXTOBJ(d), buf2, sizeof(buf2));
         NEXTOBJ(d) = v;
         DBDIRTY(d);
         SanPrint(player, "## Setting #%d's next field to %s", d, unparse_buf);
     } else if (!strcasecmp(field, "exits")) {
-        unparse_object(NOTHING, EXITS(d), buf2, sizeof(buf2));
+        flag_unparse_object(NOTHING, EXITS(d), buf2, sizeof(buf2));
         EXITS(d) = v;
         DBDIRTY(d);
         SanPrint(player, "## Setting #%d's next field to %s", d, unparse_buf);
     } else if (!strcasecmp(field, "contents")) {
-        unparse_object(NOTHING, CONTENTS(d), buf2, sizeof(buf2));
+        flag_unparse_object(NOTHING, CONTENTS(d), buf2, sizeof(buf2));
         CONTENTS(d) = v;
         DBDIRTY(d);
         SanPrint(player, "## Setting #%d's Contents list start to %s", d, unparse_buf);
     } else if (!strcasecmp(field, "location")) {
-        unparse_object(NOTHING, LOCATION(d), buf2, sizeof(buf2));
+        flag_unparse_object(NOTHING, LOCATION(d), buf2, sizeof(buf2));
         LOCATION(d) = v;
         DBDIRTY(d);
         SanPrint(player, "## Setting #%d's location to %s", d, unparse_buf);
     } else if (!strcasecmp(field, "owner")) {
-        unparse_object(NOTHING, OWNER(d), buf2, sizeof(buf2));
+        flag_unparse_object(NOTHING, OWNER(d), buf2, sizeof(buf2));
         OWNER(d) = v;
         DBDIRTY(d);
         SanPrint(player, "## Setting #%d's owner to %s", d, unparse_buf);
     } else if (!strcasecmp(field, "home")) {
-        switch (Typeof(d)) {
+        switch (OBJECT_TYPE(d)) {
             case TYPE_PLAYER:
                 ip = &(PLAYER_HOME(d));
                 break;
@@ -1698,7 +1699,7 @@ do_sanchange(dbref player, const char *command)
                 return;
         }
 
-        unparse_object(NOTHING, *ip, buf2, sizeof(buf2));
+        flag_unparse_object(NOTHING, *ip, buf2, sizeof(buf2));
         *ip = v;
         DBDIRTY(d);
         SanPrint(player, "## Setting #%d's home to: %s\n", d, unparse_buf);
@@ -1903,6 +1904,22 @@ extract_program(FILE * f, dbref obj)
 }
 
 /**
+ * Helper for unparsing objects.
+ * Uses a static buffer for internal use within this module.
+ *
+ * @private
+ * @param d the object to unparse
+ * @return the unparsed object
+ */
+static const char *
+_extract_object_unparse(dbref d)
+{
+    static char buf[BUFFER_LEN];
+    flag_unparse_object(NOTHING, d, buf, sizeof(buf));
+    return buf;
+}
+
+/**
  * Extract object information to a file
  *
  * This dumps object information to a file handle, including all
@@ -1915,41 +1932,31 @@ extract_program(FILE * f, dbref obj)
 static void
 extract_object(FILE * f, dbref d)
 {
-    char unparse_buf[1024];
-    /* @TODO This is kind of a "gross" way to do this in my opinion ...
-     *       a local define just for this little block.
-     *
-     *       I would make this a static function that 'owns'
-     *       unparse_buf as a static buffer and returns the pointer to
-     *       it instead of using precompiler tomfoolery.  It will
-     *       look rather nicer I think.
-     */
-#define unparse(x) (unparse_object(NOTHING, (x), unparse_buf, sizeof(unparse_buf)), unparse_buf)
     fprintf(f, "  #%d\n", d);
-    fprintf(f, "  Object:         %s\n", unparse(d));
-    fprintf(f, "  Owner:          %s\n", unparse(OWNER(d)));
-    fprintf(f, "  Location:       %s\n", unparse(LOCATION(d)));
-    fprintf(f, "  Contents Start: %s\n", unparse(CONTENTS(d)));
-    fprintf(f, "  Exits Start:    %s\n", unparse(EXITS(d)));
-    fprintf(f, "  Next:           %s\n", unparse(NEXTOBJ(d)));
+    fprintf(f, "  Object:         %s\n", _extract_object_unparse(d));
+    fprintf(f, "  Owner:          %s\n", _extract_object_unparse(OWNER(d)));
+    fprintf(f, "  Location:       %s\n", _extract_object_unparse(LOCATION(d)));
+    fprintf(f, "  Contents Start: %s\n", _extract_object_unparse(CONTENTS(d)));
+    fprintf(f, "  Exits Start:    %s\n", _extract_object_unparse(EXITS(d)));
+    fprintf(f, "  Next:           %s\n", _extract_object_unparse(NEXTOBJ(d)));
 
-    switch (Typeof(d)) {
+    switch (OBJECT_TYPE(d)) {
         case TYPE_THING:
-            fprintf(f, "  Home:           %s\n", unparse(THING_HOME(d)));
+            fprintf(f, "  Home:           %s\n", _extract_object_unparse(THING_HOME(d)));
             fprintf(f, "  Value:          %d\n", GETVALUE(d));
             break;
         case TYPE_ROOM:
-            fprintf(f, "  Drop-to:        %s\n", unparse(DBFETCH(d)->sp.room.dropto));
+            fprintf(f, "  Drop-to:        %s\n", _extract_object_unparse(DBFETCH(d)->sp.room.dropto));
             break;
         case TYPE_PLAYER:
-            fprintf(f, "  Home:           %s\n", unparse(PLAYER_HOME(d)));
+            fprintf(f, "  Home:           %s\n", _extract_object_unparse(PLAYER_HOME(d)));
             fprintf(f, "  Pennies:        %d\n", GETVALUE(d));
             break;
         case TYPE_EXIT:
             fprintf(f, "  Links:         ");
 
             for (int i = 0; i < DBFETCH(d)->sp.exit.ndest; i++)
-                fprintf(f, " %s;", unparse(DBFETCH(d)->sp.exit.dest[i]));
+                fprintf(f, " %s;", _extract_object_unparse(DBFETCH(d)->sp.exit.dest[i]));
 
             fprintf(f, "\n");
 
@@ -1962,7 +1969,6 @@ extract_object(FILE * f, dbref d)
         default:
             break;
     }
-#undef unparse
 
 #ifdef DISKBASE
     fetchprops(d, NULL);
@@ -2016,7 +2022,7 @@ extract(void)
     }
 
     for (i = 0; i < db_top; i++) {
-        if ((OWNER(i) == d) && (Typeof(i) != TYPE_GARBAGE)) {
+        if ((OWNER(i) == d) && (OBJECT_TYPE(i) != TYPE_GARBAGE)) {
             extract_object(f, i);
         }   /* extract only objects owned by this player */
     }   /* loop through db */
@@ -2065,7 +2071,7 @@ extract_single(void)
         f = stdout;
     }
 
-    if (Typeof(d) != TYPE_GARBAGE) {
+    if (OBJECT_TYPE(d) != TYPE_GARBAGE) {
         extract_object(f, d);
     }
 
@@ -2175,11 +2181,11 @@ san_main(void)
     printf("Good luck!\n\n");
 
     printf("Number of objects in DB is: %d\n", db_top - 1);
-    unparse_object(NOTHING, GLOBAL_ENVIRONMENT, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(NOTHING, GLOBAL_ENVIRONMENT, unparse_buf, sizeof(unparse_buf));
     printf("Global Environment is: %s\n", unparse_buf);
 
 #ifdef GOD_PRIV
-    unparse_object(NOTHING, GOD, unparse_buf, sizeof(unparse_buf));
+    flag_unparse_object(NOTHING, GOD, unparse_buf, sizeof(unparse_buf));
     printf("God is: %s\n", unparse_buf);
     printf("\n");
 #endif

--- a/src/set.c
+++ b/src/set.c
@@ -18,6 +18,7 @@
 #include "db.h"
 #include "fbstrings.h"
 #include "fbtime.h"
+#include "flags.h"
 #include "game.h"
 #include "interface.h"
 #include "log.h"
@@ -59,7 +60,7 @@ do_name(int descr, dbref player, const char *name, char *newname)
     }
 
     /* check for renaming a player */
-    if (Typeof(thing) == TYPE_PLAYER) {
+    if (OBJECT_TYPE(thing) == TYPE_PLAYER) {
         /* split off password */
         for (password = newname; *password && !isspace(*password); password++) ;
 
@@ -94,7 +95,7 @@ do_name(int descr, dbref player, const char *name, char *newname)
         notify(player, "Name set.");
         return;
     } else {
-        if (!ok_object_name(newname, Typeof(thing))) {
+        if (!ok_object_name(newname, OBJECT_TYPE(thing))) {
             notify(player, "That is not a reasonable name.");
             return;
         }
@@ -148,7 +149,7 @@ _do_unlink(int descr, dbref player, const char *name, bool quiet)
     if (!controls(player, exit) && !controls_link(player, exit)) {
         notify(player, "Permission denied. (You don't control the exit or its link)");
     } else {
-        switch (Typeof(exit)) {
+        switch (OBJECT_TYPE(exit)) {
             case TYPE_EXIT:
                 if (DBFETCH(exit)->sp.exit.ndest != 0) {
                     SETVALUE(OWNER(exit), GETVALUE(OWNER(exit)) + tp_link_cost);
@@ -164,7 +165,7 @@ _do_unlink(int descr, dbref player, const char *name, bool quiet)
                 if (!quiet)
                     notify(player, "Unlinked.");
 
-                if (MLevRaw(exit)) {
+                if (OBJECT_MLEVEL(exit)) {
                     SetMLevel(exit, 0);
                     DBDIRTY(exit);
 
@@ -276,7 +277,7 @@ do_relink(int descr, dbref player, const char *thing_name,
     if ((thing = noisy_match_result(&md)) == NOTHING)
         return;
 
-    if (Typeof(thing) != TYPE_EXIT && strchr(dest_name, EXIT_DELIMITER)) {
+    if (OBJECT_TYPE(thing) != TYPE_EXIT && strchr(dest_name, EXIT_DELIMITER)) {
         notify(player, "Only actions and exits can be linked to multiple destinations.");
         return;
     }
@@ -284,7 +285,7 @@ do_relink(int descr, dbref player, const char *thing_name,
     /* first of all, check if the new target would be valid, so we can
        avoid breaking the old link if it isn't. */
 
-    switch (Typeof(thing)) {
+    switch (OBJECT_TYPE(thing)) {
         case TYPE_EXIT:
             /* we're ok, check the usual stuff */
             if (DBFETCH(thing)->sp.exit.ndest != 0) {
@@ -327,14 +328,14 @@ do_relink(int descr, dbref player, const char *thing_name,
             match_me(&md);
             match_here(&md);
 
-            if (Typeof(thing) == TYPE_THING)
+            if (OBJECT_TYPE(thing) == TYPE_THING)
                 match_possession(&md);
 
             if ((dest = noisy_match_result(&md)) == NOTHING)
                 return;
 
             if (!controls(player, thing)
-                || !can_link_to(player, Typeof(thing), dest)) {
+                || !can_link_to(player, OBJECT_TYPE(thing), dest)) {
                 notify(player, "Permission denied. (You can't link to where you want to.");
                 return;
             }
@@ -356,7 +357,7 @@ do_relink(int descr, dbref player, const char *thing_name,
             if ((dest = noisy_match_result(&md)) == NOTHING)
                 return;
 
-            if (!controls(player, thing) || !can_link_to(player, Typeof(thing), dest)
+            if (!controls(player, thing) || !can_link_to(player, OBJECT_TYPE(thing), dest)
                 || (thing == dest)) {
                 notify(player, "Permission denied. (You can't link to the dropto like that)");
                 return;
@@ -368,7 +369,7 @@ do_relink(int descr, dbref player, const char *thing_name,
             return;
         default:
             notify(player, "Internal error: weird object type.");
-            log_status("PANIC: weird object: Typeof(%d) = %d", thing, Typeof(thing));
+            log_status("PANIC: weird object: OBJECT_TYPE(%d) = %d", thing, OBJECT_TYPE(thing));
             return;
     }
 
@@ -406,7 +407,7 @@ do_chown(int descr, dbref player, const char *name, const char *newowner)
         return;
     }
 
-    init_match(descr, player, name, NOTYPE, &md);
+    init_match(descr, player, name, TYPE_ANY, &md);
     match_everything(&md);
 
     if ((thing = noisy_match_result(&md)) == NOTHING)
@@ -434,10 +435,10 @@ do_chown(int descr, dbref player, const char *name, const char *newowner)
 #endif      /* GOD_PRIV */
 
     if (!Wizard(OWNER(player))) {
-        if (Typeof(thing) != TYPE_EXIT ||
+        if (OBJECT_TYPE(thing) != TYPE_EXIT ||
             (DBFETCH(thing)->sp.exit.ndest && !controls_link(player, thing))) {
-            if (!(FLAGS(thing) & CHOWN_OK) ||
-                Typeof(thing) == TYPE_PROGRAM
+            if (!FLAG_CHECK(thing, 'C') ||
+                OBJECT_TYPE(thing) == TYPE_PROGRAM
                 || !test_lock(descr, player, thing, MESGPROP_CHLOCK)) {
                 notify(player, "You can't take possession of that.");
                 return;
@@ -446,7 +447,7 @@ do_chown(int descr, dbref player, const char *name, const char *newowner)
     }
 
     /* handle costs */
-    if (owner == player && Typeof(thing) == TYPE_EXIT && OWNER(thing) != OWNER(player)) {
+    if (owner == player && OBJECT_TYPE(thing) == TYPE_EXIT && OWNER(thing) != OWNER(player)) {
 	if (!Builder(player)) {
 	    notify(player, "Only authorized builders may seize exits.");
 	    return;
@@ -467,12 +468,12 @@ do_chown(int descr, dbref player, const char *name, const char *newowner)
     }
 
     if (tp_realms_control && !Wizard(OWNER(player)) && TrueWizard(thing) &&
-        Typeof(thing) == TYPE_ROOM) {
+        OBJECT_TYPE(thing) == TYPE_ROOM) {
         notify(player, "You can't take possession of that.");
         return;
     }
 
-    switch (Typeof(thing)) {
+    switch (OBJECT_TYPE(thing)) {
         case TYPE_ROOM:
             if (!Wizard(OWNER(player)) && LOCATION(player) != thing) {
                 notify(player, "You can only chown \"here\".");
@@ -508,215 +509,11 @@ do_chown(int descr, dbref player, const char *name, const char *newowner)
         notify(player, "Owner changed to you.");
     else {
         char unparse_buf[BUFFER_LEN];
-        unparse_object(player, owner, unparse_buf, sizeof(unparse_buf));
+        flag_unparse_object(player, owner, unparse_buf, sizeof(unparse_buf));
         notifyf(player, "Owner changed to %s.", unparse_buf);
     }
 
     DBDIRTY(thing);
-}
-
-/**
- * Determines if a given player is unable to (re)set the given flag
- *
- * The 'business logic' here is actually fairly dense and not easily
- * summed up in a comment. The reader is encouraged to review the very
- * well documented code for details.
- *
- * This is all pretty well documented in the MUCK's help files.
- *
- * Uses an error parameter to communicate the reason for failure. This
- * should be at least SMALL_BUFFER_LEN in size.
- *
- * @private
- * @param player the effective aplayer we are checking permissions for
- * @param mlev the effective mucker level we are checking permissions for
- * @param thing the thing we want to interact with
- * @param flag the flag we wish to interact with
- * @param value whether the desired state is on or off
- * @param error[out] error message, if any
- * @return boolean 1 if restricted from setting flag, 0 if okay to set.
- */
-int
-unable_to_set_flag(dbref player, int mlev, dbref thing, object_flag_type flag, bool value, char *error)
-{
-    if (force_level && (
-            flag == WIZARD
-            || (flag == XFORCIBLE && Typeof(thing) != TYPE_EXIT)
-            || (flag & MUCKER)
-            || (flag & SMUCKER)
-    )) {
-        snprintf(error, SMALL_BUFFER_LEN, "That flag cannot be forced.");
-        return 1;
-    }
-
-    /* Non-wizards can only set their own programs M0. */
-    if (!value && (flag & (MUCKER | SMUCKER))) {
-        if (!Wizard(OWNER(player))) {
-            if ((OWNER(player) != OWNER(thing)) || (Typeof(thing) != TYPE_PROGRAM)) {
-                snprintf(error, SMALL_BUFFER_LEN, "Permission denied. (You can't set that M0)");
-                return 1;
-            }
-        }
-
-        return 0;
-    }
-
-    /* Non-wizards can only set their programs up to their own mucker level. */
-    if (flag & (MUCKER | SMUCKER)) {
-        unsigned short requested_mlevel = (((flag & MUCKER ? 2 : 0) + (flag & SMUCKER ? 1 : 0)));
-        if (!Wizard(OWNER(player))) {
-            if ((OWNER(player) != OWNER(thing)) || (Typeof(thing) != TYPE_PROGRAM)
-                || (MLevRaw(player) < requested_mlevel)) {
-                snprintf(error, SMALL_BUFFER_LEN, "Permission denied. (You can't set that M%d)", requested_mlevel);
-                return 1;
-            }
-        }
-
-        return 0;
-    }
-
-    switch (flag) {
-        case ABODE:
-            /* Trying to set a program AUTOSTART requires TrueWizard */
-            return (!TrueWizard(OWNER(player)) && (Typeof(thing) == TYPE_PROGRAM));
-
-        case GUEST:
-            /* Guest operations require a wizard */
-            return (!(Wizard(OWNER(player))));
-
-        case YIELD:
-        case OVERT:
-            /* Mucking with the env-chain matching requires TrueWizard */
-            if (!(Wizard(OWNER(player)))) {
-                return 1;
-            }
-
-            /* ...and only for makes sense for things or rooms. */
-            if (Typeof(thing) != TYPE_THING && Typeof(thing) != TYPE_ROOM) {
-                return 1;
-            }
-
-            return 0;
-
-        case ZOMBIE:
-            /* Restricting a player from using zombies requires a wizard. */
-            if (Typeof(thing) == TYPE_PLAYER) {
-                return (!(Wizard(OWNER(player))));
-            }
-
-            /* If a player's set Zombie, he's restricted from using them...
-             * unless he's a wizard, in which case he can do whatever.
-             */
-            if ((Typeof(thing) == TYPE_THING) && (FLAGS(OWNER(player)) & ZOMBIE)) {
-                return (!(Wizard(OWNER(player))));
-            }
-
-            return 0;
-
-        case VEHICLE:
-            /* Restricting a player from using vehicles requires a wizard. */
-            if (Typeof(thing) == TYPE_PLAYER){
-                return (!(Wizard(OWNER(player))));
-            }
-
-            /* Can only set things !V if they have no players in them. */
-            if (!value && Typeof(thing) == TYPE_THING) {
-                dbref obj = CONTENTS(thing);
-
-                for (; obj != NOTHING; obj = NEXTOBJ(obj)) {
-                    if (Typeof(obj) == TYPE_PLAYER) {
-                        snprintf(error, SMALL_BUFFER_LEN, "That vehicle still has players in it!");
-                        return 1;
-                    }
-                }
-            }
-
-            /* If only wizards can create vehicles... */
-            if (tp_wiz_vehicles) {
-                /* then only a wizard can create a vehicle. :) */
-                if (Typeof(thing) == TYPE_THING) {
-                    return (!(Wizard(OWNER(player))));
-                }
-            } else {
-                /* But, if vehicles aren't restricted to wizards, then
-                 * players who have not been restricted can do so
-                 */
-                if ((Typeof(thing) == TYPE_THING) && (FLAGS(player) & VEHICLE)) {
-                    return (!(Wizard(OWNER(player))));
-                }
-            }
-
-            return (0);
-
-        case DARK:
-            /* Dark can be set on a Program or Room by anyone. */
-            if (!Wizard(OWNER(player))) {
-                /* Setting a player dark requires a wizard. */
-                if (Typeof(thing) == TYPE_PLAYER) {
-                    return 1;
-                }
-
-                /* If exit darking is restricted, it requires a wizard. */
-                if (!tp_exit_darking && Typeof(thing) == TYPE_EXIT) {
-                    return 1;
-                }
-
-                /* If thing darking is restricted, it requires a wizard. */
-                if (!tp_thing_darking && Typeof(thing) == TYPE_THING) {
-                    return 1;
-                }
-            }
-
-            return 0;
-
-        case QUELL:
-#ifdef GOD_PRIV
-            /* Only God (or God's stuff) can quell or unquell another wizard. */
-            return (TrueWizard(thing) && (thing != player) && !God(OWNER(player)) &&
-                    (Typeof(thing) == TYPE_PLAYER));
-#else
-            /* You cannot quell or unquell another wizard. */
-            return (TrueWizard(thing) && (thing != player) && (Typeof(thing) == TYPE_PLAYER));
-#endif
-
-        case BUILDER:
-            /* Setting a program BOUND reguires M2. */
-            if (Typeof(thing) == TYPE_PROGRAM) {
-                return (mlev < 2);
-            }
-
-            /* Setting a player Builder or a room Bound is limited to a Wizard. */
-            return (!Wizard(OWNER(player)));
-
-        case WIZARD:
-            /* To do anything with a Wizard flag requires a Wizard. */
-            if (Wizard(OWNER(player))) {
-                /* check for stupid wizard */
-                if (!value && thing == player) {
-                    snprintf(error, SMALL_BUFFER_LEN, "You cannot make yourself mortal.");
-                    return 1;
-                }
-
-#ifdef GOD_PRIV
-                /* Only God can make a player a Wizard, or re-mort one. */
-                return ((Typeof(thing) == TYPE_PLAYER) && !God(player));
-#else
-                /* We don't want someone setting themselves !W, to prevent
-                 * a case where there are no wizards at all
-                 */
-                return ((Typeof(thing) == TYPE_PLAYER && thing == OWNER(player)));
-#endif
-            } else {
-                return 1;
-            }
-
-        case XFORCIBLE:
-            return (!Wizard(OWNER(player)) && Typeof(thing) == TYPE_EXIT);
-
-        default:
-            /* No other flags are restricted. */
-            return 0;
-    }
 }
 
 /**
@@ -882,7 +679,7 @@ do_set(int descr, dbref player, const char *name, const char *flag)
         }
     }
 
-    if (unable_to_set_flag(player, MLevel(OWNER(player)), thing, f, !negated, error)) {
+    if (unable_to_set_flag(player, OBJECT_EFFECTIVE_MLEVEL(OWNER(player)), thing, f, !negated, error)) {
         if (*error) {
             notify(player, error);
         } else {
@@ -1006,7 +803,7 @@ do_propset(int descr, dbref player, const char *name, const char *prop)
         mydat.data.fval = strtod(value, NULL);
         set_property(thing, pname, &mydat);
     } else if (string_prefix("dbref", type)) {
-        init_match(descr, player, value, NOTYPE, &md);
+        init_match(descr, player, value, TYPE_ANY, &md);
         match_everything(&md);
 
         if ((ref = noisy_match_result(&md)) == NOTHING)
@@ -1081,7 +878,7 @@ do_register(int descr, dbref player, char *arg1, const char *arg2)
 {
     dbref target, object;
     struct match_data md;
-    char buf[BUFFER_LEN], unparse_buf[BUFFER_LEN];
+    char buf[BUFFER_LEN*2+64], unparse_buf[BUFFER_LEN];
     char *propdir, *objectstr;
     char *remaining = arg1;
 
@@ -1119,7 +916,7 @@ do_register(int descr, dbref player, char *arg1, const char *arg2)
             return;
         }
 
-        init_match(descr, player, targetstr, NOTYPE, &md);
+        init_match(descr, player, targetstr, TYPE_ANY, &md);
 
         if (*targetstr == REGISTERED_TOKEN) {
             match_registered(&md);
@@ -1153,7 +950,7 @@ do_register(int descr, dbref player, char *arg1, const char *arg2)
 
     if (!*arg2) {
         PropPtr propadr, pptr;
-        char dir[BUFFER_LEN], propname[BUFFER_LEN], detail[BUFFER_LEN];
+        char dir[BUFFER_LEN+64], propname[BUFFER_LEN], detail[BUFFER_LEN+128];
         dbref detailref = -50, invalidref = -50;
 
         if (!objectstr || !*objectstr) {
@@ -1162,7 +959,7 @@ do_register(int descr, dbref player, char *arg1, const char *arg2)
             snprintf(dir, sizeof(dir), "%s%c%s", propdir, PROPDIR_DELIMITER, objectstr);
         }
 
-        unparse_object(player, target, unparse_buf, sizeof(unparse_buf));
+        flag_unparse_object(player, target, unparse_buf, sizeof(unparse_buf));
         notifyf_nolisten(player, "Registered objects on %s:", unparse_buf);
 
         propadr = first_prop(target, dir, &pptr, propname, sizeof(propname));
@@ -1199,7 +996,7 @@ do_register(int descr, dbref player, char *arg1, const char *arg2)
                 }
 
                 if (PropType(propadr) != PROP_DIRTYP) {
-                    unparse_object(player, detailref, unparse_buf, sizeof(unparse_buf));
+                    flag_unparse_object(player, detailref, unparse_buf, sizeof(unparse_buf));
                     snprintf(detail, sizeof(detail), ": %s", unparse_buf);
                 }
 
@@ -1227,7 +1024,7 @@ do_register(int descr, dbref player, char *arg1, const char *arg2)
         return;
     }
 
-    init_match(descr, player, objectstr, NOTYPE, &md);
+    init_match(descr, player, objectstr, TYPE_ANY, &md);
 
     if (*objectstr == REGISTERED_TOKEN) {
         match_registered(&md);
@@ -1251,7 +1048,7 @@ do_register(int descr, dbref player, char *arg1, const char *arg2)
 
     snprintf(buf, sizeof(buf), "%s%c%s", propdir, PROPDIR_DELIMITER, arg2);
 
-    if ((!Wizard(OWNER(player)) && (target != OWNER(player) || 
+    if ((!Wizard(OWNER(player)) && (target != OWNER(player) ||
         Prop_SeeOnly(buf) || Prop_Hidden(buf)))) {
         notifyf_nolisten(player, "Permission denied. (You can't register an object there.)");
         return;

--- a/src/smtp.c
+++ b/src/smtp.c
@@ -409,7 +409,7 @@ smtp_str_getdelimfd_read(struct str_getdelimfd *const gdfd, void *buf,
            * so we can safely convert this to an int.
            */
           bytes_read = SSL_read(smtp->tls, buf, (int)count);
-        } while(bytes_read <= 0 && BIO_should_retry(smtp->tls_bio));
+        } while (bytes_read <= 0 && BIO_should_retry(smtp->tls_bio));
 #endif /* SMTP_OPENSSL */
     } else {
         bytes_read = recv(smtp->sock, buf, count, 0);
@@ -446,7 +446,7 @@ smtp_str_getdelimfd_search_delim(const char *const buf,
 
     *delim_pos = 0;
 
-    for(i = 0; i < buf_len; i++) {
+    for (i = 0; i < buf_len; i++) {
         if (buf[i] == delim) {
             *delim_pos = i;
             return 1;
@@ -553,7 +553,7 @@ smtp_str_getdelimfd(struct str_getdelimfd *const gdfd)
 
     bytes_read = -1;
 
-    while(1) {
+    while (1) {
         if (smtp_str_getdelimfd_search_delim(gdfd->_buf,
                                             gdfd->_buf_len,
                                             gdfd->delim,
@@ -630,7 +630,7 @@ smtp_stpcpy(char *s1, const char *s2)
 
     do {
         s1[i] = s2[i];
-    } while(s2[i++] != '\0');
+    } while (s2[i++] != '\0');
 
     return &s1[i-1];
 }
@@ -742,7 +742,7 @@ smtp_str_replace(const char *const search, const char *const replace,
         return smtp_strdup(s);
     }
 
-    while(s[s_idx]) {
+    while (s[s_idx]) {
         if (smtp_si_add_size_t(snew_len, 1, &snew_len_inc) ||
            smtp_si_add_size_t(snew_sz, snew_sz, &snew_sz_dup) ||
            smtp_si_add_size_t(snew_sz, slen, &snew_sz_plus_slen)) {
@@ -837,7 +837,7 @@ smtp_base64_encode_block(const char *const buf, size_t buf_block_sz,
     in_idx[2] = ((inb[1] << 2) | ((inb[2] >> 6) & 0x3)) & 0x3F;
     in_idx[3] = ((inb[2]     ))                         & 0x3F;
 
-    for(i = 0; i < 4; i++) {
+    for (i = 0; i < 4; i++) {
         if (i < buf_block_sz + 1) {
             outb[i] = g_base64_encode_table[in_idx[i]];
         }
@@ -893,7 +893,7 @@ smtp_base64_encode(const char *const buf, size_t buflen) {
     b64_i = 0;
     remaining_block_sz = buflen;
 
-    while(remaining_block_sz > 0) {
+    while (remaining_block_sz > 0) {
         if (remaining_block_sz >= 3) {
             buf_block_sz = 3;
         } else {
@@ -967,7 +967,7 @@ smtp_base64_decode_block(const unsigned char *const buf,
 
     decode_block_len = 0;
 
-    for(i = 0; i < 4; i++) {
+    for (i = 0; i < 4; i++) {
         if (buf[i] == '=') {
             decode_table[i] = 0;
             continue;
@@ -1042,7 +1042,7 @@ smtp_base64_decode(const char *const buf, unsigned char **decode) {
 
     decode_len = 0;
 
-    for(buf_i = 0; buf_i < buf_len; buf_i += 4) {
+    for (buf_i = 0; buf_i < buf_len; buf_i += 4) {
         decode_block_len = smtp_base64_decode_block(
                              (const unsigned char*)&buf[buf_i],
                              &b64_decode[decode_len]);
@@ -1090,7 +1090,7 @@ smtp_bin2hex(const unsigned char *const s, size_t slen) {
 
     j = 0;
 
-    for(i = 0; i < slen; i++) {
+    for (i = 0; i < slen; i++) {
         hex = s[i];
         rc = sprintf(&snew[j], "%02x", hex);
 
@@ -1156,7 +1156,7 @@ smtp_str_has_nonascii_utf8(const char *const s)
     size_t i;
     size_t charlen;
 
-    for(i = 0; s[i]; i++) {
+    for (i = 0; s[i]; i++) {
         charlen = smtp_utf8_charlen(s[i]);
 
         if (charlen != 1) {
@@ -1188,14 +1188,14 @@ smtp_strnlen_utf8(const char *s, size_t maxlen)
     size_t utf8_i;
     size_t utf8_len;
 
-    for(i = 0; *s && i < maxlen; i += utf8_len) {
+    for (i = 0; *s && i < maxlen; i += utf8_len) {
         utf8_len = smtp_utf8_charlen(*s);
 
         if (utf8_len == 0) {
             return SIZE_MAX;
         }
 
-        for(utf8_i = 0; utf8_i < utf8_len; utf8_i++) {
+        for (utf8_i = 0; utf8_i < utf8_len; utf8_i++) {
             if (!*s) {
                 return SIZE_MAX;
             }
@@ -1234,15 +1234,15 @@ smtp_fold_whitespace_get_offset(const char *const s, unsigned int maxlen)
     i = 0;
     offset_i = 0;
 
-    while(s[i] == ' ' || s[i] == '\t') {
+    while (s[i] == ' ' || s[i] == '\t') {
         i += 1;
     }
 
-    while(s[i]) {
+    while (s[i]) {
         if (s[i] == ' ' || s[i] == '\t') {
             do {
                 i += 1;
-            } while(s[i] == ' ' || s[i] == '\t');
+            } while (s[i] == ' ' || s[i] == '\t');
 
             i -= 1;
 
@@ -1321,7 +1321,7 @@ smtp_fold_whitespace(const char *const s, unsigned int maxlen)
     bufsz = 0;
     buf = NULL;
 
-    while(1) {
+    while (1) {
         ws_offset = smtp_fold_whitespace_get_offset(&s[s_i], maxlen - 2);
 
         /* bufsz += ws_offset + end_slen + 1 */
@@ -1403,7 +1403,7 @@ smtp_chunk_split(const char *const s, size_t chunklen, const char *const end)
     body_i = 0;
     snew_i = 0;
 
-    for(chunk_i = 0; chunk_i < bodylen / chunklen + 1; chunk_i++) {
+    for (chunk_i = 0; chunk_i < bodylen / chunklen + 1; chunk_i++) {
         body_copy_len = smtp_strnlen_utf8(&s[body_i], chunklen);
 
         if (body_copy_len == SIZE_MAX) {
@@ -1481,7 +1481,7 @@ smtp_ffile_get_contents(FILE *stream, size_t *bytes_read)
             free(read_buf);
             return NULL;
         }
-      } while(!feof(stream));
+      } while (!feof(stream));
 
     return read_buf;
 }
@@ -1583,7 +1583,7 @@ smtp_puts_dbg(struct smtp *const smtp, const char *const prefix,
         }
 
         /* Remove carriage return and newline when printing to stderr. */
-        for(i = 0; sdup[i]; i++) {
+        for (i = 0; sdup[i]; i++) {
             if (sdup[i] == '\r' || sdup[i] == '\n') {
                 sdup[i] = ' ';
             }
@@ -1679,7 +1679,7 @@ smtp_write(struct smtp *const smtp, const char *const buf, size_t len)
     bytes_to_send = len;
     buf_offset = buf;
 
-    while(bytes_to_send) {
+    while (bytes_to_send) {
         if (bytes_to_send > INT_MAX) {
             return smtp_status_code_set(smtp, SMTP_STATUS_SEND);
         }
@@ -1803,7 +1803,7 @@ smtp_connect(struct smtp *const smtp,
         return -1;
     }
 
-    for(res = res0; res; res = res->ai_next) {
+    for (res = res0; res; res = res->ai_next) {
         smtp->sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
 
         if (smtp->sock < 0) {
@@ -2508,7 +2508,7 @@ smtp_gen_mime_boundary(char *const boundary)
 
     strcpy(boundary, "mime");
 
-    for(i = 4; i < SMTP_MIME_BOUNDARY_LEN - 1; i++) {
+    for (i = 4; i < SMTP_MIME_BOUNDARY_LEN - 1; i++) {
         /* Modulo bias okay since we only need to prevent accidental collision. */
         boundary[i] = rand() % 26 + 'A';
     }
@@ -2673,7 +2673,7 @@ smtp_print_mime_email(struct smtp *const smtp, const char *const body_dd)
         return smtp->status_code;
     }
 
-    for(i = 0; i < smtp->num_attachment; i++) {
+    for (i = 0; i < smtp->num_attachment; i++) {
         attachment = &smtp->attachment_list[i];
 
         if (smtp_print_mime_attachment(smtp,
@@ -2815,7 +2815,7 @@ smtp_append_address_to_header(struct smtp *const smtp,
     header_value = NULL;
     concat_len = 0;
 
-    for(i = 0; i < smtp->num_address; i++) {
+    for (i = 0; i < smtp->num_address; i++) {
         address = &smtp->address_list[i];
 
         if (address->type == address_type) {
@@ -2968,7 +2968,7 @@ smtp_header_key_validate(const char *const key)
         return -1;
     }
 
-    for(i = 0; i < keylen; i++) {
+    for (i = 0; i < keylen; i++) {
         uc = (unsigned char)key[i];
 
         if (uc <= ' ' || uc > 126 || uc == ':') {
@@ -2994,7 +2994,7 @@ smtp_header_value_validate(const char *const value)
     size_t i;
     unsigned char uc;
 
-    for(i = 0; value[i]; i++) {
+    for (i = 0; value[i]; i++) {
         uc = (unsigned char)value[i];
 
         if ((uc < ' ' || uc > 126) &&
@@ -3023,7 +3023,7 @@ smtp_address_validate_email(const char *const email)
     size_t i;
     unsigned char uc;
 
-    for(i = 0; email[i]; i++) {
+    for (i = 0; email[i]; i++) {
         uc = (unsigned char)email[i];
 
         if (uc <= ' ' || uc == 127 ||
@@ -3051,7 +3051,7 @@ smtp_address_validate_name(const char *const name)
     size_t i;
     unsigned char uc;
 
-    for(i = 0; name[i]; i++) {
+    for (i = 0; name[i]; i++) {
         uc = (unsigned char)name[i];
 
         if (uc < ' ' || uc == 127 || uc == '\"') {
@@ -3078,7 +3078,7 @@ smtp_attachment_validate_name(const char *const name)
     size_t i;
     unsigned char uc;
 
-    for(i = 0; name[i]; i++) {
+    for (i = 0; name[i]; i++) {
         uc = (unsigned char)name[i];
 
         if (uc < ' ' || uc == 127 ||
@@ -3228,7 +3228,7 @@ smtp_mail(struct smtp *const smtp, const char *const body)
     smtp_set_read_timeout(smtp, SMTP_READ_TIMEOUT_SEC /* 60 * 5 */);
     has_mail_from = 0;
 
-    for(i = 0; i < smtp->num_address; i++) {
+    for (i = 0; i < smtp->num_address; i++) {
         address = &smtp->address_list[i];
 
         if (address->type == SMTP_ADDRESS_FROM) {
@@ -3250,7 +3250,7 @@ smtp_mail(struct smtp *const smtp, const char *const body)
     /* RCPT timeout 5 minutes. */
     smtp_set_read_timeout(smtp, SMTP_READ_TIMEOUT_SEC /* 60 * 5 */);
 
-    for(i = 0; i < smtp->num_address; i++) {
+    for (i = 0; i < smtp->num_address; i++) {
         address = &smtp->address_list[i];
 
         if (address->type != SMTP_ADDRESS_FROM) {
@@ -3299,7 +3299,7 @@ smtp_mail(struct smtp *const smtp, const char *const body)
         return smtp->status_code;
     }
 
-    for(i = 0; i < smtp->num_headers; i++) {
+    for (i = 0; i < smtp->num_headers; i++) {
         if (smtp_print_header(smtp, &smtp->header_list[i]) != SMTP_STATUS_OK) {
             return smtp->status_code;
         }
@@ -3504,7 +3504,7 @@ smtp_header_clear_all(struct smtp *const smtp) {
     size_t i;
     struct smtp_header *header;
 
-    for(i = 0; i < smtp->num_headers; i++) {
+    for (i = 0; i < smtp->num_headers; i++) {
         header = &smtp->header_list[i];
         free(header->key);
         free(header->value);
@@ -3578,7 +3578,7 @@ smtp_address_clear_all(struct smtp *const smtp)
     size_t i;
     struct smtp_address *address;
 
-    for(i = 0; i < smtp->num_address; i++) {
+    for (i = 0; i < smtp->num_address; i++) {
         address = &smtp->address_list[i];
         free(address->email);
         free(address->name);
@@ -3702,7 +3702,7 @@ smtp_attachment_clear_all(struct smtp *const smtp)
     size_t i;
     struct smtp_attachment *attachment;
 
-    for(i = 0; i < smtp->num_attachment; i++) {
+    for (i = 0; i < smtp->num_attachment; i++) {
         attachment = &smtp->attachment_list[i];
         free(attachment->name);
         free(attachment->b64_data);

--- a/src/speech.c
+++ b/src/speech.c
@@ -62,7 +62,7 @@ do_whisper(int descr, dbref player, const char *arg1, const char *arg2)
     match_neighbor(&md);
     match_me(&md);
 
-    if (Wizard(player) && Typeof(player) == TYPE_PLAYER) {
+    if (Wizard(player) && OBJECT_TYPE(player) == TYPE_PLAYER) {
         match_absolute(&md);
         match_player(&md);
     }
@@ -194,7 +194,7 @@ do_page(dbref player, const char *arg1, const char *arg2)
         return;
     }
 
-    if (FLAGS(target) & HAVEN) {
+    if (FLAG_CHECK(target, 'H')) {
         notify(player, "That player does not wish to be disturbed.");
         return;
     }

--- a/src/timequeue.c
+++ b/src/timequeue.c
@@ -18,6 +18,7 @@
 #include "debugger.h"
 #include "fbstrings.h"
 #include "fbtime.h"
+#include "flags.h"
 #include "game.h"
 #include "inst.h"
 #include "interface.h"
@@ -890,7 +891,7 @@ next_timequeue_event(time_t now)
             strcpyn(match_cmdname, sizeof(match_cmdname),
                     DoNull(event->command));
 
-            ival = (event->subtyp & TQ_MPI_OMESG) ? MPI_ISPUBLIC : 
+            ival = (event->subtyp & TQ_MPI_OMESG) ? MPI_ISPUBLIC :
                    MPI_ISPRIVATE;
 
             if (event->subtyp & TQ_MPI_BLESSED) {
@@ -927,13 +928,13 @@ next_timequeue_event(time_t now)
                     plyr = CONTENTS(event->loc);
 
                     for (; plyr != NOTHING; plyr = NEXTOBJ(plyr)) {
-                        if (Typeof(plyr) == TYPE_PLAYER && plyr != event->uid)
+                        if (OBJECT_TYPE(plyr) == TYPE_PLAYER && plyr != event->uid)
                             notify_filtered(event->uid, plyr, bbuf, 0);
                     }
                 }
             }
         } else if (event->typ == TQ_MUF_TYP) { /* Run MUF */
-            if (Typeof(event->called_prog) == TYPE_PROGRAM) {
+            if (OBJECT_TYPE(event->called_prog) == TYPE_PROGRAM) {
                 if (event->subtyp == TQ_MUF_DELAY) {
                     /* Uncomment when DBFETCH "does" something */
                     /* FIXME: DBFETCH(event->uid); */
@@ -1090,7 +1091,7 @@ has_refs(dbref program, timequeue ptr)
     }
 
     if (ptr->typ != TQ_MUF_TYP || !(ptr->fr) ||
-        Typeof(program) != TYPE_PROGRAM || !(PROGRAM_INSTANCES(program)))
+        OBJECT_TYPE(program) != TYPE_PROGRAM || !(PROGRAM_INSTANCES(program)))
         return 0;
 
     for (int loop = 1; loop < ptr->fr->caller.top; loop++) {
@@ -1217,7 +1218,7 @@ do_process_status(dbref player)
         notify_nolisten(player, buf, 1);
         count++;
     }
- 
+
     count += muf_event_list(player, strfmt);
     notifyf_nolisten(player, "%d events.", count);
 }
@@ -1379,7 +1380,7 @@ get_pidinfo(int pid, int pin)
          *       a function that converts these type ID's to strings.
          */
         if (ptr->typ == TQ_MUF_TYP) {
-            array_set_strkey_strval(&nw, "SUBTYPE", 
+            array_set_strkey_strval(&nw, "SUBTYPE",
                                     (ptr->subtyp == TQ_MUF_READ) ? "READ" :
                                     (ptr->subtyp == TQ_MUF_QUEUE) ? "QUEUE" :
                                     (ptr->subtyp == TQ_MUF_LISTEN) ? "LISTEN" :
@@ -1460,7 +1461,7 @@ dequeue_prog_real(dbref program, int killmode, const char *file, const int line)
     prev = NULL;
     ptr = tqhead;
 
-    while(ptr) {
+    while (ptr) {
         DEBUGPRINT("dequeue_prog: ptr->called_prog = #%d, has_refs = %d ",
                    ptr->called_prog, has_refs(program, ptr));
         DEBUGPRINT("ptr->uid = #%d\n", ptr->uid);
@@ -1565,7 +1566,7 @@ dequeue_prog_real(dbref program, int killmode, const char *file, const int line)
      */
 #ifdef DEBUG
     /* KLUDGE by premchai21 */
-    if (Typeof(program) == TYPE_PROGRAM)
+    if (OBJECT_TYPE(program) == TYPE_PROGRAM)
         fprintf(stderr, "[debug] dequeue_prog: %d instances of #%d\n",
                 PROGRAM_INSTANCES(program), program);
 #endif
@@ -1744,7 +1745,7 @@ do_kill_process(int descr, dbref player, const char *arg1)
             tmp = ptr;
             tqhead = ptr = ptr->next;
             free_timenode(tmp);
- 
+
             /* free_timenode can free other things on the list when cleaning up
                timers for a backgrounded process */
             ptr = tqhead;
@@ -1756,7 +1757,7 @@ do_kill_process(int descr, dbref player, const char *arg1)
         notify_nolisten(player, "Time queue cleared.", 1);
     } else {
         if (!number(arg1)) { /* Kill based on an object */
-            init_match(descr, player, arg1, NOTYPE, &md);
+            init_match(descr, player, arg1, TYPE_ANY, &md);
             match_everything(&md);
 
             if ((match = noisy_match_result(&md)) == NOTHING) {
@@ -1926,14 +1927,14 @@ propqueue(int descr, dbref player, dbref where, dbref trigger, dbref what,
             if (the_prog != AMBIGUOUS) {
                 if (!ObjExists(the_prog)) {
                     the_prog = NOTHING;
-                } else if (Typeof(the_prog) != TYPE_PROGRAM) {
+                } else if (OBJECT_TYPE(the_prog) != TYPE_PROGRAM) {
                     the_prog = NOTHING;
-                } else if ((OWNER(the_prog) != OWNER(player)) && 
-                           !(FLAGS(the_prog) & LINK_OK)) {
+                } else if ((OWNER(the_prog) != OWNER(player)) &&
+                           !FLAG_CHECK(the_prog, 'L')) {
                     the_prog = NOTHING;
-                } else if (MLevel(the_prog) < mlev) {
+                } else if (OBJECT_EFFECTIVE_MLEVEL(the_prog) < mlev) {
                     the_prog = NOTHING;
-                } else if (MLevel(OWNER(the_prog)) < mlev) {
+                } else if (OBJECT_EFFECTIVE_MLEVEL(OWNER(the_prog)) < mlev) {
                     the_prog = NOTHING;
                 } else if (the_prog == xclude) {
                     the_prog = NOTHING;
@@ -1970,7 +1971,7 @@ propqueue(int descr, dbref player, dbref where, dbref trigger, dbref what,
                             plyr = CONTENTS(where);
 
                             while (plyr != NOTHING) {
-                                if (Typeof(plyr) == TYPE_PLAYER &&
+                                if (OBJECT_TYPE(plyr) == TYPE_PLAYER &&
                                     plyr != player)
 
                                 notify_filtered(player, plyr, bbuf, 0);
@@ -2099,7 +2100,7 @@ listenqueue(int descr, dbref player, dbref where, dbref trigger, dbref what,
     if (!OkObj(what))
         return;
 
-    if (!(FLAGS(what) & LISTENER) && !(FLAGS(OWNER(what)) & ZOMBIE))
+    if (!(FLAGS(what) & LISTENER) && !FLAG_CHECK(OWNER(what), 'Z'))
         return;
 
     tmpchar = NULL;
@@ -2171,14 +2172,14 @@ listenqueue(int descr, dbref player, dbref where, dbref trigger, dbref what,
             if (the_prog != AMBIGUOUS) {
                 if (!ObjExists(the_prog)) {
                     the_prog = NOTHING;
-                } else if (Typeof(the_prog) != TYPE_PROGRAM) {
+                } else if (OBJECT_TYPE(the_prog) != TYPE_PROGRAM) {
                     the_prog = NOTHING;
                 } else if (OWNER(the_prog) != OWNER(player) &&
-                           !(FLAGS(the_prog) & LINK_OK)) {
+                           !FLAG_CHECK(the_prog, 'L')) {
                     the_prog = NOTHING;
-                } else if (MLevel(the_prog) < mlev) {
+                } else if (OBJECT_EFFECTIVE_MLEVEL(the_prog) < mlev) {
                     the_prog = NOTHING;
-                } else if (MLevel(OWNER(the_prog)) < mlev) {
+                } else if (OBJECT_EFFECTIVE_MLEVEL(OWNER(the_prog)) < mlev) {
                     the_prog = NOTHING;
                 } else if (the_prog == xclude) {
                     the_prog = NOTHING;

--- a/src/tune.c
+++ b/src/tune.c
@@ -18,6 +18,7 @@
 #include "db.h"
 #include "fbstrings.h"
 #include "fbtime.h"
+#include "flags.h"
 #include "game.h"
 #include "inst.h"
 #include "interface.h"
@@ -54,7 +55,7 @@ tune_timespan_seconds(const char *value)
 {
     int days, hrs, mins, secs;
     int result = sscanf(value, "%dd %2d:%2d:%2d", &days, &hrs, &mins, &secs);
-    
+
     if (result == 4) {
       return (days * 86400) + (3600 * hrs) + (60 * mins) + secs;
     }
@@ -107,8 +108,8 @@ tune_entry_value(dbref player, struct tune_entry *tent)
     case TP_TYPE_DBREF:
         if (player == NOTHING) {
             snprintf(buf, sizeof(buf), "#%d", *tent->currentval.d);
-        } else {            
-            unparse_object(player, *tent->currentval.d, buf, sizeof(buf));
+        } else {
+            flag_unparse_object(player, *tent->currentval.d, buf, sizeof(buf));
         }
         break;
     case TP_TYPE_BOOLEAN:
@@ -292,7 +293,7 @@ tune_parms_array(const char *pattern, int mlev, int pinned)
                 case TP_TYPE_DBREF:
                     array_set_strkey_strval(&item, "type", "dbref");
 
-                    if (tent->type > NOTYPE) {
+                    if (tent->type > TYPE_ANY) {
                         array_set_strkey_strval(&item, "objtype", "unknown");
                     } else {
                         array_set_strkey_strval(&item, "objtype", str_objecttype[tent->objecttype]);
@@ -483,7 +484,7 @@ tune_setparm(dbref player, const char *parmname, const char *val, int mlev)
                 dbref obj;
                 struct match_data md;
 
-                init_match(NOTHING, player, parmval, NOTYPE, &md);
+                init_match(NOTHING, player, parmval, TYPE_ANY, &md);
                 match_absolute(&md);
                 match_registered(&md);
                 match_player(&md);
@@ -494,7 +495,7 @@ tune_setparm(dbref player, const char *parmname, const char *val, int mlev)
                     return TUNESET_SYNTAX;
                 if (!ObjExists(obj))
                     return TUNESET_SYNTAX;
-                if (tent->objecttype != NOTYPE && Typeof(obj) != tent->objecttype)
+                if (tent->objecttype != TYPE_ANY && OBJECT_TYPE(obj) != tent->objecttype)
                     return TUNESET_BADVAL;
 
                 *tent->currentval.d = obj;

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -21,6 +21,7 @@
 #include "diskprop.h"
 #endif
 #include "fbstrings.h"
+#include "flags.h"
 #include "game.h"
 #include "interface.h"
 #include "log.h"
@@ -90,7 +91,7 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
          *        live elsewhere and should change as well; though
          *        in most places they are not quite so blatantly repetitive.
          */
-        init_match(descr, player, arg1, NOTYPE, &md);
+        init_match(descr, player, arg1, TYPE_ANY, &md);
         match_neighbor(&md);
         match_possession(&md);
         match_me(&md);
@@ -131,11 +132,11 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
         return;
     }
 
-    unparse_object(player, victim, victim_name_buf, sizeof(victim_name_buf));
+    flag_unparse_object(player, victim, victim_name_buf, sizeof(victim_name_buf));
 
     /* If we're sending the thing home, let's figure out where that is. */
     if (destination == HOME) {
-        switch (Typeof(victim)) {
+        switch (OBJECT_TYPE(victim)) {
             case TYPE_PLAYER:
                 destination = PLAYER_HOME(victim);
 
@@ -185,12 +186,12 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
      *        The answer here may be to do nothing, but this seems like
      *        its a lot of flailing around with similar checks.
      */
-    switch (Typeof(victim)) {
+    switch (OBJECT_TYPE(victim)) {
         case TYPE_PLAYER:
             if (!controls(player, victim) ||
                 !controls(player, destination) ||
                 !controls(player, LOCATION(victim)) ||
-                (Typeof(destination) == TYPE_THING
+                (OBJECT_TYPE(destination) == TYPE_THING
                  && !controls(player, LOCATION(destination)))) {
 
                 notify(player,
@@ -198,15 +199,15 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
                 break;
             }
 
-            if (Typeof(destination) != TYPE_ROOM && 
-                Typeof(destination) != TYPE_THING) {
+            if (OBJECT_TYPE(destination) != TYPE_ROOM &&
+                OBJECT_TYPE(destination) != TYPE_THING) {
                 notify(player, "Bad destination.");
                 break;
             }
 
             if (!Wizard(victim) &&
-                (Typeof(destination) == TYPE_THING && 
-                 !(FLAGS(destination) & VEHICLE))) {
+                (OBJECT_TYPE(destination) == TYPE_THING &&
+                 !FLAG_CHECK(destination, 'V'))) {
                 notify(player, "Destination object is not a vehicle.");
                 break;
             }
@@ -217,7 +218,7 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
             }
 
             notify(victim, "You feel a wrenching sensation...");
-            unparse_object(player, destination, destination_name_buf,
+            flag_unparse_object(player, destination, destination_name_buf,
                            sizeof(destination_name_buf));
             enter_room(descr, victim, destination, LOCATION(victim));
             notifyf(player, "%s teleported to %s.", victim_name_buf,
@@ -230,9 +231,9 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
             }
             /* fall through */
         case TYPE_PROGRAM:
-            if (Typeof(destination) != TYPE_ROOM
-                && Typeof(destination) != TYPE_PLAYER
-                && Typeof(destination) != TYPE_THING) {
+            if (OBJECT_TYPE(destination) != TYPE_ROOM
+                && OBJECT_TYPE(destination) != TYPE_PLAYER
+                && OBJECT_TYPE(destination) != TYPE_THING) {
                 notify(player, "Bad destination.");
                 break;
             }
@@ -247,13 +248,13 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
             }
 
             /* check for non-sticky dropto */
-            if (Typeof(destination) == TYPE_ROOM
+            if (OBJECT_TYPE(destination) == TYPE_ROOM
                 && DBFETCH(destination)->sp.room.dropto != NOTHING
-                && !(FLAGS(destination) & STICKY))
+                && !FLAG_CHECK(destination, 'S'))
                 destination = DBFETCH(destination)->sp.room.dropto;
 
-            if (tp_secure_thing_movement && (Typeof(victim) == TYPE_THING)) {
-                if (FLAGS(victim) & ZOMBIE) {
+            if (tp_secure_thing_movement && (OBJECT_TYPE(victim) == TYPE_THING)) {
+                if (FLAG_CHECK(victim, 'Z')) {
                     notify(victim, "You feel a wrenching sensation...");
                 }
 
@@ -262,12 +263,12 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
                 moveto(victim, destination);
             }
 
-            unparse_object(player, destination, destination_name_buf, sizeof(destination_name_buf));
+            flag_unparse_object(player, destination, destination_name_buf, sizeof(destination_name_buf));
             notifyf(player, "%s teleported to %s.", victim_name_buf,
                     destination_name_buf);
             break;
         case TYPE_ROOM:
-            if (Typeof(destination) != TYPE_ROOM) {
+            if (OBJECT_TYPE(destination) != TYPE_ROOM) {
                 notify(player, "Bad destination.");
                 break;
             }
@@ -286,7 +287,7 @@ do_teleport(int descr, dbref player, const char *arg1, const char *arg2)
             }
 
             moveto(victim, destination);
-            unparse_object(player, destination, destination_name_buf, sizeof(destination_name_buf));
+            flag_unparse_object(player, destination, destination_name_buf, sizeof(destination_name_buf));
             notifyf(player, "Parent of %s set to %s.", victim_name_buf,
                     destination_name_buf);
             break;
@@ -417,7 +418,7 @@ do_unbless(int descr, dbref player, const char *what, const char *propname)
     }
 
     /* get victim */
-    init_match(descr, player, what, NOTYPE, &md);
+    init_match(descr, player, what, TYPE_ANY, &md);
     match_everything(&md);
 
     if ((victim = noisy_match_result(&md)) == NOTHING) {
@@ -457,7 +458,7 @@ do_bless(int descr, dbref player, const char *what, const char *propname)
     int cnt;
 
     /* get victim */
-    init_match(descr, player, what, NOTYPE, &md);
+    init_match(descr, player, what, TYPE_ANY, &md);
     match_everything(&md);
 
     if ((victim = noisy_match_result(&md)) == NOTHING) {
@@ -512,7 +513,7 @@ do_force(int descr, dbref player, const char *what, char *command)
         return;
     }
 
-    if (!tp_allow_zombies && (!Wizard(player) || Typeof(player) != TYPE_PLAYER)) {
+    if (!tp_allow_zombies && (!Wizard(player) || OBJECT_TYPE(player) != TYPE_PLAYER)) {
         notify(player, "Zombies are not enabled here.");
         return;
 
@@ -527,7 +528,7 @@ do_force(int descr, dbref player, const char *what, char *command)
      */
 
     /* get victim */
-    init_match(descr, player, what, NOTYPE, &md);
+    init_match(descr, player, what, TYPE_ANY, &md);
     match_neighbor(&md);
     match_possession(&md);
     match_me(&md);
@@ -543,7 +544,7 @@ do_force(int descr, dbref player, const char *what, char *command)
         return;
     }
 
-    if (Typeof(victim) != TYPE_PLAYER && Typeof(victim) != TYPE_THING) {
+    if (OBJECT_TYPE(victim) != TYPE_PLAYER && OBJECT_TYPE(victim) != TYPE_THING) {
         notify(player, "Permission Denied -- Target not a player or thing.");
         return;
     }
@@ -555,7 +556,7 @@ do_force(int descr, dbref player, const char *what, char *command)
     }
 #endif
 
-    if (!Wizard(player) && !(FLAGS(victim) & XFORCIBLE)) {
+    if (!Wizard(player) && !FLAG_CHECK(victim, 'X')) {
         notify(player, "Permission denied: forced object not @set Xforcible.");
         return;
     }
@@ -566,22 +567,22 @@ do_force(int descr, dbref player, const char *what, char *command)
     }
 
     loc = LOCATION(victim);
-    if (!Wizard(player) && Typeof(victim) == TYPE_THING && loc != NOTHING &&
-        (FLAGS(loc) & ZOMBIE) && Typeof(loc) == TYPE_ROOM) {
+    if (!Wizard(player) && OBJECT_TYPE(victim) == TYPE_THING && loc != NOTHING &&
+        FLAG_CHECK(loc, 'Z') && OBJECT_TYPE(loc) == TYPE_ROOM) {
         notify(player, "Sorry, but that's in a no-puppet zone.");
         return;
     }
 
-    if (!Wizard(OWNER(player)) && Typeof(victim) == TYPE_THING) {
+    if (!Wizard(OWNER(player)) && OBJECT_TYPE(victim) == TYPE_THING) {
         const char *ptr = NAME(victim);
         char objname[BUFFER_LEN], *ptr2;
 
-        if ((FLAGS(player) & ZOMBIE)) {
+        if (FLAG_CHECK(player, 'Z')) {
             notify(player, "Permission denied -- you cannot use zombies.");
             return;
         }
 
-        if (FLAGS(victim) & DARK) {
+        if (Dark(victim)) {
             notify(player, "Permission denied -- you cannot force dark zombies.");
             return;
         }
@@ -668,7 +669,7 @@ do_stats(dbref player, const char *name)
  *
  * @param player the player doing the @boot command
  * @param name the string name that will be matched for the player to boot.
- */ 
+ */
 void
 do_boot(dbref player, const char *name)
 {
@@ -695,7 +696,7 @@ do_boot(dbref player, const char *name)
         return;
     }
 
-    if (Typeof(victim) != TYPE_PLAYER) {
+    if (OBJECT_TYPE(victim) != TYPE_PLAYER) {
         notify(player, "You can only boot players!");
     }
 #ifdef GOD_PRIV
@@ -786,7 +787,7 @@ do_toad(int descr, dbref player, const char *name, const char *recip)
         }
     }
 
-    if (Typeof(victim) != TYPE_PLAYER) {
+    if (OBJECT_TYPE(victim) != TYPE_PLAYER) {
         notify(player, "You can only turn players into toads!");
 
 #ifdef GOD_PRIV
@@ -1046,7 +1047,7 @@ do_topprofs(dbref player, char *arg1)
                 DBFETCH(i)->mpi_proftime.tv_sec = 0;
             }
 
-            if (type != 0 && Typeof(i) == TYPE_PROGRAM && PROGRAM_CODE(i)) {
+            if (type != 0 && OBJECT_TYPE(i) == TYPE_PROGRAM && PROGRAM_CODE(i)) {
                 PROGRAM_SET_PROFTIME(i, 0, 0);
                 PROGRAM_SET_PROFSTART(i, current_systime);
                 PROGRAM_SET_PROF_USES(i, 0);
@@ -1080,7 +1081,7 @@ do_topprofs(dbref player, char *arg1)
             add_to_proflist(&tops, count, &nodecount, i, 0, current_systime);
         }
 
-        if (type != 0 && Typeof(i) == TYPE_PROGRAM && PROGRAM_CODE(i)) {
+        if (type != 0 && OBJECT_TYPE(i) == TYPE_PROGRAM && PROGRAM_CODE(i)) {
             add_to_proflist(&tops, count, &nodecount, i, 1, current_systime);
         }
     }
@@ -1091,7 +1092,7 @@ do_topprofs(dbref player, char *arg1)
     while (tops) {
         char unparse_buf[BUFFER_LEN];
         curr = tops;
-        unparse_object(player, curr->prog, unparse_buf, sizeof(unparse_buf));
+        flag_unparse_object(player, curr->prog, unparse_buf, sizeof(unparse_buf));
         notifyf_nolisten(player, "%10.3f %10.3f %9ld%s%s", curr->pcnt, curr->proftime,
                 curr->usecount, type == -1 ? (curr->type ? "  MUF   " : "  MPI   ") : "  ", unparse_buf);
         tops = tops->next;
@@ -1218,7 +1219,7 @@ static const unsigned char base64_table[65] =
  * @return size of the generated b64 string (not including null)
  */
 static size_t
-base64_encode(const unsigned char *src, size_t len, 
+base64_encode(const unsigned char *src, size_t len,
               unsigned char *out, size_t out_size)
 {
     unsigned char *pos;
@@ -1335,7 +1336,7 @@ base64_send(struct descriptor_data* descr, FILE* in)
         if (sent + b64_len > limit) {
             process_all_output(10, 1000, descr);
             sent = 0;
-        }        
+        }
 
         queue_write_max(descr, base64_buf, b64_len, 0);
         sent += b64_len;
@@ -1415,7 +1416,7 @@ do_teledump(int descr, dbref player)
      * only way to find all the programs on the MUCK.
      */
     for (dbref i = 0; i < db_top; i++) {
-        if (Typeof(i) != TYPE_PROGRAM) {
+        if (OBJECT_TYPE(i) != TYPE_PROGRAM) {
             continue;
         }
 

--- a/src/wiz.c
+++ b/src/wiz.c
@@ -612,6 +612,11 @@ do_force(int descr, dbref player, const char *what, char *command)
 }
 
 /**
+ * Returns singular or plural string based on count.
+ */
+#define PLURALFORM(count, singular, plural) ((count) == 1 ? (singular) : (plural))
+
+/**
  * Implementation of the \@stats command
  *
  * This displays stats on what is in the database, optionally showing
@@ -631,35 +636,39 @@ do_stats(dbref player, const char *name)
     dbref owner = NOTHING;
     int stats[7];
 
+    if (!Wizard(OWNER(player))) {
+        notifyf(player, "The universe contains %d objects.", db_top);
+        return;
+    }
+
     if (name != NULL && *name != '\0') {
         owner = lookup_player(name);
         if (owner == NOTHING) {
             notify(player, "I can't find that player.");
             return;
         }
-        if (!Wizard(OWNER(player)) && OWNER(player) != owner) {
-            notify(player, "Permission denied. (you must be a wizard to get someone else's stats)");
-            return;
-        }
-    } else if (!Wizard(OWNER(player))) {
-        notifyf(player, "The universe contains %d objects.", db_top);
-        return;
     }
 
     collect_dbstats(player, owner, stats);
 
-    notifyf(player, "%7d room%s        %7d exit%s        %7d thing%s",
-            stats[1], (stats[1] == 1) ? " " : "s",
-            stats[2], (stats[2] == 1) ? " " : "s",
-            stats[3], (stats[3] == 1) ? " " : "s");
+    const struct object_type *ti_room    = &object_types[TYPE_ROOM];
+    const struct object_type *ti_exit    = &object_types[TYPE_EXIT];
+    const struct object_type *ti_thing   = &object_types[TYPE_THING];
+    const struct object_type *ti_program = &object_types[TYPE_PROGRAM];
+    const struct object_type *ti_player  = &object_types[TYPE_PLAYER];
 
-    notifyf(player, "%7d program%s     %7d player%s      %7d garbage",
-            stats[4], (stats[4] == 1) ? " " : "s",
-            stats[5], (stats[5] == 1) ? " " : "s",
+    notifyf(player, "%7d %-8s %7d %-8s %7d %-8s",
+            stats[1], PLURALFORM(stats[1], ti_room->singular, ti_room->plural),
+            stats[2], PLURALFORM(stats[2], ti_exit->singular, ti_exit->plural),
+            stats[3], PLURALFORM(stats[3], ti_thing->singular, ti_thing->plural));
+
+    notifyf(player, "%7d %-8s %7d %-8s %7d garbage",
+            stats[4], PLURALFORM(stats[4], ti_program->singular, ti_program->plural),
+            stats[5], PLURALFORM(stats[5], ti_player->singular, ti_player->plural),
             stats[6]);
 
-    notifyf(player, "%7d total object%s",
-            stats[0], (stats[0] == 1) ? " " : "s");
+    notifyf(player, "%7d total %s",
+            stats[0], PLURALFORM(stats[0], "object", "objects"));
 }
 
 /**

--- a/win32/restart.cpp
+++ b/win32/restart.cpp
@@ -586,7 +586,7 @@ int main (int argc, char **argv) {
             }
             fseek(f, 0L, SEEK_SET);
             char c;
-            while((c = fgetc(f)) != EOF) {
+            while ((c = fgetc(f)) != EOF) {
                if (c != '\r') fputc(c, dbin);
             }
             fclose(f);

--- a/win32/win32.c
+++ b/win32/win32.c
@@ -7,14 +7,22 @@ void sync(void) { return; }
 
 static void ftconvert(const FILETIME *ft, struct timeval *ts)
 {
-	ts->tv_sec = (int)((*(LONGLONG *)ft - TOFFSET) / 10000000);
-	ts->tv_usec = (int)((*(LONGLONG *)ft - TOFFSET - ((LONGLONG)ts->tv_sec * (LONGLONG)10000000)) * 100) / 1000;
+    ts->tv_sec = (int)((*(LONGLONG *)ft - TOFFSET) / 10000000);
+    ts->tv_usec = (int)((*(LONGLONG *)ft - TOFFSET - ((LONGLONG)ts->tv_sec * (LONGLONG)10000000)) * 100) / 1000;
 }
 
 int gettimeofday(struct timeval *tv, struct timezone *tz)
 {
-	FILETIME ft;
-	GetSystemTimeAsFileTime(&ft);
-	ftconvert(&ft,tv);
-	return 0;
+    FILETIME ft;
+    GetSystemTimeAsFileTime(&ft);
+    ftconvert(&ft,tv);
+    return 0;
+}
+
+int ffsl(long mask) {
+    unsigned long index;
+    if (_BitScanForward(&index, (unsigned long)mask)) {
+        return (int)(index + 1);
+    }
+    return 0;
 }

--- a/win32/win32.h
+++ b/win32/win32.h
@@ -2,6 +2,7 @@
 #define _WIN32_H_
 
 #include <direct.h>
+#include <intrin.h>
 #include <process.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -31,6 +32,7 @@
 #define write(fd, buf, count) \
 			send(fd, (char *)buf, count, 0)
 
+int ffsl(long mask);
 int gettimeofday(struct timeval *tv, struct timezone *tz);
 void set_console();
 void sync();


### PR DESCRIPTION
# Draft PR: Flag Logic Refactor & Multi-Flag Support

This is a significant refactor. I appreciate any reviewer taking the time to wade through the changes.

## Summary
This PR refactors and relocates flag checking and presentation logic into a centralized subsystem. The primary goal is to make the system manageable and support a flag (re)setting refactor, while introducing powerful new multi-flag checking capabilities.

### Key Additions
* **Multi-Flag Checking:** Players can now check multiple flags at once (e.g., `"L!A"`) via:
    * The `FLAGS?` MUF primitive.
    * The `{flags?}` MPI function.
* **Flag Subsystem:** Centralized logic in `include/flags.h` and `src/flags.c` using lookup tables for bit values, flag symbols, and type aliases.

---

## API & Logic Changes

### Renames for Clarity
| Old Name | New Name |
| :--- | :--- |
| `Typeof` | `OBJECT_TYPE` |
| `MLevRaw` | `OBJECT_MLEVEL` |
| `MLevel` | `OBJECT_EFFECTIVE_MLEVEL` |
| `Plevel` | `OBJECT_PRIORITY` |

### New Public Functions & Defines
* `FLAG_CHECK`: Returns true if a single-character flag is set.
* `FLAG_VALUE`: Returns the bit value of a single-character flag.
* `flag_init`: Initializes lookup tables from an array of structs.
* `flag_eval`: Underpins `FLAG?` and `{flag?}`; recognizes symbols, aliases, and "truewizard".
* `flag_eval_pattern`: New multi-flag checker; recognizes flag symbols, type symbols, and MUCKER levels.
* `flag_list` / `flag_list_verbose`: Generates single-symbol or "wordy" flag lists.
* `flag_unparse_object`: Revised `unparse_object` utilizing the new lookup tables.
* `object_type_name`: Returns the uppercase name of an object's type.

---

## Discussion Points
These changes might be for the better, but they introduce specific logic shifts. Please review the following:

### 1. Type-Strict Lookups
The lookup tables now use the object's type as an index. Checking if a Program is `SILENT` or an Exit is `AUTOSTART` will now return **false**. 
* **Impact:** This may break legacy programs relying on "type confusion."
* **Decision:** Should we maintain the loose legacy logic (at a performance cost) or enforce strictness?

### 2. Symbols & Aliases
* **The "T" Symbol:** I've introduced `T` as the type symbol for "Things." Note that this overlaps with the "truewizard" alias in single-flag checks, but those don't recognize type symbols.
* **MUCKER Levels:** Levels are checked via `"PW3"`. "M2" and "M3" work as aliases, but only since they both include the "M" bit. Currently, `"M1"` fails because it is technically `N`. 
* **The M0 Case:** Checking for Mucker level 0 might not ever return true.
* **Proposal:** Should we add code to make `M1` intuitive, or perhaps remove `M` from the short flag list entirely to manage search expectations?

### 3. Internal Flags (Untouched)
I have excluded the following internal flags from this refactor for now. I am considering moving some of these out of the flag system.

| Flag | Purpose | Current Status |
| :--- | :--- | :--- |
| `INTERACTIVE` | Player is in MUF editor | **Searchable** via flag checkers. |
| `INTERNAL` | Player sees line numbers / Program is being edited | Saved to disk; needs prop-based migration. |
|`LISTENER`| Determines if object has a listener propqueue | Re-applied on database load. |
| `OBJECT_CHANGED` | Delta-dumping | Historical utility. |
| `READMODE` | Player in a READ state | Runtime state only. |
| `SANEBIT` | Database sanity tools | Cleanup/Sweep utility. |

---

## Miscellaneous Fixes
* **Style:** Removed trailing spaces in `.c` and `.h` files; fixed control flow spacing.
* **Refactors:** Simplified `do_examine` unparsing and `do_dig` flag inheritance.
* **Safety:** Reduced compiler warnings by patching a few potential buffer overflows.

---

## Testing Status
Testing has been successful in my local environment, but given the scope of the refactor, I welcome any edge cases I may have missed.
