### PR TITLE
Fix for telnet client state machine going insane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ venv
 
 # Password file
 pw-file.txt
+
+# Python cache
+__pycache__

--- a/include/interface.h
+++ b/include/interface.h
@@ -180,6 +180,20 @@ struct descriptor_data {
     unsigned char  height_buf[2];   /**< Bytes for height protocol   */
 
     /*
+     * NAWS (window size) negotiation state, tracked per direction.
+     *
+     * We proactively request NAWS at connect time (IAC DO NAWS).  These
+     * flags record that the DO/WILL handshake has already been settled so
+     * we do not re-answer an option that is already agreed.  Re-answering
+     * a settled negotiation makes some clients re-answer in turn, which
+     * produces an unbounded IAC DO/WILL (or WILL/DO) loop that floods an
+     * otherwise idle connection with packets.  The window size itself
+     * still arrives via the SB NAWS subnegotiation, independent of these.
+     */
+    int naws_remote_will;           /**< Remote agreed to send window size */
+    int naws_local_will;            /**< We agreed to send window size     */
+
+    /*
      * As required by the Telnet protocol, any occurrence of 255 in the
      * subnegotiation must be doubled to distinguish it from the IAC
      * character (which has a value of 255).

--- a/src/interface.c
+++ b/src/interface.c
@@ -3103,6 +3103,22 @@ process_input(struct descriptor_data *d)
     got = socket_read(d, buf, maxget);
 
     /*
+     * A zero-length read means the peer closed the connection (EOF).  On
+     * the console descriptor (-console mode) stdin is the primary
+     * interface, so a closed stdin -- a drained input pipe or Ctrl-D --
+     * means the operator's session is over.  Reconnecting the console
+     * would just re-hit EOF and spin, reprinting the welcome screen
+     * forever, so instead request a clean shutdown via the same path as
+     * @shutdown and SIGTERM.  Non-console sockets fall through to the
+     * normal disconnect handling below.
+     */
+    if (got == 0 && d->is_console) {
+        shutdown_flag = 1;
+        restart_flag = 0;
+        return 0;
+    }
+
+    /*
      * The way the error works varies based on Windows or not.  Basically,
      * if the error is EWOULDBLOCK (or the windows equivalent) then that
      * isn't really an error -- just means no data.  Otherwise, it is
@@ -3401,11 +3417,22 @@ process_input(struct descriptor_data *d)
                 } else
 #endif
                 if (*q == TELOPT_NAWS) {
-                    sendbuf[0] = TELNET_IAC;
-                    sendbuf[1] = TELNET_DO;
-                    sendbuf[2] = (unsigned char)*q;
-                    sendbuf[3] = '\0';
-                    queue_immediate_raw(d, (const char *)sendbuf);
+                    /*
+                     * NAWS (window size).  Acknowledge the remote's WILL
+                     * with a DO only the first time; once the option is
+                     * settled we stay silent.  Re-sending DO here makes
+                     * some clients re-send WILL, looping forever and
+                     * flooding an idle connection.  The window size still
+                     * arrives via the SB NAWS subnegotiation regardless.
+                     */
+                    if (!d->naws_remote_will) {
+                        d->naws_remote_will = 1;
+                        sendbuf[0] = TELNET_IAC;
+                        sendbuf[1] = TELNET_DO;
+                        sendbuf[2] = (unsigned char)*q;
+                        sendbuf[3] = '\0';
+                        queue_immediate_raw(d, (const char *)sendbuf);
+                    }
 
                     /* Otherwise, we don't negotiate: send back DONT
                      * option
@@ -3435,20 +3462,38 @@ process_input(struct descriptor_data *d)
              * We want to allow NAWS
              */
             if ((unsigned char)*q == TELOPT_NAWS) {
-                sendbuf[1] = TELNET_WILL;
+                /*
+                 * Agree to NAWS with WILL, but only the first time.
+                 * Re-answering an already-settled DO makes some clients
+                 * re-send DO in turn, looping forever; stay silent once
+                 * the option is settled.
+                 */
+                if (!d->naws_local_will) {
+                    d->naws_local_will = 1;
+                    sendbuf[1] = TELNET_WILL;
+                    sendbuf[2] = (unsigned char)*q;
+                    sendbuf[3] = '\0';
+                    queue_immediate_raw(d, (const char *)sendbuf);
+                }
             } else {
+                /* We don't negotiate anything else: send back WONT */
                 sendbuf[1] = TELNET_WONT;
+                sendbuf[2] = (unsigned char)*q;
+                sendbuf[3] = '\0';
+                queue_immediate_raw(d, (const char *)sendbuf);
             }
-
-            sendbuf[2] = (unsigned char)*q;
-            sendbuf[3] = '\0';
-
-            queue_immediate_raw(d, (const char *)sendbuf);
 
             d->telnet_state = TELNET_STATE_NORMAL;
             d->telnet_enabled = 1;
         } else if (d->telnet_state == TELNET_STATE_WONT) {
-            /* Ignore WONT option. */
+            /* A WONT NAWS means the remote will no longer send window
+             * sizes; clear the state so a later WILL can re-enable it.
+             * Otherwise ignore WONT.
+             */
+            if ((unsigned char)*q == TELOPT_NAWS) {
+                d->naws_remote_will = 0;
+            }
+
             d->telnet_state = TELNET_STATE_NORMAL;
             d->telnet_enabled = 1;
         } else if (d->telnet_state == TELNET_STATE_DONT) {
@@ -3460,6 +3505,13 @@ process_input(struct descriptor_data *d)
             sendbuf[3] = '\0';
 
             queue_immediate_raw(d, (const char *)sendbuf);
+
+            /* A DONT NAWS means we should no longer send window sizes;
+             * clear the state so a later DO can re-enable it.
+             */
+            if ((unsigned char)*q == TELOPT_NAWS) {
+                d->naws_local_will = 0;
+            }
 
             d->telnet_state = TELNET_STATE_NORMAL;
             d->telnet_enabled = 1;
@@ -4091,7 +4143,14 @@ shovechars()
                 int was_console = d->is_console;
                 shutdownsock(d);
 #ifndef WIN32
-                if (was_console) {
+                /*
+                 * Reconnect the console after an in-world disconnect (e.g.
+                 * QUIT) so the operator gets a fresh login prompt -- but
+                 * not when we are shutting down (notably console stdin EOF,
+                 * handled in process_input), where reconnecting would just
+                 * reprint the welcome screen and spin.
+                 */
+                if (was_console && shutdown_flag == 0) {
                     connect_console();
                 }
 #endif

--- a/tests/test_telnet.py
+++ b/tests/test_telnet.py
@@ -1,0 +1,101 @@
+"""Telnet-level regression tests driven over the console connection.
+
+Unlike the declarative command-cases (which are plain text), these tests need
+to send raw telnet IAC negotiation bytes, so they drive the server directly
+rather than through the YAML harness.
+
+Background: the server proactively requests NAWS (window size) at connect with
+IAC DO NAWS.  It historically answered every client WILL NAWS with another DO
+NAWS (and every DO NAWS with another WILL NAWS).  A client that in turn
+re-answers each of those -- a common naive telnet stack -- produces an
+unbounded DO/WILL negotiation loop that floods an otherwise idle connection
+with packets (very visible over TLS, where each frame is its own record).  The
+fix makes the DO/WILL handshake idempotent per direction; these tests guard it.
+"""
+
+import test_util
+
+IAC = 0xff
+DONT = 0xfe
+DO = 0xfd
+WONT = 0xfc
+WILL = 0xfb
+SB = 0xfa
+SE = 0xf0
+TELOPT_NAWS = 0x1f
+
+DO_NAWS = bytes([IAC, DO, TELOPT_NAWS])
+WILL_NAWS = bytes([IAC, WILL, TELOPT_NAWS])
+
+
+class TelnetNawsTest(test_util.ServerTestBase):
+    """Drive the raw telnet handshake ourselves, then log in as One (#1)."""
+
+    async def _drive(self, prelude):
+        """Start the server, send `prelude` (raw bytes) ahead of the login,
+        then connect and emit a marker so the read is bounded.  Returns all
+        bytes received up to and including the connect prompt."""
+        await self._start_server()
+        out = await self._write_and_await_prompt(
+            prelude + self.connect_string, self.connect_prompt)
+        await self._finish()
+        return out
+
+    def test_will_naws_does_not_loop(self):
+        """Answering the server's DO NAWS with WILL NAWS -- repeatedly, as a
+        naive client would -- must not make the server re-DO each one.  We send
+        eight WILL NAWS and never react to the replies; a fixed server answers
+        at most one of them, a looping server answers all eight."""
+        out = test_util._asyncio_run(self._drive(WILL_NAWS * 8))
+        count = out.count(DO_NAWS)
+        # One DO NAWS is sent proactively at connect; at most one more should
+        # acknowledge the client's WILL.  Anything near eight means regression.
+        self.assertLessEqual(
+            count, 3,
+            "server emitted {} DO NAWS for 8 WILL NAWS (loop?)".format(count))
+
+    def test_do_naws_does_not_loop(self):
+        """Symmetric case: a client that answers our WILL NAWS with DO NAWS
+        must not make the server re-WILL each one."""
+        out = test_util._asyncio_run(self._drive(DO_NAWS * 8))
+        count = out.count(WILL_NAWS)
+        self.assertLessEqual(
+            count, 2,
+            "server emitted {} WILL NAWS for 8 DO NAWS (loop?)".format(count))
+
+    def test_window_size_still_captured(self):
+        """The whole point of the NAWS handshake is capturing screen size, so
+        make sure the fix didn't break the SB subnegotiation path: enable NAWS,
+        send a 120x40 window size, then read it back via the MUF WIDTH/HEIGHT
+        prims for our own descriptor."""
+        width, height = 120, 40
+        naws = WILL_NAWS + bytes(
+            [IAC, SB, TELOPT_NAWS, 0, width, 0, height, IAC, SE])
+        program = (
+            b"@program cmd-size.muf\n"
+            b"i\n"
+            b": main pop "
+            b'"SIZE=" descr width intostr strcat "x" strcat '
+            b"descr height intostr strcat "
+            b"me @ swap notify ;\n"
+            b".\n"
+            b"c\n"
+            b"q\n"
+            b"@action cmd-size=here\n"
+            b"@link cmd-size=cmd-size.muf\n"
+        )
+
+        async def run():
+            await self._start_server()
+            # Negotiate NAWS and send the window size before logging in; the
+            # size is stored on the descriptor, which survives the login.
+            await self._write_and_await_prompt(
+                naws + self.connect_string, self.connect_prompt)
+            out = await self._write_and_await_prompt(
+                program + b"cmd-size\n" + self.done_command_command,
+                self.done_command_prompt)
+            await self._finish()
+            return out
+
+        out = test_util._asyncio_run(run())
+        self.assertIn(b"SIZE=120x40", out)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -331,6 +331,9 @@ Args:
 """
 def create_command_tests_for(base_class, yaml_file):
     with open(yaml_file, 'r') as fh:
-        lst = yaml.load(fh)
+        # safe_load: the cases are plain data, and bare yaml.load() dropped its
+        # implicit-Loader default in PyYAML 5.1+ (removed in 6.x), which broke
+        # this call.  safe_load has the same behavior across those versions.
+        lst = yaml.safe_load(fh)
     for item in lst:
         _create_command_test_from(base_class, yaml_file, item)


### PR DESCRIPTION
The bug

A NAWS (telnet window-size) negotiation loop, which can happen with certain client implementations. It's a bad interaction with the client and server. The server had no per-option negotiation state, so it re-answered every WILL NAWS with a fresh DO NAWS (and every DO NAWS with a fresh WILL NAWS). A client that re-answers each one ping-pongs forever.

The fix

Two direction flags on the descriptor (naws_remote_will, naws_local_will). Each DO/WILL response now fires only the first time; once settled the server stays silent. Cleared on WONT/DONT so re-negotiation still works.

Additionally, some fixes to the test harness and accompanying tests for this because it is a somewhat difficult thing to manually trigger. It requires very specific circumstances :)  The `-console` flag was pretty severely misbehaving and was not shutting down the server on EOF, rather it was just making a weird console display loop. Also we were using pyyaml in a very old way.