### PR TITLE
#757 Fix MUCK Crash in Debugger

### DIFF
--- a/src/debugger.c
+++ b/src/debugger.c
@@ -462,18 +462,33 @@ muf_backtrace(dbref player, dbref program, int count, struct frame *fr)
                 const char *nam = scopedvar_getname(fr, lev, k);
                 char *val;
 
-                if (!nam) {
+                /*
+                 * Space remaining in buf2, holding back some slack for
+                 * the ANSI escapes.
+                 */
+                size_t avail = sizeof(buf2) - (size_t)(bufend - buf2);
+
+                if (!nam || avail <= 19) {
                     break;
                 }
+
+                avail -= 18;
 
                 varinst = scopedvar_get(fr, lev, k);
                 val = insttotext(fr, lev, varinst, buf3, sizeof(buf3), 30, program, 1);
 
                 if (k) {
-                    bufend += snprintf(bufend, buf2 - bufend - 18, "\033[1m, %s=\033[0m%s", nam, val);
+                    snplen = snprintf(bufend, avail, "\033[1m, %s=\033[0m%s", nam, val);
                 } else {
-                    bufend += snprintf(bufend, buf2 - bufend - 18, "\033[1m%s=\033[0m%s", nam, val);
+                    snplen = snprintf(bufend, avail, "\033[1m%s=\033[0m%s", nam, val);
                 }
+
+                if (snplen < 0 || (size_t)snplen >= avail) {
+                    /* Output was truncated; stop appending arguments. */
+                    break;
+                }
+
+                bufend += snplen;
             }
 
             ptr = buf2;

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -1259,7 +1259,10 @@ prim_roomp(PRIM_PROTOTYPE)
         abort_interp("Invalid argument type.");
     }
 
-    if (!valid_object(oper1) && !is_home(oper1)) {
+    if (is_home(oper1)) {
+        /* HOME per doc explicitly returns 1 */
+        result = 1;
+    } else if (!valid_object(oper1)) {
         result = 0;
     } else {
         ref = oper1->data.objref;


### PR DESCRIPTION
Fixes #757 

This fixes a buffer overflow that causes crashes in the MUCK debugger. It's 100% definitely the bug I'm experiencing on Space Fox MUCK and it's probably the error Jessamyn reported though I never could make a reproducible process around that one. But the symptoms are the same and this is the same code path she would have hit.

Also adds a CLAUDE.md. I did use claude to help track this down and I believe embracing our robot overlords will help us sort out some of the long standing issues.