### PR TITLE
welcome screen processing refactor

### DIFF
--- a/include/fbstrings.h
+++ b/include/fbstrings.h
@@ -597,6 +597,25 @@ void tolower_string(char **s);
 void toupper_string(char **s);
 
 /**
+ * Tokenizes a string into an array of fixed-size pre-allocated buffers.
+ *
+ * @param msg             The input string.
+ * @param buffer_array    Array of pointers to your destination buffers.
+ * @param array_size      How many buffers you passed.
+ * @param buffer_capacity The maximum capacity of EACH individual buffer.
+ */
+void tokenize_to_array(const char *msg, char **buffer_array, int array_size, size_t buffer_capacity);
+
+/**
+ * Tokenizes a string directly into a sequence of inline destination buffers.
+ *
+ * @param msg             The input string.
+ * @param cap             The maximum capacity of EACH individual buffer.
+ * @param ...             The sequential list of destination buffers.
+ */
+#define tokenize_as(msg, cap, ...) \
+    tokenize_to_array(msg, ((char*[]){__VA_ARGS__}), ARRAYSIZE(((char*[]){__VA_ARGS__})), cap)
+/**
  * Figure out if a string should be considered a true value
  *
  * This is used by MPI for instance to determine if a string

--- a/include/tune.h
+++ b/include/tune.h
@@ -169,6 +169,7 @@ extern int         tp_listen_mlev;              /**< Tune variable */
 extern bool        tp_lock_envcheck;            /**< Tune variable */
 extern bool        tp_log_commands;             /**< Tune variable */
 extern bool        tp_log_failed_commands;      /**< Tune variable */
+extern bool        tp_log_hosts;                /**< Tune variable */
 extern bool        tp_log_interactive;          /**< Tune variable */
 extern bool        tp_log_programs;             /**< Tune variable */
 extern int         tp_lookup_cost;              /**< Tune variable */
@@ -225,6 +226,7 @@ extern bool        tp_secure_teleport;          /**< Tune variable */
 extern bool        tp_secure_thing_movement;    /**< Tune variable */
 extern bool        tp_secure_who;               /**< Tune variable */
 extern bool        tp_server_cipher_preference; /**< Tune variable */
+extern bool        tp_show_hidden_object_types; /**< Tune variable */
 extern const char *tp_smtp_server;              /**> Described below */
 extern const char *tp_smtp_port;                /**> Described below */
 extern int         tp_smtp_ssl_type;            /**> Described below */
@@ -254,7 +256,7 @@ extern dbref       tp_welcome_mpi_what;         /**< Tune variable */
 extern dbref       tp_welcome_mpi_who;          /**< Tune variable */
 extern bool        tp_who_hides_dark;           /**< Tune variable */
 extern bool        tp_wiz_vehicles;             /**< Tune variable */
-extern bool        tp_show_hidden_object_types; /**< Tune variable */
+extern const char *tp_wizonly_bootmesg;       /**< Tune variable */
 
 /**
  * @var tune_list

--- a/include/tunelist.h
+++ b/include/tunelist.h
@@ -116,6 +116,7 @@ int         tp_listen_mlev;                         /**> Described below */
 bool        tp_lock_envcheck;                       /**> Described below */
 bool        tp_log_commands;                        /**> Described below */
 bool        tp_log_failed_commands;                 /**> Described below */
+bool        tp_log_hosts;                           /**> Described below */
 bool        tp_log_interactive;                     /**> Described below */
 bool        tp_log_programs;                        /**> Described below */
 int         tp_lookup_cost;                         /**> Described below */
@@ -172,6 +173,7 @@ bool        tp_secure_teleport;                     /**> Described below */
 bool        tp_secure_thing_movement;               /**> Described below */
 bool        tp_secure_who;                          /**> Described below */
 bool        tp_server_cipher_preference;            /**> Described below */
+bool        tp_show_hidden_object_types;            /**> Described below */
 int         tp_smtp_auth_type;                      /**> Described below */
 const char *tp_smtp_from_name;                      /**> Described below */
 const char *tp_smtp_from_email;                     /**> Described below */
@@ -201,7 +203,7 @@ dbref       tp_welcome_mpi_what;                    /**> Described below */
 dbref       tp_welcome_mpi_who;                     /**> Described below */
 bool        tp_who_hides_dark;                      /**> Described below */
 bool        tp_wiz_vehicles;                        /**> Described below */
-bool        tp_show_hidden_object_types;            /**> Described below */
+const char *tp_wizonly_bootmesg;                    /**> Described below */
 
 /**
  * @var tune_list
@@ -1236,6 +1238,18 @@ struct tune_entry tune_list[] = {
         true
     },
     {
+        "log_hosts",
+        "Log hosts during connection events",
+        "Logging",
+        "",
+        TP_TYPE_BOOLEAN,
+        .defaultval.b=true,
+        .currentval.b=&tp_log_hosts,
+        MLEV_WIZARD,
+        MLEV_WIZARD,
+        true
+    },
+    {
         "log_interactive",
         "Log text sent to MUF",
         "Logging",
@@ -1708,7 +1722,7 @@ struct tune_entry tune_list[] = {
         "",
         TP_TYPE_STRING,
         .defaultval.s=
-            "Sorry, but there are too many players online.  Please try " \
+            "Sorry, but there are too many players online. Please try " \
             "reconnecting in a few minutes.",
         .currentval.s=&tp_playermax_bootmesg,
         0,
@@ -1923,6 +1937,18 @@ struct tune_entry tune_list[] = {
         .currentval.b=&tp_server_cipher_preference,
         MLEV_GOD,
         MLEV_GOD,
+        true
+    },
+    {
+        "show_hidden_object_types",
+        "Display object type flags in a non-backwards compatible manner",
+        "Database",
+        "",
+        TP_TYPE_BOOLEAN,
+        .defaultval.b=false,
+        .currentval.b=&tp_show_hidden_object_types,
+        0,
+        MLEV_WIZARD,
         true
     },
     {
@@ -2295,13 +2321,15 @@ struct tune_entry tune_list[] = {
         true
     },
     {
-        "show_hidden_object_types",
-        "Display object type flags in a non-backwards compatible manner",
-        "Database",
+        "wizonly_bootmesg",
+        "Maintenance mode connection error message",
+        "Connecting",
         "",
-        TP_TYPE_BOOLEAN,
-        .defaultval.b=false,
-        .currentval.b=&tp_show_hidden_object_types,
+        TP_TYPE_STRING,
+        .defaultval.s=
+            "Sorry, but the game is in maintenance mode currently, and " \
+            "only wizards are allowed to connect. Please try again later.",
+        .currentval.s=&tp_wizonly_bootmesg,
         0,
         MLEV_WIZARD,
         true

--- a/src/fbstrings.c
+++ b/src/fbstrings.c
@@ -2022,3 +2022,33 @@ toupper_string(char **s)
    for (char *p = *s; *p; p++)
         *p = toupper(*p);
 }
+
+/**
+ * Tokenizes a string into an array of fixed-size pre-allocated buffers.
+ *
+ * @param msg             The input string.
+ * @param buffer_array    Array of pointers to your destination buffers.
+ * @param array_size      How many buffers you passed.
+ * @param buffer_capacity The maximum capacity of EACH individual buffer.
+ */
+void
+tokenize_to_array(const char *msg, char **buffer_array, int array_size, size_t buffer_capacity)
+{
+    if (!msg || !buffer_array || array_size <= 0 || buffer_capacity == 0) return;
+    
+    const char *current = msg;
+    const char *delimiters = " \t";
+
+    for (int i = 0; i < array_size; i++) {
+        buffer_array[i][0] = '\0';
+        current += strspn(current, delimiters);
+        if (*current == '\0') break;
+
+        size_t token_len = strcspn(current, delimiters);
+        size_t copy_len = (token_len >= buffer_capacity) ? (buffer_capacity - 1) : token_len;
+
+        memcpy(buffer_array[i], current, copy_len);
+        buffer_array[i][copy_len] = '\0';
+        current += token_len;
+    }
+}

--- a/src/interface.c
+++ b/src/interface.c
@@ -1746,7 +1746,7 @@ process_welcome_input(struct descriptor_data *d, const char *msg)
     if (do_connect) {
         log_status("CONNECTED: %s(%d), %s", NAME(player), player, connect_string);
     } else {
-        log_status("CREATED %s(%d), %s", NAME(player), player, connect_string);
+        log_status("CREATED: %s(%d), %s", NAME(player), player, connect_string);
     }
 
     d->connected = 1;

--- a/src/interface.c
+++ b/src/interface.c
@@ -1597,43 +1597,67 @@ descrdata_by_descr(int c)
  * it doesn't do any of the book keeping needed to log the player into
  * the game.
  *
+ * Uses an error parameter to communicate the reason for failure. This
+ * should be at least SMALL_BUFFER_LEN in size.
+ *
  * @private
  * @param name the player name to look up
  * @param password the player's password
+ * @param[out] error why the create failed
  * @return the dbref of the player or NOTHING if authentication fails.
  */
 static dbref
-connect_player(const char *name, const char *password)
+connect_player(const char *name, const char *password, char *error)
 {
-    dbref player;
+    dbref player = NOTHING;
 
-    if (*name == NUMBER_TOKEN && number(name + 1) && atoi(name + 1)) {
-        player = (dbref) atoi(name + 1);
-        if (!ObjExists(player) || OBJECT_TYPE(player) != TYPE_PLAYER)
-            player = NOTHING;
+    if (*name == NUMBER_TOKEN && number(name + 1)) {
+        dbref target = (dbref) atoi(name + 1);
+        
+        if (ObjExists(target) && OBJECT_TYPE(target) == TYPE_PLAYER) {
+            player = target;
+        }
     } else {
         player = lookup_player(name);
     }
 
-    if (player == NOTHING)
+    if (player == NOTHING || !check_password(player, password)) {
+        snprintf(error, SMALL_BUFFER_LEN, "%s", tp_connect_fail_mesg);
         return NOTHING;
-
-    if (!check_password(player, password))
-        return NOTHING;
+    }
 
     return player;
 }
 
 /**
+ * Boot a descriptor due to server restriction
+ *
+ * Handles the messaging and disconnection flags when a user attempts to
+ * connect or create a character while the server is locked down. It checks
+ * the restriction state to send the appropriate message, and marks the
+ * descriptor as booted.
+ *
+ * @private
+ * @param d the descriptor structure of the user to be booted
+ */
+static void
+boot_restricted(struct descriptor_data *d)
+{
+    if (wizonly_mode) {
+        queue_ansi(d, tp_wizonly_bootmesg);
+    } else {
+        queue_ansi(d, tp_playermax_bootmesg);
+    }
+    queue_write(d, "\r\n", 2);
+    d->booted = 1;
+}
+
+/**
  * Input processing for the welcome screen / pre-connect screen
  *
- * 'check_connect' is another misnomer.  This is more like
- * 'process_welcome_input' or just 'check_welcome' or 'welcome_input' or
- * something.
- *
- * Anyway, it handles the commands understood by the welcome screen:
- * create, connect, and help.  For create and connect, only the first
- * two characters are checked.
+ * Handles the commands understood by the welcome screen: create,
+ * connect, and help.  For create and connect, only the first two
+ * characters are checked for create and connect.
  *
  * If the player successfully creates or connects, the descriptor's state
  * will be changed to connected which will take them past the login
@@ -1645,154 +1669,103 @@ connect_player(const char *name, const char *password)
  * @param msg the unprocessed message typed in from the user
  */
 static void
-check_connect(struct descriptor_data *d, const char *msg)
+process_welcome_input(struct descriptor_data *d, const char *msg)
 {
     char command[MAX_COMMAND_LEN];
     char user[MAX_COMMAND_LEN];
     char password[MAX_COMMAND_LEN];
-    dbref player;
+    dbref player = NOTHING;
     char connect_string[BUFFER_LEN];
     char error[SMALL_BUFFER_LEN] = "";
+    int do_connect = 0;
+    int do_create = 0;
+    int server_is_restricted = (wizonly_mode || (tp_playermax && con_players_curr >= tp_playermax_limit));
+    const char *host_log = tp_log_hosts ? d->hostname : "hidden host";
 
-    snprintf(connect_string, sizeof(connect_string), "%sfrom %s",
 #ifdef USE_SSL
-         d->ssl_session ? "securely " : "",
-#else
-         "",
+    if (d->ssl_session) {
+        snprintf(connect_string, sizeof(connect_string), "descriptor %d, securely (via %s) from %s",
+                 d->descriptor, SSL_get_cipher_name(d->ssl_session), host_log);
+    } else {
 #endif
-    d->hostname);
-
-    parse_connect(msg, command, user, password);
-
-    /*
-     * @TODO Create and connect have a lot of overlapping code.
-     *       Worse, create seems to be missing some checks that connect
-     *       does.
-     *
-     *       Instead, I would suggest something like this:
-     *
-     *  if ( command is help ) {
-     *      display help
-     *  } else if ( command is create ) {
-     *      do_create = 1
-     *  } else if ( command is connect ) {
-     *      do_connect = 1
-     *  } else if ( !*command ) {
-     *      return
-     *  } else {
-     *      do_welcome and return
-     *  }
-     *
-     *  put the 'connect' code here, with a conditional to create vs.
-     *  connect_player.  Make sure all conditions are met for both
-     *  cases.
-     */
-
-    if (!strncmp(command, "co", 2)) {
-        player = connect_player(user, password);
-
-        if (player == NOTHING) {
-            queue_ansi(d, tp_connect_fail_mesg);
-            queue_write(d, "\r\n", 2);
-            log_status("FAILED CONNECT: '%s', descriptor %d, %s",
-                    user, d->descriptor, connect_string);
-        } else {
-            if ((wizonly_mode ||
-                 (tp_playermax && con_players_curr >= tp_playermax_limit)) &&
-                 !TrueWizard(player)) {
-                if (wizonly_mode) {
-                    queue_ansi(d,
-                            "Sorry, but the game is in maintenance mode "
-                            "currently, and only wizards are allowed to "
-                            "connect.  Try again later.");
-                } else {
-                    queue_ansi(d, tp_playermax_bootmesg);
-                }
-
-                queue_write(d, "\r\n", 2);
-                d->booted = 1;
-            } else {
-                log_status("CONNECTED: %s(%d), descriptor %d, %s",
-                        NAME(player), player, d->descriptor, connect_string);
+        snprintf(connect_string, sizeof(connect_string), "descriptor %d, from %s",
+                 d->descriptor, host_log);
 #ifdef USE_SSL
-
-                if (d->ssl_session) {
-                    log_status("Connected via %s",
-                            SSL_get_cipher_name(d->ssl_session));
-                }
+    }
 #endif
-                d->connected = 1;
-                d->connected_at = time(NULL);
-                d->player = player;
-                remember_player_descr(player, d->descriptor);
 
-                /* cks: someone has to initialize this somewhere. */
-                PLAYER_SET_BLOCK(d->player, 0);
-                show_file(d, tp_file_motd);
-                announce_connect(d->descriptor, player);
-                interact_warn(player);
+    tokenize_as(msg, MAX_COMMAND_LEN, command, user, password);
 
-                if (sanity_violated && Wizard(player)) {
-                    notify(player, "#########################################################################");
-                    notify(player, "## WARNING!  The DB appears to be corrupt!  Please repair immediately! ##");
-                    notify(player, "#########################################################################");
-                }
-
-                con_players_curr++;
-            }
-        }
+    if (!strncmp(command, "help", 4)) {
+        show_file(d, tp_file_connection_help);
+        return;
+    } else if (!strncmp(command, "co", 2)) {
+        do_connect = 1;
     } else if (!strncmp(command, "cr", 2)) {
-        if (!tp_registration) {
-            if (wizonly_mode
-                || (tp_playermax && con_players_curr >= tp_playermax_limit)) {
-                if (wizonly_mode) {
-                    queue_ansi(d,
-                            "Sorry, but the game is in maintenance mode "
-                            "currently, and only wizards are allowed to "
-                            "connect.  Try again later.");
-                } else {
-                    queue_ansi(d, tp_playermax_bootmesg);
-                }
-
-                queue_write(d, "\r\n", 2);
-                d->booted = 1;
-            } else {
-                player = create_player(user, password, error);
-
-                if (player == NOTHING) {
-                    queue_ansi(d, error);
-                    queue_write(d, "\r\n", 2);
-                    log_status("FAILED CREATE: '%s', descriptor %d, %s",
-                            user, d->descriptor, connect_string);
-                } else {
-                    log_status("CREATED %s(%d), descriptor %d, %s",
-                            NAME(player), player, d->descriptor, connect_string);
-
-                    d->connected = 1;
-                    d->connected_at = time(NULL);
-                    d->player = player;
-                    remember_player_descr(player, d->descriptor);
-
-                    /* cks: someone has to initialize this somewhere. */
-                    PLAYER_SET_BLOCK(d->player, 0);
-                    spit_file_segment(player, tp_file_motd, "");
-                    announce_connect(d->descriptor, player);
-                    con_players_curr++;
-                }
-            }
-        } else {
+        if (tp_registration) {
             queue_ansi(d, tp_register_mesg);
             queue_write(d, "\r\n", 2);
-            log_status("FAILED CREATE: '%s', descriptor %d, %s",
-                    user, d->descriptor, connect_string);
+            log_status("REGISTRATION REQUIRED: '%s', %s", user, connect_string);
+            return;
         }
-    } else if (!strncmp(command, "help", 4)) {
-        show_file(d, tp_file_connection_help);
+        if (server_is_restricted) {
+            boot_restricted(d);
+            return;
+        }
+        do_create = 1;
     } else if (!*command) {
-        /* do nothing */
+        return;
     } else {
         welcome_user(d);
+        return;
     }
+
+    if (do_connect) {
+        player = connect_player(user, password, error);
+        if (player == NOTHING) {
+            queue_ansi(d, error);
+            queue_write(d, "\r\n", 2);
+            log_status("FAILED CONNECT: '%s', %s", user, connect_string);
+            return;
+        }
+
+        if (server_is_restricted && !TrueWizard(player)) {
+            boot_restricted(d);
+            return;
+        }
+    } else if (do_create) {
+        player = create_player(user, password, error);
+        if (player == NOTHING) {
+            queue_ansi(d, error);
+            queue_write(d, "\r\n", 2);
+            log_status("FAILED CREATE: '%s', %s", user, connect_string);
+            return;
+        }
+    }
+
+    if (do_connect) {
+        log_status("CONNECTED: %s(%d), %s", NAME(player), player, connect_string);
+    } else {
+        log_status("CREATED %s(%d), %s", NAME(player), player, connect_string);
+    }
+
+    d->connected = 1;
+    d->connected_at = time(NULL);
+    d->player = player;
+    remember_player_descr(player, d->descriptor);
+    PLAYER_SET_BLOCK(d->player, 0);
+
+    show_file(d, tp_file_motd);
+    announce_connect(d->descriptor, player);
+    interact_warn(player);
+
+    if (sanity_violated && Wizard(player)) {
+        notify_nolisten(player, "#########################################################################", 1);
+        notify_nolisten(player, "## WARNING!  The DB appears to be corrupt!  Please repair immediately! ##", 1);
+        notify_nolisten(player, "#########################################################################", 1);
+    }
+
+    con_players_curr++;
 }
 
 /**
@@ -1805,11 +1778,11 @@ check_connect(struct descriptor_data *d, const char *msg)
  * @see mcp_frame_process_input
  *
  * This processes certain built-in 'special' commands; \@Q (BREAK_COMMAND),
- * QUIT, and WHO.  Then it hands off to process_command or check_connect
+ * QUIT, and WHO.  Then it hands off to process_command or process_welcome_input
  * based on if you're connected or not.
  *
  * @see process_command
- * @see check_connect
+ * @see process_welcome_input
  *
  * @private
  * @param d the descriptor data structure
@@ -1875,7 +1848,7 @@ do_command(struct descriptor_data *d, char *command)
                 dump_users(d, command + sizeof(WHO_COMMAND) - 1);
             }
         } else {
-            check_connect(d, command);
+            process_welcome_input(d, command);
         }
     } else if (d->connected) {
         /**


### PR DESCRIPTION
This attempts a refactor of welcome screen logic, based on the related TODO.

Added sysparms:
- `log_hosts`: if no, logs hosts as "hidden host". Defaults to yes. MUF and Wizards can currently still view the host.
- `wizonly_bootmesg`: the string sent to the descriptor if the server is in wizonly mode.

Added functions:
- `boot_restricted`: sends the "reason" message and sets the descriptor to be booted.
- `tokenize_as`: I like the use of the previous `check_connect`, and this could be useful in other contexts.

Changed log lines. I could see these being a minor - and temporary - inconvenience for log parsers.
- Uses `REGISTRATION REQUIRED` instead of `FAILED CREATE` if registration=yes.
- Combines SSL cipher name display with creation/connection message.
- Adds the colon to `CREATED:` on successful player creation.

I think I've tested each path, and did not notice any logic deviation. However, please feel free to switch into this PR branch and test!
