### PR TITLE
Flag patch and compatibility

### DIFF
--- a/include/flags.h
+++ b/include/flags.h
@@ -15,17 +15,19 @@
 /**
  * Definitions of the bit used in object flags.
  */
-#define TYPE_ROOM           0x0 /**< room bit */
-#define TYPE_THING          0x1 /**< thing bit */
-#define TYPE_EXIT           0x2 /**< exit bit */
-#define TYPE_PLAYER         0x3 /**< player bit */
-#define TYPE_PROGRAM        0x4 /**< program bit */
+/** Object types are values contained within the first
+    few bits of the overall bit flag.  Confusing, I know. **/
+#define TYPE_ROOM           0x0 /**< room value */
+#define TYPE_THING          0x1 /**< thing value */
+#define TYPE_EXIT           0x2 /**< exit value */
+#define TYPE_PLAYER         0x3 /**< player value */
+#define TYPE_PROGRAM        0x4 /**< program value */
 
 /* 0x5 available */
 
-#define TYPE_GARBAGE        0x6 /**< garbage bit */
+#define TYPE_GARBAGE        0x6 /**< garbage value */
 #define TYPE_ANY            0x7 /**< no particular type */
-#define TYPE_MASK           0x7 /**< bitmask for all types */
+#define TYPE_MASK           0x7 /**< bitmask for all object types */
 
 /* 0x8 available */
 
@@ -129,6 +131,7 @@ struct object_type {
     char *titlecase;
     char *singular;
     char *plural;
+    bool hidden;
 };
 
 extern struct object_type object_types[];

--- a/include/tune.h
+++ b/include/tune.h
@@ -254,6 +254,7 @@ extern dbref       tp_welcome_mpi_what;         /**< Tune variable */
 extern dbref       tp_welcome_mpi_who;          /**< Tune variable */
 extern bool        tp_who_hides_dark;           /**< Tune variable */
 extern bool        tp_wiz_vehicles;             /**< Tune variable */
+extern bool        tp_show_hidden_object_types; /**< Tune variable */
 
 /**
  * @var tune_list

--- a/include/tunelist.h
+++ b/include/tunelist.h
@@ -201,6 +201,7 @@ dbref       tp_welcome_mpi_what;                    /**> Described below */
 dbref       tp_welcome_mpi_who;                     /**> Described below */
 bool        tp_who_hides_dark;                      /**> Described below */
 bool        tp_wiz_vehicles;                        /**> Described below */
+bool        tp_show_hidden_object_types;            /**> Described below */
 
 /**
  * @var tune_list
@@ -2289,6 +2290,18 @@ struct tune_entry tune_list[] = {
         TP_TYPE_BOOLEAN,
         .defaultval.b=false,
         .currentval.b=&tp_wiz_vehicles,
+        0,
+        MLEV_WIZARD,
+        true
+    },
+    {
+        "show_hidden_object_types",
+        "Display object type flags in a non-backwards compatible manner",
+        "Database",
+        "",
+        TP_TYPE_BOOLEAN,
+        .defaultval.b=false,
+        .currentval.b=&tp_show_hidden_object_types,
         0,
         MLEV_WIZARD,
         true

--- a/src/flags.c
+++ b/src/flags.c
@@ -276,7 +276,7 @@ flag_object(dbref ref)
 {
     int type = OBJECT_TYPE(ref);
     char flag = object_types[type].symbol;
-    boolean hidden = object_types[type].hidden;
+    bool hidden = object_types[type].hidden;
 
     if (!tp_show_hidden_object_types && hidden) {
         flag = '\0';

--- a/src/flags.c
+++ b/src/flags.c
@@ -382,7 +382,7 @@ flag_unparse_object(dbref player, dbref ref, char *buf, size_t size)
                 ))) {
 
                 flag_list(ref, flags_buf, sizeof(flags_buf));
-                typeflag_buf = "\0\0";
+                typeflag_buf[1] = '\0';
                 typeflag_buf[0] = flag_object(ref);
                 snprintf(buf, size, "%.*s(#%d%s%s)", BUFFER_LEN / 2, NAME(ref), ref, typeflag_buf, flags_buf);
             } else {

--- a/src/flags.c
+++ b/src/flags.c
@@ -21,11 +21,14 @@
  * their associated display strings.
  */
 struct object_type object_types[] = {
-    { 'R', "ROOM", "Room", "room", "rooms" },
-    { 'T', "THING", "Thing", "thing", "things" },
-    { 'E', "EXIT/ACTION", "Exit", "exit", "exits" },
-    { 'P', "PLAYER", "Player", "player", "players" },
-    { 'F', "PROGRAM", "Program", "program", "programs" }
+    { 'R', "ROOM", "Room", "room", "rooms", false },
+    { 'T', "THING", "Thing", "thing", "things", true },
+    { 'E', "EXIT/ACTION", "Exit", "exit", "exits", false },
+    { 'P', "PLAYER", "Player", "player", "players", false },
+    { 'F', "PROGRAM", "Program", "program", "programs", false },
+    { '-', "UNDEF", "Undefined", "undefined", "undefined", true },
+    { 'G', "GARBAGE", "Garbage", "garbage", "garbage", false },
+    { '-', "UNDEF", "Undefined", "undefined", "undefined", true }
 };
 /**
  * This structure and array support the listing of system flags and provides
@@ -263,6 +266,25 @@ flag_list_verbose(dbref ref, char *buf, size_t size)
 }
 
 /**
+ * Returns the char representation of the object-type flag.  This may
+ * be a null character.
+ *
+ * @param thing the object to return the flag for.
+ */
+char
+flag_object(dbref ref)
+{
+    int type = OBJECT_TYPE(ref);
+    char flag = object_types[type].symbol;
+    boolean hidden = object_types[type].hidden;
+
+    if (!tp_show_hidden_object_types && hidden) {
+        flag = '\0';
+    }
+    return flag;
+}
+
+/**
  * Generates a string representation of object flags. Uses the provided
  * buffer that has the given size.
  *
@@ -296,7 +318,8 @@ flag_list(dbref ref, char *buf, size_t size)
     }
 
     int mlevel = OBJECT_MLEVEL(ref);
-    if (mlevel > 0 && (p + 1 < end)) {
+    if (mlevel > 0 && (p + 2 < end)) {
+        *p++ = 'M';
         *p++ = mlevel + '0';
     }
 
@@ -330,6 +353,7 @@ void
 flag_unparse_object(dbref player, dbref ref, char *buf, size_t size)
 {
     char flags_buf[MINI_BUFFER_LEN];
+    char typeflag_buf[2];
 
     if (player != NOTHING) {
         player = OWNER(player);
@@ -358,7 +382,9 @@ flag_unparse_object(dbref player, dbref ref, char *buf, size_t size)
                 ))) {
 
                 flag_list(ref, flags_buf, sizeof(flags_buf));
-                snprintf(buf, size, "%.*s(#%d%c%s)", BUFFER_LEN / 2, NAME(ref), ref, object_types[OBJECT_TYPE(ref)].symbol, flags_buf);
+                typeflag_buf = "\0\0";
+                typeflag_buf[0] = flag_object(ref);
+                snprintf(buf, size, "%.*s(#%d%s%s)", BUFFER_LEN / 2, NAME(ref), ref, typeflag_buf, flags_buf);
             } else {
                 strcpyn(buf, size, NAME(ref));
             }

--- a/src/mfuns.c
+++ b/src/mfuns.c
@@ -3532,6 +3532,8 @@ mfn_money(MFUNARGS)
 const char *
 mfn_flags(MFUNARGS)
 {
+    char buf2[BUFFER_LEN];
+    char buf3[2];
     dbref obj = mesg_dbref_local(descr, player, what, perms, argv[0], mesgtyp);
 
     if (obj == UNKNOWN || obj == AMBIGUOUS || obj == NOTHING || obj == HOME)
@@ -3540,7 +3542,10 @@ mfn_flags(MFUNARGS)
     if (obj == PERMDENIED)
         ABORT_MPI("FLAGS", "Permission denied.");
 
-    flag_list(obj, buf, sizeof(buf));
+    buf3[1] = '\0';
+    buf3[0] = flag_object(obj);
+    flag_list(obj, buf2, sizeof(buf2));
+    snprintf(buf, sizeof(buf), "%s%s", buf3, buf2);
     return buf;
 }
 


### PR DESCRIPTION
This fixes the issue where the MPI flag function was no longer returning the object type flags.  Additionally, we recreated backwards compatibility for flag strings overall, BUT added a tune to allow for 'new style' flags going forward - e.g. for folks who want 'T' to show up for Things, which is not how the system used to work.  Some minor code/comment cleanup.
This brings back the 'M' part of the MUCKER level flags when parsing out the strings, and returns the ability to display 'Garbage' type flags if you somehow manage to ram a garbage dbref through.