### PR TITLE
Minor TODO cleanup

### DIFF
--- a/include/flags.h
+++ b/include/flags.h
@@ -218,6 +218,14 @@ bool flag_eval(dbref ref, const char *spec);
 bool flag_eval_pattern(dbref ref, const char *pattern);
 
 /**
+ * Returns the char representation of the object-type flag.  This may
+ * be a null character.
+ *
+ * @param thing the object to return the flag for.
+ */
+char flag_object(dbref ref);
+
+/**
  * Generates a string representation of object flags. Uses the provided
  * buffer that has the given size.
  *

--- a/include/player.h
+++ b/include/player.h
@@ -12,16 +12,13 @@
 #include "config.h"
 
 /**
- * Adds a player to the player lookup cache: WARNING poorly named function
+ * Adds a player to the player lookup cache.
  *
  * This does NOT actually create a player -- @see create_player
  *
- * @todo: Rename this to player_hash_add or something similar to that
- *        to make it more clear.
- *
  * @param who the player ref to add to the hash
  */
-void add_player(dbref who);
+void player_hash_add(dbref who);
 
 /**
  * Check a player's password
@@ -88,7 +85,7 @@ void clear_players(void);
 dbref create_player(const char *name, const char *password, char *error);
 
 /**
- * Deletes a player from the lookup cache: WARNING poorly named function
+ * Deletes a player from the lookup cache.
  *
  * This does not actually delete a player -- @see toad_player
  *
@@ -97,12 +94,9 @@ dbref create_player(const char *name, const char *password, char *error);
  *
  * The wizards will be notified if there is a failure here.  @see wall_wizards
  *
- * @todo: Rename this to player_hash_delete or something similar to that
- *        to make it more clear.
- *
  * @param who the player to remove from the cache
  */
-void delete_player(dbref who);
+void player_hash_delete(dbref who);
 
 /**
  * Look up a player by name

--- a/src/db.c
+++ b/src/db.c
@@ -1129,7 +1129,7 @@ db_read_object(FILE * f, dbref objno)
         PLAYER_SET_CURR_PROG(objno, NOTHING);
         PLAYER_SET_IGNORE_LAST(objno, NOTHING);
         OWNER(objno) = objno;
-        add_player(objno);
+        player_hash_add(objno);
         break;
 
     case TYPE_PROGRAM:

--- a/src/fbsignal.c
+++ b/src/fbsignal.c
@@ -274,9 +274,7 @@ void
 sig_emerg(int i)
 {
     (void)i;
-    /*
-     * @TODO This should probably log_status as well ?
-     */
+    log_status("EMERGENCY: via SIGEMERG");
     wall_and_flush
         ("\nEmergency signal received ! (power failure ?)\nThe database will be saved.\n");
     dump_database();

--- a/src/fbtime.c
+++ b/src/fbtime.c
@@ -317,17 +317,18 @@ timestr_full(long dtime)
 const char *
 timestr_long(long dtime)
 {
-    static char buf[SMALL_BUFFER_LEN], value[SMALL_BUFFER_LEN];
+    static char buf[SMALL_BUFFER_LEN];
     const char *str[7] = { "year", "month", "week", "day", "hour", "minute", "second" };
     int div[7] = { 31556736, 2621376, 604800, 86400, 3600, 60, 1 };
 
-    *buf = *value = 0;
+    *buf = 0;
 
     for (int i = 0; i < 7; i++) {
         if (dtime >= div[i]) {
             long temp = dtime / div[i];
-            snprintf(value, sizeof(value), "%s%s%ld %s%s", buf, (*buf ? ", " : ""), temp, str[i], temp != 1 ? "s" : "");
-            strncpy(buf, value, sizeof(buf));
+            size_t used = strlen(buf);
+            snprintf(buf + used, sizeof(buf) - used, "%s%ld %s%s",
+                     used ? ", " : "", temp, str[i], temp != 1 ? "s" : "");
             dtime %= div[i];
         }
     }

--- a/src/fbtime.c
+++ b/src/fbtime.c
@@ -320,15 +320,21 @@ timestr_long(long dtime)
     static char buf[SMALL_BUFFER_LEN];
     const char *str[7] = { "year", "month", "week", "day", "hour", "minute", "second" };
     int div[7] = { 31556736, 2621376, 604800, 86400, 3600, 60, 1 };
+    size_t used = 0;
 
     *buf = 0;
 
     for (int i = 0; i < 7; i++) {
         if (dtime >= div[i]) {
             long temp = dtime / div[i];
-            size_t used = strlen(buf);
-            snprintf(buf + used, sizeof(buf) - used, "%s%ld %s%s",
-                     used ? ", " : "", temp, str[i], temp != 1 ? "s" : "");
+            int printed = snprintf(buf + used, sizeof(buf) - used, "%s%ld %s%s",
+                                   (used ? ", " : ""), temp, str[i], temp != 1 ? "s" : "");
+            if (printed > 0) {
+                used += printed;
+                if (used >= sizeof(buf)) {
+                    used = sizeof(buf) - 1;
+                }
+            }
             dtime %= div[i];
         }
     }

--- a/src/mcppkgs.c
+++ b/src/mcppkgs.c
@@ -24,6 +24,8 @@
 #include "props.h"
 #include "tune.h"
 
+#define MCP_LANGUAGES_MUF_VERSION "muf:7.0"
+
 /**
  * Send an MCP error message using the org-fuzzball-notify package
  *
@@ -423,12 +425,7 @@ mcppkg_languages(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
     if (!strcasecmp(msg->mesgname, "request")) {
         mcp_mesg_init(&omsg, "org-fuzzball-languages", "supported");
 
-        /*
-         * TODO: Shouldn't this constant MUF version be in some define?
-         *       Are we really at "version 7" or is this out of date?
-         *       Or is this just the same as the MUCK version?
-         */
-        mcp_mesg_arg_append(&omsg, "languages", "muf:7.0");
+        mcp_mesg_arg_append(&omsg, "languages", MCP_LANGUAGES_MUF_VERSION);
         mcp_frame_output_mesg(mfr, &omsg);
         mcp_mesg_clear(&omsg);
         return;

--- a/src/mcppkgs.c
+++ b/src/mcppkgs.c
@@ -390,9 +390,8 @@ mcppkg_simpleedit(McpFrame * mfr, McpMesg * msg, McpVer ver, void *context)
 
             tune_setparm(player, reference, content, TUNE_MLEV(player));
         } else if (!strcasecmp(category, "user")) {
-            /*
-             * @TODO this should probably have an 'unsupported' error ?
-             */
+            show_mcp_error(mfr, "simpleedit-set", "Unsupported reference category.");
+            return;
         } else {
             show_mcp_error(mfr, "simpleedit-set", "Unknown reference category.");
             return;

--- a/src/mfuns.c
+++ b/src/mfuns.c
@@ -3545,7 +3545,7 @@ mfn_flags(MFUNARGS)
     buf3[1] = '\0';
     buf3[0] = flag_object(obj);
     flag_list(obj, buf2, sizeof(buf2));
-    snprintf(buf, sizeof(buf), "%s%s", buf3, buf2);
+    snprintf(buf, buflen, "%s%s", buf3, buf2);
     return buf;
 }
 

--- a/src/mufevent.c
+++ b/src/mufevent.c
@@ -81,20 +81,52 @@ muf_event_process_free(struct mufevent_process *ptr)
         mufevent_processes = ptr->next;
     }
 
+    /*
+     * @TODO: This is just a waste of CPU to NULL this stuff out.  If we were
+     *        re-using the structure it would make sense, but we're setting
+     *        all this then freeing it.  Even in a theoretical threaded
+     *        situation this doesn't make sense, because we already dequeue'd
+     *        it.
+     */
+    ptr->prev = NULL;
+    ptr->next = NULL;
+    ptr->player = NOTHING;
+
     if (ptr->fr) {
         if (PROGRAM_INSTANCES(ptr->prog)) {
             prog_clean(ptr->fr);
         }
+
+        /* @TODO: I know it's nitpicky, but this continues to be silly */
+        ptr->fr = NULL;
     }
+
+    /* @TODO: ....and this */
+    ptr->prog = NOTHING;
 
     if (ptr->filters) {
         for (int i = 0; i < ptr->filtercount; i++) {
             free(ptr->filters[i]);
+            ptr->filters[i] = NULL;
         }
 
         free(ptr->filters);
+
+        /* @TODO: ....and this */
+        ptr->filters = NULL;
+        ptr->filtercount = 0;
     }
 
+    /* @TODO: ....and this */
+    ptr->deleted = 1;
+
+    /*
+     * See?  We just blew away all those assignments we set and rattled up
+     * the CPU's cache for nothing.
+     *
+     * ... of course this is such a rarely used feature anyway, we probably
+     * aren't saving all that much.
+     */
     free(ptr);
 }
 

--- a/src/mufevent.c
+++ b/src/mufevent.c
@@ -81,52 +81,20 @@ muf_event_process_free(struct mufevent_process *ptr)
         mufevent_processes = ptr->next;
     }
 
-    /*
-     * @TODO: This is just a waste of CPU to NULL this stuff out.  If we were
-     *        re-using the structure it would make sense, but we're setting
-     *        all this then freeing it.  Even in a theoretical threaded
-     *        situation this doesn't make sense, because we already dequeue'd
-     *        it.
-     */
-    ptr->prev = NULL;
-    ptr->next = NULL;
-    ptr->player = NOTHING;
-
     if (ptr->fr) {
         if (PROGRAM_INSTANCES(ptr->prog)) {
             prog_clean(ptr->fr);
         }
-
-        /* @TODO: I know it's nitpicky, but this continues to be silly */
-        ptr->fr = NULL;
     }
-
-    /* @TODO: ....and this */
-    ptr->prog = NOTHING;
 
     if (ptr->filters) {
         for (int i = 0; i < ptr->filtercount; i++) {
             free(ptr->filters[i]);
-            ptr->filters[i] = NULL;
         }
 
         free(ptr->filters);
-
-        /* @TODO: ....and this */
-        ptr->filters = NULL;
-        ptr->filtercount = 0;
     }
 
-    /* @TODO: ....and this */
-    ptr->deleted = 1;
-
-    /*
-     * See?  We just blew away all those assignments we set and rattled up
-     * the CPU's cache for nothing.
-     *
-     * ... of course this is such a rarely used feature anyway, we probably
-     * aren't saving all that much.
-     */
     free(ptr);
 }
 

--- a/src/p_array.c
+++ b/src/p_array.c
@@ -1692,7 +1692,12 @@ prim_array_get_propdirs(PRIM_PROTOTYPE)
     propadr = first_prop(ref, dir, &pptr, propname, sizeof(propname));
 
     while (propadr) {
-        snprintf(buf, sizeof(buf), "%s%c%s", dir, PROPDIR_DELIMITER, propname);
+        int used = snprintf(buf, sizeof(buf), "%s%c%s", dir, PROPDIR_DELIMITER, propname);
+
+        if (used < 0 || (size_t) used >= sizeof(buf)) {
+            array_free(nu);
+            abort_interp("Property name too long.");
+        }
 
         if (prop_read_perms(ProgUID, ref, buf, mlev)) {
             prptr = get_property(ref, buf);
@@ -2153,23 +2158,29 @@ prim_array_put_propvals(PRIM_PROTOTYPE)
         do {
             oper4 = array_getitem(arr, &temp1);
 
+            int used = 0;
+
             switch (temp1.type) {
                 case PROG_STRING:
-                    snprintf(propname, sizeof(propname), "%s%c%s", dir,
+                    used = snprintf(propname, sizeof(propname), "%s%c%s", dir,
                              PROPDIR_DELIMITER, DoNullInd(temp1.data.string));
                     break;
 
                 case PROG_INTEGER:
-                    snprintf(propname, sizeof(propname), "%s%c%d", dir,
+                    used = snprintf(propname, sizeof(propname), "%s%c%d", dir,
                              PROPDIR_DELIMITER, temp1.data.number);
                     break;
 
                 case PROG_FLOAT:
-                    snprintf(propname, sizeof(propname), "%s%c%.15g", dir,
+                    used = snprintf(propname, sizeof(propname), "%s%c%.15g", dir,
                              PROPDIR_DELIMITER, temp1.data.fnumber);
 
                     if (!strchr(propname, '.') && !strchr(propname, 'n')
                         && !strchr(propname, 'e')) {
+                        if (strlen(propname) + 2 >= sizeof(propname)) {
+                            abort_interp("Property name too long.");
+                        }
+
                         strcatn(propname, sizeof(propname), ".0");
                     }
 
@@ -2177,6 +2188,10 @@ prim_array_put_propvals(PRIM_PROTOTYPE)
 
                 default:
                     *propname = '\0';
+            }
+
+            if (used < 0 || (size_t) used >= sizeof(propname)) {
+                abort_interp("Property name too long.");
             }
 
             if (!prop_write_perms(ProgUID, ref, propname, mlev))

--- a/src/p_db.c
+++ b/src/p_db.c
@@ -719,9 +719,9 @@ prim_setname(PRIM_PROTOTYPE)
         /* everything ok, notify */
         log_status("NAME CHANGE (MUF): %s(#%d) to %s", NAME(ref), ref, b);
 
-        delete_player(ref);
+        player_hash_delete(ref);
         change_player_name(ref, b);
-        add_player(ref);
+        player_hash_add(ref);
     } else {
         if (!ok_object_name(b, OBJECT_TYPE(ref))) {
             abort_interp("Invalid name.");

--- a/src/p_mcp.c
+++ b/src/p_mcp.c
@@ -72,12 +72,10 @@ struct mcpevent_context {
 /**
  * Easy cleanup of a pointer to a mcp_muf_context struct
  *
- * TODO: Add inline to this.
- *
  * @private
  * @param context the pointer to a mcp_muf_context to free
  */
-static void
+static inline void
 muf_mcp_context_cleanup(void *context)
 {
     struct mcp_muf_context *mmc = context;

--- a/src/p_mcp.c
+++ b/src/p_mcp.c
@@ -78,9 +78,7 @@ struct mcpevent_context {
 static inline void
 muf_mcp_context_cleanup(void *context)
 {
-    struct mcp_muf_context *mmc = context;
-
-    free(mmc);
+    free(context);
 }
 
 /**
@@ -209,8 +207,7 @@ muf_mcp_callback(McpFrame * mfr, McpMesg * mesg, McpVer version, void *context)
 static void
 mcpevent_context_cleanup(void *context)
 {
-    struct mcpevent_context *mec = context;
-    free(mec);
+    free(context);
 }
 
 /**

--- a/src/player.c
+++ b/src/player.c
@@ -245,7 +245,7 @@ create_player(const char *name, const char *password, char *error)
 
     /* link him to tp_player_start */
     PUSH(player, CONTENTS(tp_player_start));
-    add_player(player);
+    player_hash_add(player);
     DBDIRTY(player);
     DBDIRTY(tp_player_start);
 
@@ -307,7 +307,7 @@ toad_player(int descr, dbref player, dbref victim, dbref recipient)
     free((void *) PLAYER_PASSWORD(victim));
     PLAYER_SET_PASSWORD(victim, 0);
 
-    delete_player(victim);
+    player_hash_delete(victim);
     snprintf(buf, sizeof(buf), "A slimy toad named %s", NAME(victim));
     free((void *) NAME(victim));
     NAME(victim) = alloc_string(buf);
@@ -378,17 +378,14 @@ clear_players(void)
 }
 
 /**
- * Adds a player to the player lookup cache: WARNING poorly named function
+ * Adds a player to the player lookup cache.
  *
  * This does NOT actually create a player -- @see create_player
- *
- * @TODO: Rename this to player_hash_add or something similar to that
- *        to make it more clear.
  *
  * @param who the player ref to add to the hash
  */
 void
-add_player(dbref who)
+player_hash_add(dbref who)
 {
     hash_data hd;
 
@@ -402,7 +399,7 @@ add_player(dbref who)
 }
 
 /**
- * Deletes a player from the lookup cache: WARNING poorly named function
+ * Deletes a player from the lookup cache.
  *
  * This does not actually delete a player -- @see toad_player
  *
@@ -411,13 +408,10 @@ add_player(dbref who)
  *
  * The wizards will be notified if there is a failure here.  @see wall_wizards
  *
- * @TODO: Rename this to player_hash_delete or something similar to that
- *        to make it more clear.
- *
  * @param who the player to remove from the cache
  */
 void
-delete_player(dbref who)
+player_hash_delete(dbref who)
 {
     int result;
     /*
@@ -480,9 +474,9 @@ delete_player(dbref who)
                     }
 
                     change_player_name(ren, namebuf);
-                    add_player(ren);
+                    player_hash_add(ren);
                 } else {
-                    add_player(i);
+                    player_hash_add(i);
                 }
             }
         }

--- a/src/prochelp.c
+++ b/src/prochelp.c
@@ -575,20 +575,14 @@ print_topics(FILE * f, FILE * hf)
  * Stores section, topic, and summary information for the given helpfile.
  *
  * @private
- * @param infile the sourc helpfile
+ * @param infile the source helpfile
  * @return the string length of the longest topic
  */
-static int
+static void
 find_topics(FILE * infile)
 {
     char buf[4096];
     char *s, *p;
-    int longest, lng;
-
-    /**
-     * @TODO Remove longest, and change function to return void.
-     */
-    longest = 0;
 
     while (!feof(infile)) {
         do {
@@ -644,17 +638,10 @@ find_topics(FILE * infile)
 
                 add_topic(p);
 
-                lng = strlen(p);
-
-                if (lng > longest)
-                    longest = lng;
-
                 break;
             }
         }
     }
-
-    return (longest);
 }
 
 /**

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -224,8 +224,9 @@ static const char * hostfetch_v6(struct in6_addr *ip) {
  * @private
  * @param ip the IP to add to the cache
  * @param name the host name to add to the cache
+ * @param timestamp the time to store
  */
-static void hostadd_v6(struct in6_addr *ip, const char *name) {
+static void hostadd_v6(struct in6_addr *ip, const char *name, time_t timestamp) {
     struct hostcache *ptr;
 
     if (!(ptr = malloc(sizeof(struct hostcache))))
@@ -241,31 +242,9 @@ static void hostadd_v6(struct in6_addr *ip, const char *name) {
     hostcache_list = ptr;
     memcpy(&(ptr->ipnum_v6), ip, sizeof(struct in6_addr));
     ptr->ipnum = 0;
-    ptr->time = 0;
+    ptr->time = timestamp;
     strcpyn(ptr->name, sizeof(ptr->name), name);
     hostprune();
-}
-
-/**
- * Add an IPv6 and name pair to the cache, and set the timestamp
- *
- * Why this is separate, I'm not entirely sure; hostadd_v6 is called
- * seperately from this call for some reason, though it seems like
- * this and hostadd_v6 could be merged and the timestamp always set.
- *
- * TODO: Investiage if this and hostadd_v6 can be merged and timestamp
- *       always set -- I'm really not sure why we would ever want the
- *       timestamp to not be set.
- *
- * @see hostadd_v6
- *
- * @private
- * @param ip the IP to set
- * @param name the host name paired to the IP.
- */
-static void hostadd_timestamp_v6(struct in6_addr *ip, const char *name) {
-    hostadd_v6(ip, name);
-    hostcache_list->time = time(NULL);
 }
 
 /**
@@ -439,7 +418,7 @@ static const char * addrout_v6(struct in6_addr *a, in_port_t prt,
 
     if (he) {
         strcpyn(tmpbuf, sizeof(tmpbuf), he->h_name);
-        hostadd_v6(a, tmpbuf);
+        hostadd_v6(a, tmpbuf, 0);
         ptr = get_username_v6(a, prt, myprt);
 
         if (ptr) {
@@ -452,7 +431,7 @@ static const char * addrout_v6(struct in6_addr *a, in_port_t prt,
     }
 
     inet_ntop(AF_INET6, a, tmpbuf, SMALL_BUFFER_LEN);
-    hostadd_timestamp_v6(a, tmpbuf);
+    hostadd_v6(a, tmpbuf, time(NULL));
     ptr = get_username_v6(a, prt, myprt);
 
     if (ptr) {
@@ -539,8 +518,9 @@ static const char * hostfetch(long ip) {
  * @private
  * @param ip the IP to add
  * @param name the host to map the IP to
+ * @param timestamp the time to store
  */
-static void hostadd(long ip, const char *name) {
+static void hostadd(long ip, const char *name, time_t timestamp) {
     struct hostcache *ptr;
 
     if (!(ptr = malloc(sizeof(struct hostcache))))
@@ -556,25 +536,9 @@ static void hostadd(long ip, const char *name) {
     hostcache_list = ptr;
     memset(&(ptr->ipnum_v6), 0, sizeof(struct in6_addr));
     ptr->ipnum = ip;
-    ptr->time = 0;
+    ptr->time = timestamp;
     strcpyn(ptr->name, sizeof(ptr->name), name);
     hostprune();
-}
-
-/**
- * Add an IPv4 host to the cache and set the current time
- *
- * TODO: Investiage if this and hostadd can be merged and timestamp
- *       always set -- I'm really not sure why we would ever want the
- *       timestamp to not be set.
- *
- * @private
- * @param ip the IP to add
- * @param name the hostname that belongs to that IP
- */
-static void hostadd_timestamp(long ip, const char *name) {
-    hostadd(ip, name);
-    hostcache_list->time = time(NULL);
 }
 
 /**
@@ -759,7 +723,7 @@ static const char * addrout(in_addr_t a, in_port_t prt, in_port_t myprt) {
 
     if (he) {
         strcpyn(tmpbuf, sizeof(tmpbuf), he->h_name);
-        hostadd(ntohl(a), tmpbuf);
+        hostadd(ntohl(a), tmpbuf, 0);
         ptr = get_username(a, prt, myprt);
 
         if (ptr) {
@@ -775,7 +739,7 @@ static const char * addrout(in_addr_t a, in_port_t prt, in_port_t myprt) {
     snprintf(tmpbuf, sizeof(tmpbuf),
              "%" PRIu32 ".%" PRIu32 ".%" PRIu32 ".%" PRIu32, (a >> 24) & 0xff,
              (a >> 16) & 0xff, (a >> 8) & 0xff, a & 0xff);
-    hostadd_timestamp(a, tmpbuf);
+    hostadd(a, tmpbuf, time(NULL));
     ptr = get_username(htonl(a), prt, myprt);
 
     if (ptr) {

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -833,15 +833,8 @@ static pthread_mutex_t output_mutex = PTHREAD_MUTEX_INITIALIZER;
  * @see resolver_thread_root
  *
  * @private
- * @return int -- not really used for anything, does not always return
  */
 static int do_resolve(void) {
-    /*
-     * TODO: change this to return void and just have the 'return 0's
-     *       below just 'return'.  If you get to the bottom of this function,
-     *       it actually returns NOTHING which is weird -- thankfully nothing
-     *       pays attention to the return value of this function.
-     */
     int ip1, ip2, ip3, ip4;
     in_port_t prt, myprt;
     int doagain;
@@ -864,13 +857,13 @@ static int do_resolve(void) {
 
             /* lock input here. */
             if (pthread_mutex_lock(&input_mutex)) {
-                return 0;
+                return;
             }
 
             if (shutdown_was_requested) {
                 /* unlock input here. */
                 pthread_mutex_unlock(&input_mutex);
-                return 0;
+                return;
             }
 
             /*
@@ -903,7 +896,7 @@ static int do_resolve(void) {
             pthread_mutex_unlock(&input_mutex);
 
             if (shutdown_was_requested) {
-                return 0;
+                return;
             } else if (doagain) {
                 sleep(1);
             }
@@ -966,7 +959,7 @@ static int do_resolve(void) {
 
         /* lock output here. */
         if (pthread_mutex_lock(&output_mutex)) {
-            return 0;
+            return;
         }
 
         fprintf(stdout, "%s\n", outbuf);

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -577,11 +577,6 @@ static void hostadd_timestamp(long ip, const char *name) {
     hostcache_list->time = time(NULL);
 }
 
-/*
- * TODO: I'm pretty sure we don't need this declaration
- */
-void set_signals(void);
-
 /**
  * Traps certain signals that we don't care about
  *

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -53,29 +53,15 @@ static char *strcpyn(char *buf, size_t bufsize, const char *src) {
     return buf;
 }
 
-/*
- * TODO: I don't think this declaration is needed since the definition is
- *       right after it, and this is local to the file.
- *
- *       If this is being linked to another file that defines notify, then
- *       it would make since to declare ... but to declare + define?
- *       I think we can delete it.
- *
- *       In fact, 'notify' is not used in this file at all -- maybe it is
- *       needed for a define?  Maybe we should just remove it altogether?
- */
-int notify(int player, const char *msg);
-
 /**
- * This is a local version of the 'notify' method used by fuzzball
- *
- * It just is a wrapper around printf, probably to satisfy some dependency.
+ * Local notify shim when building fb-resolver (interface.o not linked)
  *
  * @param player ignored
  * @param msg the message to display
  * @return the return value of printf
  */
-int notify(int player, const char *msg) {
+int
+notify(int player, const char *msg) {
     (void)player;
     return printf("%s\n", msg);
 }

--- a/src/resolver.c
+++ b/src/resolver.c
@@ -779,7 +779,7 @@ static pthread_mutex_t output_mutex = PTHREAD_MUTEX_INITIALIZER;
  *
  * @private
  */
-static int do_resolve(void) {
+static void do_resolve(void) {
     int ip1, ip2, ip3, ip4;
     in_port_t prt, myprt;
     int doagain;

--- a/src/sanity.c
+++ b/src/sanity.c
@@ -1315,14 +1315,16 @@ find_misplaced_objects(void)
 
                 case TYPE_PLAYER: {
                     char *name = malloc(tp_player_name_limit+1);
+                    int temp;
 
-                    /* Loop to find a name we can use */
+                    for (temp = 1; ; temp++) {
+                        int len = snprintf(name, tp_player_name_limit+1,
+                                           "Unnamed%d", temp);
 
-                    /* @TODO: turn this into a for loop */
-                    int temp = 0;
-
-                    while (lookup_player(name) != NOTHING && strlen(name) < (unsigned int)tp_player_name_limit) {
-                        snprintf(name, tp_player_name_limit+1, "Unnamed%d", ++temp);
+                        if (len < 0 || len >= tp_player_name_limit ||
+                            lookup_player(name) == NOTHING) {
+                            break;
+                        }
                     }
 
                     NAME(loop) = alloc_string(name);

--- a/src/sanity.c
+++ b/src/sanity.c
@@ -1121,7 +1121,7 @@ create_lostandfound(dbref * player, dbref * room)
 {
     char *player_name = malloc(tp_player_name_limit+1);
     char unparse_buf[16384];
-    int temp = 0;
+    int player_name_len, temp;
 
     *room = new_object(false);
     NAME(*room) = alloc_string("lost+found");
@@ -1132,11 +1132,19 @@ create_lostandfound(dbref * player, dbref * room)
     PUSH(*room, CONTENTS(GLOBAL_ENVIRONMENT));
     SanFixed(*room, "Using %s to resolve unknown location");
 
-    while (lookup_player(player_name) != NOTHING && strlen(player_name) < (unsigned int)tp_player_name_limit) {
-        snprintf(player_name, tp_player_name_limit+1, "lost+found%d", ++temp);
+    player_name_len = snprintf(player_name, tp_player_name_limit+1,
+                               "lost+found");
+
+    for (temp = 1;
+         player_name_len >= 0 &&
+         player_name_len < tp_player_name_limit &&
+         lookup_player(player_name) != NOTHING;
+         temp++) {
+        player_name_len = snprintf(player_name, tp_player_name_limit+1,
+                                   "lost+found%d", temp);
     }
 
-    if (strlen(player_name) >= (unsigned int)tp_player_name_limit) {
+    if (player_name_len < 0 || player_name_len >= tp_player_name_limit) {
         flag_unparse_object(NOTHING, GOD, unparse_buf, sizeof(unparse_buf));
         log_sanfix("WARNING: Unable to get lost+found player, using %s", unparse_buf);
         *player = GOD;

--- a/src/sanity.c
+++ b/src/sanity.c
@@ -1158,7 +1158,7 @@ create_lostandfound(dbref * player, dbref * room)
         PLAYER_SET_INSERT_MODE(*player, 0);
         PUSH(*player, CONTENTS(*room));
         DBDIRTY(*player);
-        add_player(*player);
+        player_hash_add(*player);
         flag_unparse_object(NOTHING, *player, unparse_buf, sizeof(unparse_buf));
         log_sanfix("Using %s (with password %s) to resolve unknown owner",
                    unparse_buf, rpass);
@@ -1326,7 +1326,7 @@ find_misplaced_objects(void)
                     }
 
                     NAME(loop) = alloc_string(name);
-                    add_player(loop);
+                    player_hash_add(loop);
                     free(name);
                     break;
                 }

--- a/src/sanity.c
+++ b/src/sanity.c
@@ -1121,7 +1121,7 @@ create_lostandfound(dbref * player, dbref * room)
 {
     char *player_name = malloc(tp_player_name_limit+1);
     char unparse_buf[16384];
-    int player_name_len, temp;
+    int player_name_len;
 
     *room = new_object(false);
     NAME(*room) = alloc_string("lost+found");
@@ -1135,7 +1135,7 @@ create_lostandfound(dbref * player, dbref * room)
     player_name_len = snprintf(player_name, tp_player_name_limit+1,
                                "lost+found");
 
-    for (temp = 1;
+    for (int temp = 1;
          player_name_len >= 0 &&
          player_name_len < tp_player_name_limit &&
          lookup_player(player_name) != NOTHING;
@@ -1323,9 +1323,8 @@ find_misplaced_objects(void)
 
                 case TYPE_PLAYER: {
                     char *name = malloc(tp_player_name_limit+1);
-                    int temp;
 
-                    for (temp = 1; ; temp++) {
+                    for (int temp = 1; ; temp++) {
                         int len = snprintf(name, tp_player_name_limit+1,
                                            "Unnamed%d", temp);
 

--- a/src/set.c
+++ b/src/set.c
@@ -89,9 +89,9 @@ do_name(int descr, dbref player, const char *name, char *newname)
 
         /* everything ok, notify */
         log_status("NAME CHANGE: %s(#%d) to %s", NAME(thing), thing, newname);
-        delete_player(thing);
+        player_hash_delete(thing);
         change_player_name(thing, newname);
-        add_player(thing);
+        player_hash_add(thing);
         notify(player, "Name set.");
         return;
     } else {

--- a/src/timequeue.c
+++ b/src/timequeue.c
@@ -1048,21 +1048,17 @@ timequeue_pid_frame(int pid)
 time_t
 next_event_time(time_t now)
 {
-    /*
-     * TODO: this assumes the return value of this will be a long.
-     *       Instead, cast thusly: return (time_t) -1;
-     */
     if (tqhead) {
         if (tqhead->when == -1) {
-            return (-1L);
+            return (time_t)-1;
         } else if (now >= tqhead->when) {
-            return 0L;
+            return 0;
         } else {
             return ((time_t) (tqhead->when - now));
         }
     }
 
-    return -1L;
+    return (time_t)-1;
 }
 
 /**


### PR DESCRIPTION
These changes:
- remove unused return values and prototypes in prochelp.c and resolver.c
- address a time_t inconsistency in timequeue.c
- make the callback function inline in p_mcp.c
- add "muf:7.0" (arbitarilty the major server version) as a #define in mcppkgs.c
- return an unsupported message for the "user" category for simpleedit in mcppkgs.c
- rename add_ and delete_player in player.c
- fix uninitialized variables in sanity.c
- write to status log during emergency signal in fbsignal.c
- ~remove dead stores in mufevent.c~
- combine timestamp storage with host_add* functions in resolver.c 
- fix compiler warnings relating to string truncation and a missing prototype