### PR TITLE
Remove bad internal defines for deprecated prims.

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -832,16 +832,6 @@ include_internal_defs(COMPSTATE * cstat)
     insert_intdef(cstat, "bg_mode", BACKGROUND);
     insert_intdef(cstat, "fg_mode", FOREGROUND);
     insert_intdef(cstat, "pr_mode", PREEMPT);
-    insert_def(cstat, "conboot", "descrboot");
-    insert_def(cstat, "concount", "descrcount");
-    insert_def(cstat, "condbref", "descrdbref");
-    insert_def(cstat, "conhost", "descrhost");
-    insert_def(cstat, "conidle", "descridle");
-    insert_def(cstat, "connotify", "descrnotify");
-    insert_def(cstat, "contime", "descrtime");
-    insert_def(cstat, "conuser", "descruser");
-    insert_def(cstat, "condescr", "");
-    insert_def(cstat, "descrcon", "");
 }
 
 /**


### PR DESCRIPTION
This removes the internal definitions for the connection number primitives that did bad mappings to descr-based prims that broke existing MUF.  Better to have programs abort on unknown prim.  Will also provide a temp replacement MUF lib that can bridge.  Issue #762