### PR TITLE
Update timefmt error from strftime (#764)

### DIFF
--- a/src/p_misc.c
+++ b/src/p_misc.c
@@ -292,7 +292,7 @@ prim_timefmt(PRIM_PROTOTYPE)
     }
 
     if (!strftime(buf, BUFFER_LEN, oper1->data.string->data, time_tm)) {
-        abort_interp("Operation would result in overflow.");
+        abort_interp("Bad format string or operation would result in overflow.");
     }
 
     CHECKOFLOW(1);


### PR DESCRIPTION
Per issue https://github.com/fuzzball-muck/fuzzball/issues/764, some variants of libc's strftime will also return 0 for unknown sequences in the time format string, not just buffer overflow. This makes the error 'correct' for a wider range of implementations. Already checked, and current documentation does a good job of only documenting minimal substitutions that have wide availability. The old usages of %k and %l (GNU extensions) were removed already from the MUF docs.