### PR TITLE
#763 Fix pointer math problem that was causing core

### DIFF
--- a/src/property.c
+++ b/src/property.c
@@ -1312,7 +1312,7 @@ displayprop(dbref player, dbref obj, const char *name, char *buf, size_t bufsiz)
         blesschar = 'B';
 
     pdflag = (PropDir(p) != NULL);
-    snprintf(mybuf, bufsiz, "%.*s%c", (BUFFER_LEN / 4), name,
+    snprintf(mybuf, sizeof(mybuf), "%.*s%c", (BUFFER_LEN / 4), name,
             (pdflag) ? PROPDIR_DELIMITER : '\0');
 
     switch (PropType(p)) {


### PR DESCRIPTION
This fixes #763 

This was incorrectly attributed to a compiler optimization; the optimization causes the problem to surface, but the real problem is that we're passing 'bufsize' which is the size of 'buf' as the size to 'mybuf' which is actually smaller than 'mybuf' so that causes a segfault. But for whatever reason, only when optimizing.

Oops.
