### PR TITLE
Fix for #771 to limit propdir recursion to 100 subdirs

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -116,6 +116,7 @@ typedef int dbref;  /**< Type wrapper for dbref - must support negatives */
 #define MAX_LINKS 50            /**< max destinations for an exit */
 #define MAX_LISTEN_SOCKS 16     /**< max ports we will open */
 #define MAX_PARENT_DEPTH 256    /**< max parenting depth allowed */
+#define MAX_PROPTREE_DEPTH 100  /**< max propdir nesting depth allowed */
 
 /**
  * Maximum buffer length

--- a/src/look.c
+++ b/src/look.c
@@ -456,10 +456,12 @@ do_look_at(int descr, dbref player, const char *name, const char *detail)
  * @param thing the thing we are checking props on
  * @param dir root dir to search from - used for recursion -- pass "" for root
  * @param wild the pattern to search for.
+ * @param depth current propdir nesting depth - pass 0 for the root call
  * @return int number of props returned.
  */
 static int
-listprops_wildcard(dbref player, dbref thing, const char *dir, const char *wild)
+listprops_wildcard(dbref player, dbref thing, const char *dir, const char *wild,
+                   int depth)
 {
     char propname[BUFFER_LEN];
     char wld[BUFFER_LEN];
@@ -473,21 +475,10 @@ listprops_wildcard(dbref player, dbref thing, const char *dir, const char *wild)
     /* Guard against runaway recursion on a pathologically deep prop tree.
      * set_property_nofetch enforces MAX_PROPTREE_DEPTH on newly set props,
      * but a legacy database could already contain a deeper tree, and
-     * recursing into it would overflow the C stack.  'dir' carries one
-     * PROPDIR_DELIMITER per level of nesting, so its delimiter count is
-     * our current depth.
+     * recursing into it would overflow the C stack.
      */
-    {
-        int depth = 0;
-
-        for (const char *s = dir; *s; s++) {
-            if (*s == PROPDIR_DELIMITER)
-                depth++;
-        }
-
-        if (depth >= MAX_PROPTREE_DEPTH)
-            return cnt;
-    }
+    if (depth >= MAX_PROPTREE_DEPTH)
+        return cnt;
 
     strcpyn(wld, sizeof(wld), wild);
     i = strlen(wld);
@@ -523,7 +514,7 @@ listprops_wildcard(dbref player, dbref thing, const char *dir, const char *wild)
                 if (recurse)
                     ptr = "**";
 
-                cnt += listprops_wildcard(player, thing, buf, ptr);
+                cnt += listprops_wildcard(player, thing, buf, ptr, depth + 1);
             }
         }
 
@@ -584,7 +575,7 @@ do_examine(int descr, dbref player, const char *name, const char *dir)
 
     if (*dir) {
         /* show him the properties */
-        cnt = listprops_wildcard(player, thing, "", dir);
+        cnt = listprops_wildcard(player, thing, "", dir, 0);
         notifyf(player, "%d propert%s listed.", cnt, (cnt == 1 ? "y" : "ies"));
         return;
     }

--- a/src/look.c
+++ b/src/look.c
@@ -470,6 +470,25 @@ listprops_wildcard(dbref player, dbref thing, const char *dir, const char *wild)
     int i, cnt = 0;
     int recurse = 0;
 
+    /* Guard against runaway recursion on a pathologically deep prop tree.
+     * set_property_nofetch enforces MAX_PROPTREE_DEPTH on newly set props,
+     * but a legacy database could already contain a deeper tree, and
+     * recursing into it would overflow the C stack.  'dir' carries one
+     * PROPDIR_DELIMITER per level of nesting, so its delimiter count is
+     * our current depth.
+     */
+    {
+        int depth = 0;
+
+        for (const char *s = dir; *s; s++) {
+            if (*s == PROPDIR_DELIMITER)
+                depth++;
+        }
+
+        if (depth >= MAX_PROPTREE_DEPTH)
+            return cnt;
+    }
+
     strcpyn(wld, sizeof(wld), wild);
     i = strlen(wld);
 

--- a/src/property.c
+++ b/src/property.c
@@ -120,6 +120,22 @@ set_property_nofetch(dbref player, const char *pname, PData * dat)
     if (!*buf)
         return;
 
+    /* Refuse to create a propdir tree nested deeper than
+     * MAX_PROPTREE_DEPTH levels.  Without this limit, a sufficiently
+     * deep prop will overflow the C stack the next time something
+     * recurses over the prop tree -- for example a recursive 'examine'
+     * listing (see listprops_wildcard in look.c).  Each PROPDIR_DELIMITER
+     * adds one level of nesting on top of the leaf, so depth starts at 1.
+     */
+    {
+        int depth = 1;
+
+        for (char *s = buf; *s; s++) {
+            if (*s == PROPDIR_DELIMITER && ++depth > MAX_PROPTREE_DEPTH)
+                return;
+        }
+    }
+
     /* Create a new element for our new property, or get an existing
      * property object if it already exists.
      */

--- a/tests/command-cases/look.yml
+++ b/tests/command-cases/look.yml
@@ -32,6 +32,45 @@
     - "- str /_testdir/innervalue2:abc"
     - "2 properties listed"
 
+# A propdir nested exactly MAX_PROPTREE_DEPTH (100) levels deep is allowed
+# and can be listed without crashing.  The path below is 100 components.
+- name: examine-deep-prop-allowed
+  setup: |
+    @create Foo
+    @set Foo=a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a:ALLOWME
+  commands: |
+    ex Foo=a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a
+  expect:
+    - ":ALLOWME"
+    - "1 property listed"
+
+# Recursively listing an object whose deepest prop is at the maximum depth
+# must complete cleanly -- this is the listing that used to overflow the C
+# stack and core the server.
+- name: examine-deep-prop-recursive
+  setup: |
+    @create Foo
+    @set Foo=a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a:ALLOWME
+  commands: |
+    ex Foo=/**
+  expect:
+    # Reaching the leaf proves the recursion descended all 100 levels, and a
+    # clean completion line proves it returned instead of coring the server.
+    - ":ALLOWME"
+    - "[0-9]+ properties listed"
+
+# Setting a propdir deeper than MAX_PROPTREE_DEPTH (101 components here) is
+# refused outright, so the prop is never created.  Listing the exact path it
+# would have occupied therefore finds nothing.
+- name: examine-deep-prop-rejected
+  setup: |
+    @create Foo
+    @set Foo=a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a:REJECTME
+  commands: |
+    ex Foo=a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a/a
+  expect:
+    - "0 properties listed"
+
 - name: examine-named-fields
   setup: |
     @create Foo


### PR DESCRIPTION
This fixes #771 and adds a recursion limit to make sure `ex me=/**` or similar can't crash the MUCK. Further, it prevents SETTING a prop that deep to begin with. The default limit is 100 deep which is plenty deep for all reasonable purposes.