### PR TITLE
Fix compile warning.

### DIFF
--- a/src/flags.c
+++ b/src/flags.c
@@ -12,6 +12,7 @@
 
 #include "db.h"
 #include "fbstrings.h"
+#include "predicates.h"
 #include "flags.h"
 #include "game.h"
 


### PR DESCRIPTION
Explicitly pull in predicates.h to fix implicit function definition issue.  Believe this should fix the compile time error.