### PR TITLE
For now, simply raise the timeout to get tests running again, however…

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -4251,6 +4251,15 @@ shovechars()
                         timeout.tv_usec = 10; /* 10 msecs min.  Arbitrary. */
                     }
                 }
+                if (d->is_console) {
+                  /* TODO - only run this is console is NOT PTY/TTY */
+                  if (timeout.tv_sec > 0) {
+                    timeout.tv_sec = 0L;
+                    if (!timeout.tv_usec || timeout.tv_usec > 500) {
+                      timeout.tv_usec = 500;
+                    }
+                  }
+                }
             }
 
             if (d->ssl_session) {
@@ -4478,7 +4487,10 @@ shovechars()
                     }
                 }
 
-                if (FD_ISSET(d->descriptor, &output_set)) {
+                /* TODO - only bring in is_console logic IFF
+                   we detect that we're not PTY */
+                if (FD_ISSET(d->descriptor, &output_set) ||
+                    (d->is_console && has_output(d))) {
                     process_output(d);
                 }
 
@@ -6815,6 +6827,11 @@ main(int argc, char **argv)
 
             if (fork() != 0)
                 _exit(0);
+        } else {
+            if (no_detach_flag && console_flag) {
+                setvbuf(stdout, NULL, _IONBF, 0);
+                setvbuf(stderr, NULL, _IONBF, 0);
+            }
         }
 # endif
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -4251,8 +4251,7 @@ shovechars()
                         timeout.tv_usec = 10; /* 10 msecs min.  Arbitrary. */
                     }
                 }
-                if (d->is_console) {
-                  /* TODO - only run this is console is NOT PTY/TTY */
+                if (d->is_console && !isatty(d->descriptor)) {
                   if (timeout.tv_sec > 0) {
                     timeout.tv_sec = 0L;
                     if (!timeout.tv_usec || timeout.tv_usec > 500) {
@@ -4278,8 +4277,7 @@ shovechars()
 #else
             if (has_output(d)) {
                 FD_SET(d->descriptor, &output_set);
-                if (d->is_console) {
-                  /* TODO - only run this is console is NOT PTY/TTY */
+                if (d->is_console && !isatty(d->descriptor)) {
                   if (timeout.tv_sec > 0) {
                     timeout.tv_sec = 0L;
                     if (!timeout.tv_usec || timeout.tv_usec > 500) {
@@ -4496,10 +4494,9 @@ shovechars()
                     }
                 }
 
-                /* TODO - only bring in is_console logic IFF
-                   we detect that we're not PTY */
                 if (FD_ISSET(d->descriptor, &output_set) ||
-                    (d->is_console && has_output(d))) {
+                    (d->is_console && !isatty(d->descriptor) &&
+                     has_output(d))) {
                     process_output(d);
                 }
 

--- a/src/interface.c
+++ b/src/interface.c
@@ -4278,6 +4278,15 @@ shovechars()
 #else
             if (has_output(d)) {
                 FD_SET(d->descriptor, &output_set);
+                if (d->is_console) {
+                  /* TODO - only run this is console is NOT PTY/TTY */
+                  if (timeout.tv_sec > 0) {
+                    timeout.tv_sec = 0L;
+                    if (!timeout.tv_usec || timeout.tv_usec > 500) {
+                      timeout.tv_usec = 500;
+                    }
+                  }
+                }
             }
 #endif
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -280,7 +280,7 @@ class CommandTestCase(ServerTestBase):
     """Expected output (as str) of done_setup_command."""
     done_setup_prompt = "One ENDSETUPMARKER\n"
     """Default timeout for setup + command to complete in, in seconds."""
-    default_timeout = 60
+    default_timeout = 180
 
     def _test_one(self, info):
         setup = info.get('setup', '')


### PR DESCRIPTION
… slowly.
Issue #725 - this is NOT a resolution, just a temp work-around.